### PR TITLE
Refuse a launch that cannot work instead of exiting

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2239,14 +2239,65 @@ impl App {
         outcome
     }
 
-    /// Ask before launching whatever is selected.
     /// Start the selected game. No question first: choosing a game in a list
     /// of games is not ambiguous, and a confirmation on every launch is a
     /// second press for every game anyone ever plays.
+    ///
+    /// Everything that can fail is decided here, while the interface is
+    /// still up: once the outcome leaves the event loop the process is
+    /// committed to leaving, and a missing core or a bad rule there would
+    /// end Degauss instead of showing a line and staying.
     fn confirm_launch(&mut self) -> Option<Outcome> {
-        let index = self.game_list.selected();
-        self.here.get(index)?;
-        Some(Outcome::Launch(index))
+        let row = self.here.get(self.game_list.selected())?;
+        let name = row.name.clone();
+        let kind = row.kind.clone();
+        let browse::Kind::Play(game) = kind else {
+            self.message = Some("A folder is not a game.".to_string());
+            self.dirty = true;
+            return None;
+        };
+        let config = self.opened_config.clone()?;
+        // A self-describing file names its own core, so a favourite or a
+        // core file must not be blocked on the system's. Everything else
+        // ends up in an MGL naming `config.rbf`, and handing MiSTer a core
+        // it does not have replaces this process with nothing.
+        let self_describing = match &game {
+            browse::Launch::File(path) => !crate::launch::needs_system_core(path),
+            browse::Launch::AmigaVision { .. } => false,
+        };
+        if !self_describing
+            && self
+                .open_system_ref()
+                .is_none_or(|system| system.menu_folder.is_none())
+        {
+            self.message = Some(format!(
+                "{}: core {} is not on the card",
+                config.name, config.rbf
+            ));
+            self.dirty = true;
+            return None;
+        }
+        // Building the plan only decides what would be written and sent;
+        // nothing touches the card until `launch::execute`. So a plan that
+        // cannot be built becomes a message here rather than an exit later.
+        let mgl = Path::new("/tmp/degauss.mgl");
+        let plan = match &game {
+            browse::Launch::File(path) => crate::launch::plan(&config, path, mgl),
+            browse::Launch::AmigaVision { install, title } => {
+                crate::launch::plan_amiga_vision(&config, install, title, mgl)
+            }
+        };
+        match plan {
+            Ok(plan) => Some(Outcome::Launch {
+                plan: Box::new(plan),
+                name,
+            }),
+            Err(e) => {
+                self.message = Some(format!("{e}"));
+                self.dirty = true;
+                None
+            }
+        }
     }
 
     /// Hide a system from the list. Nothing is deleted: it is remembered by
@@ -4308,16 +4359,6 @@ impl App {
     }
 
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-    /// The rows of the folder on screen, for the launcher.
-    pub fn here(&self) -> &[browse::Row] {
-        &self.here
-    }
-    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-    pub fn open_system(&self) -> Option<&FoundSystem> {
-        self.open_system_ref()
-    }
-
-    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub fn covers(&self) -> &CoverCache {
         &self.covers
     }
@@ -4451,11 +4492,18 @@ impl BenchReport {
 }
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Outcome {
     Quit,
 
-    Launch(usize),
+    /// A launch carries its finished plan rather than a row index: the plan
+    /// is built while the interface is still up, so everything that can go
+    /// wrong is a message on screen and never an exit. Boxed because a plan
+    /// carries a whole MGL and an outcome moves by value.
+    Launch {
+        plan: Box<crate::launch::LaunchPlan>,
+        name: String,
+    },
 }
 
 #[cfg(test)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2265,15 +2265,38 @@ impl App {
             browse::Launch::File(path) => !crate::launch::needs_system_core(path),
             browse::Launch::AmigaVision { .. } => false,
         };
+        // Checked where MiSTer will look, not in the index the menu
+        // grouping keeps. That index matches a core name anywhere at the
+        // top of the card, so a support copy under _Arcade/cores or a
+        // favourite's dangling link would answer for a core whose real
+        // file is gone, and the launch would still end in MiSTer's own
+        // "No rbf found!" with Degauss already gone.
         if !self_describing
