### PR TITLE
Name a favourite the way the browser named the game

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3091,6 +3091,9 @@ impl App {
             _ => None,
         };
         if let Some((install, title)) = amiga {
+            // The title is already the shown name, so sanitising it keeps
+            // the favourite recognisable while making the name one the
+            // card can hold.
             let outcome =
                 crate::launch::favorite_mgl_amiga(&config, &install, &title).and_then(|mgl| {
                     crate::favorites::add_game(&target, &sanitise(&title), &mgl).map(|_| title)
@@ -3111,13 +3114,17 @@ impl App {
 
         let outcome = match crate::launch::favorite_mgl(&config, &game) {
             Ok(Some(mgl)) => {
-                let stem = game
-                    .file_stem()
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| name.clone());
-                crate::favorites::add_game(&target, &stem, &mgl).map(|_| stem)
+                // The favourite is filed under the name the browser showed,
+                // which the gamelist may have set, not under the file's own
+                // stem: a favourite called "mslug" would be a stranger in a
+                // list that has always said "Metal Slug".
+                let fav_name = crate::favorites::favorite_name(&name, &game);
+                crate::favorites::add_game(&target, &fav_name, &mgl).map(|_| fav_name)
             }
-            // A core file is linked to, not described.
+            // A core file is linked to, not described. The link keeps the
+            // real filename, not the shown name: the stock script resolves
+            // a link by its filename, and the browser derives the shown
+            // name from the stem at browse time anyway.
             Ok(None) => {
                 let file = game
                     .file_name()

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -190,6 +190,21 @@ pub fn name_is_usable(name: &str) -> bool {
     !name.is_empty() && name != "." && name != ".." && !name.chars().any(|c| BAD_CHARS.contains(&c))
 }
 
+/// The name a favourite is filed under: the name the browser showed for the
+/// game, so the favourites folder lists it the way its owner has seen it. A
+/// shown name the card cannot hold (empty, ".", "..", any of `BAD_CHARS`)
+/// falls back to the file's own stem rather than being sanitised, so a name
+/// made here is one MiSTer's script would have made.
+pub fn favorite_name(display: &str, path: &Path) -> String {
+    if name_is_usable(display) {
+        display.trim().to_string()
+    } else {
+        path.file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    }
+}
+
 /// Make a folder inside the favourites folder.
 pub fn make_folder(root: &Path, name: &str) -> Result<PathBuf> {
     if !name_is_usable(name) {
@@ -358,6 +373,40 @@ mod tests {
         assert!(!name_is_usable("Shoot/em/ups"));
         assert!(!name_is_usable(""));
         assert!(!name_is_usable("   "));
+    }
+
+    #[test]
+    fn the_shown_name_names_the_favourite_when_the_card_can_hold_it() {
+        // The favourite must be listed under the name the owner has seen,
+        // not under the file's stem.
+        assert_eq!(
+            favorite_name("Blazing Star", Path::new("/x/Blazing Star (blazstar).neo")),
+            "Blazing Star"
+        );
+    }
+
+    #[test]
+    fn a_name_the_card_cannot_hold_falls_back_to_the_files_own() {
+        // MiSTer's script refuses these characters, so a name made here
+        // must be one it would have made: the file's own stem is.
+        let path = Path::new("/x/mslug.neo");
+        assert_eq!(
+            favorite_name("Metal Slug: Super Vehicle-001", path),
+            "mslug"
+        );
+        assert_eq!(favorite_name("A/B", path), "mslug");
+        assert_eq!(favorite_name("", path), "mslug");
+        assert_eq!(favorite_name("  ", path), "mslug");
+    }
+
+    #[test]
+    fn a_shown_name_is_trimmed_before_it_names_a_file() {
+        // A stray space around a gamelist name would otherwise become part
+        // of the filename on the card.
+        assert_eq!(
+            favorite_name("  Blazing Star  ", Path::new("/x/blazstar.neo")),
+            "Blazing Star"
+        );
     }
 
     #[cfg(unix)]

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -193,8 +193,11 @@ pub fn name_is_usable(name: &str) -> bool {
 /// The name a favourite is filed under: the name the browser showed for the
 /// game, so the favourites folder lists it the way its owner has seen it. A
 /// shown name the card cannot hold (empty, ".", "..", any of `BAD_CHARS`)
-/// falls back to the file's own stem rather than being sanitised, so a name
-/// made here is one MiSTer's script would have made.
+/// falls back to the file's own stem rather than being sanitised, which is
+/// the name MiSTer's own script files a game under. The stem is not
+/// validated: it names a file that already exists, and in the rare case a
+/// foreign mount let it hold a character the card refuses, writing the
+/// favourite fails loudly, exactly as the stock script would.
 pub fn favorite_name(display: &str, path: &Path) -> String {
     if name_is_usable(display) {
         display.trim().to_string()


### PR DESCRIPTION
Fixes #9: a favourite is saved under the file’s name, not the name shown for it.

## What this changes

Adding a game to favourites saves it under the name Degauss was showing for it, not the file's name. A game the gamelist calls Blazing Star was favourited as "Blazing Star (blazstar)", the romset id from the filename that the browser never shows.

The display name is preferred when it is usable as a favourite filename (`name_is_usable` already defines what MiSTer's own script accepts) and the file stem stays as the fallback, chosen by a small helper in `favorites.rs` with its own tests. The AmigaVision path already used the title and the core-symlink path must keep the real filename; both are unchanged, with the why in comments.

## Why

The mismatch appears exactly when a game has gamelist metadata, which for a scraped library is most of it, so favourites were routinely listed under names their owner had never seen.

## How it was checked

- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --target armv7-unknown-linux-musleabihf --all-targets -- -D warnings`
- [x] Run on a real MiSTer
- [x] On a CRT, if it changes anything drawn

198 tests. CodeRabbit CLI against main: no findings. A test binary with this fix is staged for device testing; the boxes get ticked when it has actually been run there.

## Licensing

By opening this pull request I agree that my contribution is licensed under
the [PolyForm Noncommercial License 1.0.0](../LICENSE), the same licence as
the rest of Degauss, and that I have the right to license it that way.

Changes to `MiSTer_Degauss` do not belong here: it is a separate GPLv3
program in its own repository,
[Degauss-Main](https://github.com/giancarloerra/Degauss-Main).

- [x] I agree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Favourite entries now use the displayed game title when it is valid.
  - Titles are trimmed and sanitised to create cleaner, more consistent favourite filenames.
  - If a title is empty or unsuitable, the original source filename is used instead.
  - AmigaVision favourites now follow the same explicit title-based naming behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
