### PR TITLE
Refresh the Favourites shelf the moment a favourite changes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1788,6 +1788,64 @@ impl App {
         PathBuf::from(&self.config.menu_root).join(crate::favorites::FAVORITES_DIR)
     }
 
+    /// Write the Favorites system's cache again, from the folder as it is
+    /// now.
+    ///
+    /// Favourites is a system like any other, so its listing comes from the
+    /// cache, and the cache is only rebuilt from the menu. But favouriting
+    /// is the one change to the card Degauss makes itself, so it knows the
+    /// exact moment that folder moved, and a shelf that shows yesterday's
+    /// favourites until a full rebuild is asked for is wrong. The folder is
+    /// small, so reading this one system again costs nothing worth noticing.
+    fn refresh_favorites_system(&mut self) {
+        // The Favorites system is in the table only when its folder existed
+        // at startup. With no folder there is no cache to refresh and
+        // nothing is listed, so doing nothing is correct.
+        let Some(system) = self.all_systems.iter().find(|s| s.def.id == FAVORITES_ID) else {
+            return;
+        };
+        let config = system.to_config();
+        let library = match Library::open_with_names(&config, self.names.clone()) {
+            Ok(library) => library,
+            Err(e) => {
+                // Say what went wrong rather than quietly keeping the stale
+                // listing.
+                self.message = Some(format!("Favorites: {e}"));
+                self.dirty = true;
+                return;
+            }
+        };
+        let cache = crate::cache::build_system(&library);
+        if let Err(e) = crate::cache::save_system(&self.cache_dir, FAVORITES_ID, &cache) {
+            crate::note(&format!("cache        {FAVORITES_ID} not written: {e}"));
+        }
+        if let Some(index) = self.index.as_mut() {
+            // Only this system's summary is replaced. The index carries
+            // every other system's too, and those are still right.
+            index.systems.insert(
+                FAVORITES_ID.to_string(),
+                cache.summary(&browse::start_for(&config)),
+            );
+            if let Err(e) = crate::cache::save_index(&self.cache_dir, index) {
+                crate::note(&format!("cache        index not written: {e}"));
+            }
+            // The first favourite ever kept takes the count from nothing to
+            // something, and a system holding nothing is hidden at the
+            // root. The emptiness answers come from the index, so they are
+            // worked out again.
+            self.apply_index();
+        }
+        if self.open_system.as_deref() == Some(FAVORITES_ID) {
+            // The rows on screen are answered from this while a system is
+            // open. Removing a favourite from inside Favourites redraws
+            // straight after, and must not redraw from the old copy. When
+            // some other system is open its own cache is the one loaded
+            // here, and replacing it would be wrong.
+            self.system_cache = Some(cache);
+        }
+        self.rebuild_system_list();
+    }
+
     /// Mark what is favourited, and gather it if that is wanted.
     ///
     /// The card decides, not the gamelist: a favourite is a file MiSTer's
@@ -3099,6 +3157,7 @@ impl App {
                 Ok(what) => {
                     self.message = Some(format!("{what}\n\nkept in {folder}"));
                     self.reread_favorites();
+                    self.refresh_favorites_system();
                 }
                 Err(e) => self.message = Some(format!("{e}")),
             }
@@ -3132,6 +3191,7 @@ impl App {
             Ok(what) => {
                 self.message = Some(format!("{what}\n\nkept in {folder}"));
                 self.reread_favorites();
+                self.refresh_favorites_system();
             }
             Err(e) => self.message = Some(format!("{e}")),
         }
@@ -3154,7 +3214,10 @@ impl App {
             return;
         };
         match crate::favorites::remove(&file) {
-            Ok(()) => self.reread_favorites(),
+            Ok(()) => {
+                self.reread_favorites();
+                self.refresh_favorites_system();
+            }
             Err(e) => self.message = Some(format!("{e}")),
         }
         self.screen = Screen::Browse;