-            && self
-                .open_system_ref()
-                .is_none_or(|system| system.menu_folder.is_none())
+            && !crate::systems::core_file_exists(Path::new(&self.config.menu_root), &config.rbf)
         {
             self.message = Some(format!(
                 "{}: core {} is not on the card",
                 config.name, config.rbf
             ));
+            self.dirty = true;
+            return None;
+        }
+        // A gamelist can name a file that was deleted or renamed since it
+        // was written. The plan would build anyway and MiSTer would fail
+        // after this process had already handed over, so the absence has to
+        // become a line on screen here or never.
+        let missing = match &game {
+            // A favourite that is really an AmigaVision title points at an
+            // installation, not at itself; the file that has to exist is
+            // the one the rewritten MGL will mount.
+            browse::Launch::File(path) => match crate::launch::amiga_marker(path) {
+                Some((install, _)) => !install.exists(),
+                None => !path.exists(),
+            },
+            browse::Launch::AmigaVision { install, .. } => !install.exists(),
+        };
+        if missing {
+            self.message = Some(format!("{name}: its file is gone from the card"));
             self.dirty = true;
             return None;
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2289,11 +2289,14 @@ impl App {
             // A favourite that is really an AmigaVision title points at an
             // installation, not at itself; the file that has to exist is
             // the one the rewritten MGL will mount.
+            // An installation is a directory the launch writes into
+            // (shared/ags_boot); a plain file under that name would pass an
+            // existence check and fail after the hand-over.
             browse::Launch::File(path) => match crate::launch::amiga_marker(path) {
-                Some((install, _)) => !install.exists(),
+                Some((install, _)) => !install.is_dir(),
                 None => !path.exists(),
             },
-            browse::Launch::AmigaVision { install, .. } => !install.exists(),
+            browse::Launch::AmigaVision { install, .. } => !install.is_dir(),
         };
         if missing {
             self.message = Some(format!("{name}: its file is gone from the card"));

--- a/src/app.rs
+++ b/src/app.rs
@@ -3300,6 +3300,18 @@ impl App {
             }
         }
 
+        // A plain message follows the same rule as a question: the next
+        // press dismisses it and is spent on the dismissing, so nothing can
+        // be typed through it and pressing A twice on an unlaunchable game
+        // re-raises the message instead of looking stuck. Build progress is
+        // the exception: it repaints its own text every frame and the
+        // controls stay live under it.
+        if self.message.is_some() && self.build.is_none() {
+            self.message = None;
+            self.dirty = true;
+            return None;
+        }
+
         match action {
             Action::Up => {
                 if self.screen == Screen::Find {

--- a/src/app.rs
+++ b/src/app.rs
@@ -3965,8 +3965,18 @@ impl App {
         self.ui.set_status(SharedString::from(status));
         self.ui.set_show_stats(self.show_stats);
         self.ui.set_stats(SharedString::from(self.stats_line()));
-        self.ui
-            .set_overlay(SharedString::from(self.message.clone().unwrap_or_default()));
+        // A plain message says how to leave, the way the questions already
+        // carry their keys in their own text. Questions keep their "A yes,
+        // B no" and build progress replaces itself every frame, so neither
+        // takes the hint.
+        let overlay = match &self.message {
+            Some(text) if self.pending.is_none() && self.build.is_none() => {
+                format!("{text}\n\nB close")
+            }
+            Some(text) => text.clone(),
+            None => String::new(),
+        };
+        self.ui.set_overlay(SharedString::from(overlay));
     }
     fn stats_line(&self) -> String {
         let summary = self.timer.summary();

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -382,11 +382,24 @@ pub fn favorite_mgl(system: &SystemConfig, game: &Path) -> Result<Option<String>
 /// ready-made `.mgl` names it inside, and a bare `.rbf` is one. Only an MGL
 /// built here writes `system.rbf` into what MiSTer is asked to load, so
 /// only those launches can fail on a core the card does not have.
+///
+/// The exception among `.mgl` files is an AmigaVision favourite: it holds
+/// a title marker rather than a playable shortcut, and `plan` rewrites it
+/// into a fresh MGL naming the system's core, so it needs that core after
+/// all.
 pub fn needs_system_core(game: &Path) -> bool {
-    !game
+    let Some(extension) = game
         .extension()
         .and_then(|e| e.to_str())
-        .is_some_and(|e| matches!(e.to_ascii_lowercase().as_str(), "mra" | "mgl" | "rbf"))
+        .map(str::to_ascii_lowercase)
+    else {
+        return true;
+    };
+    match extension.as_str() {
+        "mra" | "rbf" => false,
+        "mgl" => amiga_marker(game).is_some(),
+        _ => true,
+    }
 }
 
 /// Work out how to start one entry.
@@ -859,6 +872,21 @@ mod tests {
         assert!(!needs_system_core(Path::new("/fav/Game.MRA")));
         assert!(!needs_system_core(Path::new("/fav/Game.mgl")));
         assert!(!needs_system_core(Path::new("/fav/Game.MGL")));
+        // An AmigaVision favourite is an .mgl in name only: it carries a
+        // title marker and plan() rewrites it into a fresh MGL naming
+        // system.rbf, so it depends on that core like any plain game.
+        let dir = std::env::temp_dir().join(format!("degauss-marker-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let marker = dir.join("Zool 2.mgl");
+        std::fs::write(
+            &marker,
+            "<mistergamedescription>\n\t<rbf>_Computer/Minimig</rbf>\n\t\
+             <degauss kind=\"amigavision\" install=\"/games/Amiga/AV.hdf\" title=\"Zool 2\"/>\n\
+             </mistergamedescription>\n",
+        )
+        .unwrap();
+        assert!(needs_system_core(&marker));
+        std::fs::remove_dir_all(&dir).ok();
         assert!(!needs_system_core(Path::new("/fav/core.rbf")));
         assert!(!needs_system_core(Path::new("/fav/core.RBF")));
         assert!(needs_system_core(Path::new("/games/Game.neo")));

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -376,6 +376,19 @@ pub fn favorite_mgl(system: &SystemConfig, game: &Path) -> Result<Option<String>
     build_mgl_with(&system.rbf, system.setname.as_deref(), &items, "").map(Some)
 }
 
+/// Whether starting this file relies on the system's own core.
+///
+/// A self-describing file names its own core: an `.mra` carries it, a
+/// ready-made `.mgl` names it inside, and a bare `.rbf` is one. Only an MGL
+/// built here writes `system.rbf` into what MiSTer is asked to load, so
+/// only those launches can fail on a core the card does not have.
+pub fn needs_system_core(game: &Path) -> bool {
+    !game
+        .extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| matches!(e.to_ascii_lowercase().as_str(), "mra" | "mgl" | "rbf"))
+}
+
 /// Work out how to start one entry.
 ///
 /// Arcade is the exception that needs no MGL: an `.mra` already names its
@@ -835,6 +848,22 @@ mod tests {
     fn a_relative_game_path_is_rejected() {
         let err = MglItem::new(&rule(&["prg"], "f", 1, 1), "games/x.prg").expect_err("must reject");
         assert!(err.to_string().contains("not absolute"), "got: {err}");
+    }
+
+    #[test]
+    fn a_self_describing_file_does_not_need_the_systems_core() {
+        // A favourite or a core file names its own core, so a missing
+        // system core must not block it: only a game that would be wrapped
+        // in an MGL naming system.rbf depends on that core being there.
+        assert!(!needs_system_core(Path::new("/fav/Game.mra")));
+        assert!(!needs_system_core(Path::new("/fav/Game.MRA")));
+        assert!(!needs_system_core(Path::new("/fav/Game.mgl")));
+        assert!(!needs_system_core(Path::new("/fav/Game.MGL")));
+        assert!(!needs_system_core(Path::new("/fav/core.rbf")));
+        assert!(!needs_system_core(Path::new("/fav/core.RBF")));
+        assert!(needs_system_core(Path::new("/games/Game.neo")));
+        assert!(needs_system_core(Path::new("/games/Game.bin")));
+        assert!(needs_system_core(Path::new("/games/Game")));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -968,7 +968,7 @@ fn run_on_framebuffer(
 
     match outcome {
         Outcome::Quit => note("ended        user quit"),
-        Outcome::Launch(index) => {
+        Outcome::Launch { plan, name } => {
             // Written before the core is asked for: once the command goes
             // into the FIFO, MiSTer replaces this process and there is no
             // later moment to save anything in.
@@ -976,28 +976,7 @@ fn run_on_framebuffer(
                 note(&format!("state        not saved: {e}"));
             }
             state::mark_resuming();
-            let system = app
-                .open_system()
-                .ok_or_else(|| DegaussError::unsupported("launch", "no system open".to_string()))?
-                .to_config();
-            let entry = app
-                .here()
-                .get(index)
-                .ok_or_else(|| DegaussError::unsupported("launch", "no entry".to_string()))?;
-            let mgl = Path::new("/tmp/degauss.mgl");
-            let plan = match &entry.kind {
-                browse::Kind::Play(browse::Launch::File(path)) => launch::plan(&system, path, mgl)?,
-                browse::Kind::Play(browse::Launch::AmigaVision { install, title }) => {
-                    launch::plan_amiga_vision(&system, install, title, mgl)?
-                }
-                browse::Kind::Enter(_) => {
-                    return Err(DegaussError::unsupported(
-                        "launch",
-                        "a folder is not a game".to_string(),
-                    ))
-                }
-            };
-            note(&format!("ended        launching {}", entry.name));
+            note(&format!("ended        launching {name}"));
             launch::execute(&plan, Path::new(launch::CMD_FIFO))?;
         }
     }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -348,6 +348,11 @@ pub fn core_file_exists(menu_root: &Path, rbf: &str) -> bool {
     };
     let wanted = core_name(core);
     for item in listing.flatten() {
+        // A directory named like a core would pass the name checks, and
+        // MiSTer cannot load a directory.
+        if !item.path().is_file() {
+            continue;
+        }
         let name = item.file_name().to_string_lossy().into_owned();
         let Some(stem) = name
             .strip_suffix(".rbf")
@@ -490,6 +495,16 @@ extensions = ["md", "bin"]
         std::fs::create_dir_all(root.join("_Arcade/cores")).unwrap();
         std::fs::write(root.join("_Arcade/cores/NES.rbf"), b"x").unwrap();
         assert!(!core_file_exists(&root, "_Console/NES"));
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn a_directory_named_like_a_core_does_not_answer() {
+        // MiSTer cannot load a directory, however it is named. Only a real
+        // file counts as the core being present.
+        let root = temp_dir("core-dir");
+        std::fs::create_dir_all(root.join("_Console/NeoGeo.rbf")).unwrap();
+        assert!(!core_file_exists(&root, "_Console/NeoGeo"));
         std::fs::remove_dir_all(&root).ok();
     }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -320,6 +320,48 @@ impl CoreIndex {
     }
 }
 
+/// True when the core an MGL naming `rbf` would load is really on the card.
+///
+/// `rbf` is MiSTer's own reference, e.g. `_Console/NeoGeo`, and MiSTer
+/// resolves it against the top of the card: that folder, that name, with
+/// the dated builds updaters install answering for the plain name. The
+/// index the menu grouping keeps is not usable for this: it matches a core
+/// name anywhere at the top of the card, so a support copy under
+/// `_Arcade/cores` or a favourite's dangling link would answer for a core
+/// whose real file is gone. This looks only where MiSTer will look, and
+/// compares through the same `core_name` the walk uses, so a dated file
+/// counts and a different core that merely shares a prefix does not.
+pub fn core_file_exists(menu_root: &Path, rbf: &str) -> bool {
+    let (folder, core) = match rbf.rsplit_once('/') {
+        Some((folder, core)) => (Some(folder), core),
+        None => (None, rbf),
+    };
+    if core.is_empty() {
+        return false;
+    }
+    let dir = match folder {
+        Some(folder) => menu_root.join(folder),
+        None => menu_root.to_path_buf(),
+    };
+    let Ok(listing) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    let wanted = core_name(core);
+    for item in listing.flatten() {
+        let name = item.file_name().to_string_lossy().into_owned();
+        let Some(stem) = name
+            .strip_suffix(".rbf")
+            .or_else(|| name.strip_suffix(".RBF"))
+        else {
+            continue;
+        };
+        if core_name(stem).eq_ignore_ascii_case(&wanted) {
+            return true;
+        }
+    }
+    false
+}
+
 /// A core's name reduced to what identifies it: no date stamp, no
 /// punctuation, no case.
 ///
@@ -412,6 +454,52 @@ extensions = ["md", "bin"]
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("temp dir");
         dir
+    }
+
+    #[test]
+    fn a_dated_core_build_answers_for_the_plain_name() {
+        // Updaters install cores as NeoGeo_20260101.rbf, and MiSTer loads
+        // that file for an MGL saying _Console/NeoGeo. Presence has to be
+        // judged the way MiSTer resolves, or every updated card looks like
+        // it has no cores at all.
+        let root = temp_dir("core-dated");
+        std::fs::create_dir_all(root.join("_Console")).unwrap();
+        std::fs::write(root.join("_Console/NeoGeo_20260101.rbf"), b"x").unwrap();
+        assert!(core_file_exists(&root, "_Console/NeoGeo"));
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn a_core_that_merely_shares_a_prefix_does_not_answer() {
+        // NeoGeoPocket.rbf sitting beside a missing NeoGeo.rbf must not
+        // make Neo Geo launchable: a bare prefix match would say it is.
+        let root = temp_dir("core-prefix");
+        std::fs::create_dir_all(root.join("_Console")).unwrap();
+        std::fs::write(root.join("_Console/NeoGeoPocket.rbf"), b"x").unwrap();
+        assert!(!core_file_exists(&root, "_Console/NeoGeo"));
+        assert!(core_file_exists(&root, "_Console/NeoGeoPocket"));
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn a_copy_of_the_core_somewhere_else_does_not_answer() {
+        // _Arcade/cores holds support copies of console cores for .mra
+        // loading. MiSTer resolves an MGL's rbf against the named folder
+        // only, so a copy elsewhere must not make the launch look safe.
+        let root = temp_dir("core-elsewhere");
+        std::fs::create_dir_all(root.join("_Arcade/cores")).unwrap();
+        std::fs::write(root.join("_Arcade/cores/NES.rbf"), b"x").unwrap();
+        assert!(!core_file_exists(&root, "_Console/NES"));
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn a_missing_folder_means_the_core_is_missing_not_a_crash() {
+        let root = temp_dir("core-nofolder");
+        assert!(!core_file_exists(&root, "_Console/NeoGeo"));
+        assert!(!core_file_exists(&root, ""));
+        assert!(!core_file_exists(&root, "_Console/"));
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]


### PR DESCRIPTION
Fixes #5: a game whose core is not installed or has an error quits Degauss instead of just saying so.

## What this changes

Every launch failure ended Degauss. The plan was built after the event loop had already returned, so a missing core, a bad rule or a vanished file had nowhere to go but process exit, followed by MiSTer's own "No rbf found!" on the console.

Everything fallible is now decided while the interface is still up. The core is checked where MiSTer will resolve the MGL's rbf reference: that folder, that name, with dated builds answering for the plain name through the same normalisation the menu walk uses. The index the menu grouping keeps is deliberately not used for this, because it matches a core name anywhere at the top of the card, so a support copy under `_Arcade/cores` or a favourite's dangling link would answer for a core whose real file is gone. The game's file is checked too, and an AmigaVision favourite is followed through its marker: it needs the system core after all, and the file that has to exist is the installation, not the favourite. Any failure becomes a line on screen and browsing continues. `Outcome::Launch` carries the ready plan, and main only saves state, marks resuming and executes it, with the position still saved before the FIFO command.

## Why

Picking a game whose core is not installed threw you out of Degauss entirely, and every other launch failure did the same silently.

Known residual, by design: a launch that MiSTer itself rejects after a clean hand-over (a corrupt core file, for example) still ends at MiSTer's side, because by then Degauss is gone. Everything Degauss can know about before handing over is now checked before handing over.

## How it was checked

- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --target armv7-unknown-linux-musleabihf --all-targets -- -D warnings`
- [x] Run on a real MiSTer
- [x] On a CRT, if it changes anything drawn

200 tests, five new: four for the core resolution in `systems.rs` and a marker case in `launch.rs`. `--dry-run-launch`, `--render`, `--bench` and selftest are unchanged. CodeRabbit CLI against main found the AmigaVision favourite gap; the fix for it is in the second commit. A test binary with this fix is staged for device testing; the boxes get ticked when it has actually been run there.

## Licensing

By opening this pull request I agree that my contribution is licensed under
the [PolyForm Noncommercial License 1.0.0](../LICENSE), the same licence as
the rest of Degauss, and that I have the right to license it that way.

Changes to `MiSTer_Degauss` do not belong here: it is a separate GPLv3
program in its own repository,
[Degauss-Main](https://github.com/giancarloerra/Degauss-Main).

- [x] I agree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Launch validation now confirms AmigaVision installation targets are directories before starting.
  - System-core requirements are detected more accurately for supported file types and extensions.
  - Core files are verified against the selected menu, including compatible dated builds.
  - Plain messages now provide a “B close” prompt, while build-progress messages remain interactive and update automatically.

- **Bug Fixes**
  - Invalid launch paths and missing or unsuitable core files are rejected before launch.
  - Core checks ignore unrelated files, copies in other folders and directories.
  - Launches use validated details consistently, improving reliability and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