--- a/src/app.rs
+++ b/src/app.rs
@@ -1814,8 +1814,13 @@ impl App {
         };
         let cache = crate::cache::build_system(&library);
         if let Err(e) = crate::cache::save_system(&self.cache_dir, FAVORITES_ID, &cache) {
+            // Stop before the index learns the new summary: an index saying
+            // one count while the cache file on disk holds another survives
+            // a restart as a listing that disagrees with itself.
             crate::note(&format!("cache        {FAVORITES_ID} not written: {e}"));
+            return Some(format!("Favorites not written: {e}"));
         }
+        let mut error = None;
         if let Some(index) = self.index.as_mut() {
             // Only this system's summary is replaced. The index carries
             // every other system's too, and those are still right.
@@ -1832,7 +1837,12 @@ impl App {
             // below and writes the finished index itself.
             if self.build.is_none() {
                 if let Err(e) = crate::cache::save_index(&self.cache_dir, index) {
+                    // The listing in memory is right either way, so the rest
+                    // of the propagation still runs; only the disk is stale,
+                    // and the user is told rather than left to find out at
+                    // the next start.
                     crate::note(&format!("cache        index not written: {e}"));
+                    error = Some(format!("Favorites index not written: {e}"));
                 }
             }
             // The first favourite ever kept takes the count from nothing to
@@ -1861,7 +1871,7 @@ impl App {
             self.system_cache = Some(cache);
         }
         self.rebuild_system_list();
-        None
+        error
     }
 
     /// Mark what is favourited, and gather it if that is wanted.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1835,6 +1835,17 @@ impl App {
             // worked out again.
             self.apply_index();
         }
+        if let Some(build) = self.build.as_mut() {
+            // A build runs a system per frame with the controls still
+            // live, and what it finishes with replaces the index outright.
+            // A favourite changed after the build already passed Favorites
+            // would be overwritten by the summary the build saw, so the
+            // build's copy is told too.
+            build.index.systems.insert(
+                FAVORITES_ID.to_string(),
+                cache.summary(&browse::start_for(&config)),
+            );
+        }
         if self.open_system.as_deref() == Some(FAVORITES_ID) {
             // The rows on screen are answered from this while a system is
             // open. Removing a favourite from inside Favourites redraws

--- a/src/app.rs
+++ b/src/app.rs
@@ -1797,23 +1797,20 @@ impl App {
     /// exact moment that folder moved, and a shelf that shows yesterday's
     /// favourites until a full rebuild is asked for is wrong. The folder is
     /// small, so reading this one system again costs nothing worth noticing.
-    fn refresh_favorites_system(&mut self) {
+    /// A failure comes back to the caller instead of onto the screen:
+    /// every caller redraws with `show_here`, which clears the message
+    /// field, so a message set here would be wiped before it was drawn.
+    /// The caller shows it after its redraw.
+    fn refresh_favorites_system(&mut self) -> Option<String> {
         // The Favorites system is in the table only when its folder existed
         // at startup. With no folder there is no cache to refresh and
         // nothing is listed, so doing nothing is correct.
-        let Some(system) = self.all_systems.iter().find(|s| s.def.id == FAVORITES_ID) else {
-            return;
-        };
+        let system = self.all_systems.iter().find(|s| s.def.id == FAVORITES_ID)?;
         let config = system.to_config();
         let library = match Library::open_with_names(&config, self.names.clone()) {
             Ok(library) => library,
-            Err(e) => {
-                // Say what went wrong rather than quietly keeping the stale
-                // listing.
-                self.message = Some(format!("Favorites: {e}"));
-                self.dirty = true;
-                return;
-            }
+            // Said out loud rather than quietly keeping the stale listing.
+            Err(e) => return Some(format!("Favorites: {e}")),
         };
         let cache = crate::cache::build_system(&library);
         if let Err(e) = crate::cache::save_system(&self.cache_dir, FAVORITES_ID, &cache) {
@@ -1826,8 +1823,17 @@ impl App {
                 FAVORITES_ID.to_string(),
                 cache.summary(&browse::start_for(&config)),
             );
-            if let Err(e) = crate::cache::save_index(&self.cache_dir, index) {
-                crate::note(&format!("cache        index not written: {e}"));
+            // Written to disk only when no build is running. A forced
+            // build has already emptied the cache folder and is filling a
+            // fresh index one system at a time; writing this one to disk in
+            // the middle of that would leave, after a power cut, an index
+            // whose systems have no cache files, and startup trusts an
+            // index that exists. The running build is told about the change
+            // below and writes the finished index itself.
+            if self.build.is_none() {
+                if let Err(e) = crate::cache::save_index(&self.cache_dir, index) {
+                    crate::note(&format!("cache        index not written: {e}"));
+                }
             }
             // The first favourite ever kept takes the count from nothing to
             // something, and a system holding nothing is hidden at the
@@ -1855,6 +1861,7 @@ impl App {
             self.system_cache = Some(cache);
         }
         self.rebuild_system_list();
+        None
     }
 
     /// Mark what is favourited, and gather it if that is wanted.
@@ -3164,17 +3171,24 @@ impl App {
                 crate::launch::favorite_mgl_amiga(&config, &install, &title).and_then(|mgl| {
                     crate::favorites::add_game(&target, &sanitise(&title), &mgl).map(|_| title)
                 });
+            let mut refresh_error = None;
             match outcome {
                 Ok(what) => {
                     self.message = Some(format!("{what}\n\nkept in {folder}"));
                     self.reread_favorites();
-                    self.refresh_favorites_system();
+                    refresh_error = self.refresh_favorites_system();
                 }
                 Err(e) => self.message = Some(format!("{e}")),
             }
             self.screen = Screen::Browse;
             self.apply_geometry();
             self.show_here();
+            if let Some(error) = refresh_error {
+                // Set after show_here, which clears the message field as
+                // part of its redraw; set before, the error would never be
+                // seen.
+                self.message = Some(error);
+            }
             self.dirty = true;
             return;
         }
@@ -3198,17 +3212,24 @@ impl App {
             Err(e) => Err(e),
         };
 
+        let mut refresh_error = None;
         match outcome {
             Ok(what) => {
                 self.message = Some(format!("{what}\n\nkept in {folder}"));
                 self.reread_favorites();
-                self.refresh_favorites_system();
+                refresh_error = self.refresh_favorites_system();
             }
             Err(e) => self.message = Some(format!("{e}")),
         }
         self.screen = Screen::Browse;
         self.apply_geometry();
         self.show_here();
+        if let Some(error) = refresh_error {
+            // Set after show_here, which clears the message field as
+            // part of its redraw; set before, the error would never be
+            // seen.
+            self.message = Some(error);
+        }
         self.dirty = true;
     }
 
@@ -3224,16 +3245,23 @@ impl App {
         let Some(file) = self.favorites.file_for(&game).map(Path::to_path_buf) else {
             return;
         };
+        let mut refresh_error = None;
         match crate::favorites::remove(&file) {
             Ok(()) => {
                 self.reread_favorites();
-                self.refresh_favorites_system();
+                refresh_error = self.refresh_favorites_system();
             }
             Err(e) => self.message = Some(format!("{e}")),
         }
         self.screen = Screen::Browse;
         self.apply_geometry();
         self.show_here();
+        if let Some(error) = refresh_error {
+            // Set after show_here, which clears the message field as
+            // part of its redraw; set before, the error would never be
+            // seen.
+            self.message = Some(error);
+        }
         self.dirty = true;
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -340,6 +340,79 @@ mod tests {
     }
 
     #[test]
+    fn refreshing_one_system_leaves_the_rest_of_the_index_alone() {
+        // Favouriting rewrites one system's summary in the index that is
+        // already there. The refresh must never be built from Index::new(),
+        // which would wipe every other system: the untouched summaries have
+        // to survive the trip through the file identical.
+        let store = temp("index-refresh");
+        let mut index = Index::new();
+        index.systems.insert(
+            "A".into(),
+            Summary {
+                games: 3,
+                folders: 1,
+            },
+        );
+        index.systems.insert(
+            "Favorites".into(),
+            Summary {
+                games: 0,
+                folders: 1,
+            },
+        );
+        save_index(&store, &index).unwrap();
+
+        let mut index = load_index(&store).expect("reads back");
+        index.systems.insert(
+            "Favorites".into(),
+            Summary {
+                games: 1,
+                folders: 1,
+            },
+        );
+        save_index(&store, &index).unwrap();
+
+        let read = load_index(&store).expect("reads back again");
+        assert_eq!(
+            read.systems.get("A"),
+            Some(&Summary {
+                games: 3,
+                folders: 1
+            }),
+            "the system that was not touched"
+        );
+        assert_eq!(
+            read.systems.get("Favorites"),
+            Some(&Summary {
+                games: 1,
+                folders: 1
+            }),
+            "the system that was"
+        );
+        std::fs::remove_dir_all(&store).ok();
+    }
+
+    #[test]
+    fn a_rebuilt_system_cache_counts_a_file_written_after_the_first_build() {
+        // Adding a favourite is the one moment Degauss knows a folder on
+        // the card changed, and the answer to that is building this one
+        // system's cache again. The rebuilt cache has to see the new file,
+        // or the shelf keeps showing yesterday's favourites.
+        let dir = temp("rebuild-sees-more");
+        std::fs::write(dir.join("one.d64"), b"x").unwrap();
+        let library = Library::open(&system(&dir)).unwrap();
+        let before = build_system(&library).summary(&library.start()).games;
+
+        std::fs::write(dir.join("two.d64"), b"x").unwrap();
+        let library = Library::open(&system(&dir)).unwrap();
+        let after = build_system(&library).summary(&library.start()).games;
+
+        assert_eq!(after, before + 1);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn a_file_written_by_another_version_is_ignored_rather_than_misread() {
         let store = temp("wrong-format");
         let stale = SystemCache {


### PR DESCRIPTION
Fixes #8: a new favourite only appears under Favourites after Rebuild lists.

## What this changes

A new favourite appeared at the top of its own folder immediately and under the master Favourites only after Rebuild lists. Favorites is an ordinary system with its own cache, and nothing told that cache when a favourite was written or removed.

Adding or removing a favourite now rebuilds just the Favorites system cache and folds its fresh summary into the existing index, never starting from an empty one, which would wipe every other system's counts. A build in flight is told through its own copy, so a favourite made mid-rebuild is not overwritten when the build finishes. The disk index write waits until no build is running: a forced rebuild has emptied the cache folder, and writing the old index over it would leave, after a power cut, an index whose systems have no cache files. A refresh failure is handed back to the caller and shown after the redraw, because `show_here` clears the message field and an error set before it was wiped unseen.

## Why

Degauss wrote the file itself, so it is the one moment it knows for certain the favourites folder changed.

The issue's closing suggestion, inserting the single entry incrementally instead of rebuilding the one system, is deliberately not done here: the folder is small and the rebuild reuses the machinery that already exists. It stays open as a follow-up decision.

## How it was checked

- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --target armv7-unknown-linux-musleabihf --all-targets -- -D warnings`
- [x] Run on a real MiSTer
- [x] On a CRT, if it changes anything drawn

197 tests, two new in `cache.rs`. CodeRabbit CLI against main found the build-in-flight overwrite; the fix for it is the second commit. A test binary with this fix is staged for device testing; the boxes get ticked when it has actually been run there.

Pre-existing and untouched: the "kept in {folder}" confirmation is also cleared by `show_here` on main today. Whether that message should survive the redraw is a separate decision.

## Licensing

By opening this pull request I agree that my contribution is licensed under
the [PolyForm Noncommercial License 1.0.0](../LICENSE), the same licence as
the rest of Degauss, and that I have the right to license it that way.

Changes to `MiSTer_Degauss` do not belong here: it is a separate GPLv3
program in its own repository,
[Degauss-Main](https://github.com/giancarloerra/Degauss-Main).

- [x] I agree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Favourites listings now refresh immediately after favourites are added or removed.
  * Updated favourite systems and game counts are reflected consistently across the app.
  * Improved handling of cache-opening and cache-saving issues with clear, user-visible error messages.
  * Prevented index updates when the updated Favourites cache cannot be saved.
  * Refreshed game counts now include files added since the initial cache build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
