### PR TITLE
Come back to the row a folder was left on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@
 # Binaries staged for the card; built, not committed.
 /deploy/Scripts/.config/degauss/degauss
 
-# Written by Degauss itself when settings change
+# Written by Degauss itself: options, and where you were
 /settings.toml
+/state.toml
 
 # Staged for the card at build time from assets/logos; not committed twice.
 /deploy/Scripts/.config/degauss/logos/

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Enter, Escape, Space and Tab.
 - **Nothing written to your card** except favourites you ask for, its own
   index, the `settings.toml` holding what you changed in Options, and a
   small `state.toml` remembering where you were: every folder you visit
-  keeps the row you left it on until the machine is powered off, found
+  keeps the row you left it on for the whole sitting, riding along when
+  a game takes the screen and starting fresh on a cold start, found
   again by the game itself rather than by its position, so a folder whose
   contents changed still comes back to the same game. An AmigaVision
   title also needs its `shared/ags_boot` file written, which is how those

--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ Enter, Escape, Space and Tab.
   small `state.toml` remembering where you were: every folder you visit
   keeps the row you left it on until the machine is powered off, found
   again by the game itself rather than by its position, so a folder whose
-  contents changed still comes back to the same game. AmigaVision titles
-  also need its own `shared/ags_boot` written to start the right game.
+  contents changed still comes back to the same game. An AmigaVision
+  title also needs its `shared/ags_boot` file written, which is how those
+  games are started.
   Gamelists and artwork are read, never modified.
 - **Awkward systems handled** without hassle: AmigaVision, DOS,
   Neo Geo, Arcade, X68000, and cores that are several machines.

--- a/README.md
+++ b/README.md
@@ -95,8 +95,11 @@ Enter, Escape, Space and Tab.
   anywhere else appears here.
 - **Nothing written to your card** except favourites you ask for, its own
   index, the `settings.toml` holding what you changed in Options, and a
-  small `state.toml` remembering where you were. AmigaVision titles also
-  need its own `shared/ags_boot` written to start the right game.
+  small `state.toml` remembering where you were: every folder you visit
+  keeps the row you left it on until the machine is powered off, found
+  again by the game itself rather than by its position, so a folder whose
+  contents changed still comes back to the same game. AmigaVision titles
+  also need its own `shared/ags_boot` written to start the right game.
   Gamelists and artwork are read, never modified.
 - **Awkward systems handled** without hassle: AmigaVision, DOS,
   Neo Geo, Arcade, X68000, and cores that are several machines.

--- a/src/app.rs
+++ b/src/app.rs
@@ -4564,7 +4564,9 @@ impl App {
         // The first place is the one opening the system already reached.
         // `places` stops at anything the card no longer has, so a renamed
         // folder lands on its parent instead of an error screen.
-        for place in saved.places().into_iter().skip(1) {
+        let places = saved.places();
+        let walked_everything = places.len() == saved.trail.len();
+        for place in places.into_iter().skip(1) {
             self.enter(place);
         }
         // Every level keeps the row it was left on. `enter` above wrote the
@@ -4578,7 +4580,15 @@ impl App {
         // were the walk's own rather than the user's. The saved memory is
         // the truthful one, so it goes back in whole.
         self.left_at = saved.left_at.clone();
-        self.game_list.select(saved.selected);
+        if walked_everything {
+            self.game_list.select(saved.selected);
+        } else {
+            // The walk stopped short of the folder the cursor position
+            // belongs to; that number means a row in a folder that was
+            // not reached. Re-list where the walk DID land, whose own
+            // remembered row is the honest answer.
+            self.show_here();
+        }
         self.touch_selection();
         self.apply_geometry();
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -460,6 +460,17 @@ fn row_key(row: &browse::Row) -> String {
     }
 }
 
+/// Where the cursor lands in a freshly listed folder: the remembered row
+/// found again by what it is, or the fallback index when there is nothing
+/// remembered or the row is gone. Identity is asked first because an index
+/// goes stale whenever rows are added, hidden or resorted, and landing on
+/// an arbitrary row looks like the list moved on its own.
+fn reselect(rows: &[browse::Row], remembered: Option<&str>, fallback: usize) -> usize {
+    remembered
+        .and_then(|key| rows.iter().position(|row| row_key(row) == key))
+        .unwrap_or(fallback)
+}
+
 /// A title with the characters MiSTer's favourites script refuses taken
 /// out, so a name made here is one it would have made.
 fn sanitise(name: &str) -> String {
@@ -781,6 +792,13 @@ pub struct App {
     library: Option<Library>,
     names: browse::DisplayNames,
     trail: Vec<Crumb>,
+    /// The row every visited folder was left standing on, by the row's own
+    /// key. The crumbs remember an index for walking straight back out;
+    /// this remembers identity, so a folder that is re-entered later, or
+    /// whose contents changed in between, still comes back to the same
+    /// game. Saved with the position at launch and gone after a power
+    /// cycle, like the rest of where the user was standing.
+    left_at: Vec<crate::state::LeftAt>,
     /// The rows of the folder being shown.
     here: Vec<browse::Row>,
     game_list: ListState,
@@ -1033,6 +1051,7 @@ impl App {
             library: None,
             names,
             trail: Vec::new(),
+            left_at: Vec::new(),
             here: Vec::new(),
             game_list: ListState::new(0, geometry.visible),
             menu_list: ListState::new(0, geometry.visible),
@@ -1714,8 +1733,41 @@ impl App {
         }
     }
 
+    /// Write down the row the folder on screen is standing on, so coming
+    /// back to this folder lands there again.
+    ///
+    /// Keyed by the system as well as the place, because place keys are
+    /// only unique within one system: every system's root shares the same
+    /// key. Nothing to write when no folder is on screen or it is empty.
+    fn remember_here(&mut self) {
+        if self.browsing != Browsing::Games {
+            return;
+        }
+        let Some(system) = self.open_system.clone() else {
+            return;
+        };
+        let Some(crumb) = self.trail.last() else {
+            return;
+        };
+        let Some(row) = self.here.get(self.game_list.selected()) else {
+            return;
+        };
+        crate::state::remember_left_at(
+            &mut self.left_at,
+            crate::state::LeftAt {
+                system,
+                place: crumb.place.key(),
+                row: row_key(row),
+            },
+        );
+    }
+
     /// Walk into a folder and show it.
     fn enter(&mut self, place: Place) {
+        // By identity too: the crumb below keeps an index for walking
+        // straight back out, but a later visit through a changed list
+        // needs the row itself to find the place again.
+        self.remember_here();
         if let Some(crumb) = self.trail.last_mut() {
             // Remember where we were standing, so coming back lands there
             // rather than at the top of a list of thousands.
@@ -1728,6 +1780,10 @@ impl App {
     /// Walk back out. False when there is nothing left to walk out of, and
     /// the caller should leave the system entirely.
     fn leave(&mut self) -> bool {
+        // The folder being left keeps its place. This is the only moment
+        // its cursor is still alive; without it, re-entering starts at the
+        // top every time.
+        self.remember_here();
         self.trail.pop();
         if self.trail.is_empty() {
             return false;
@@ -2127,7 +2183,7 @@ impl App {
         self.correct_system_counts();
         self.screen = Screen::Browse;
         self.apply_geometry();
-        self.show_here();
+        self.relist_here();
         self.dirty = true;
     }
 
@@ -2179,7 +2235,15 @@ impl App {
                 self.all_here.clear();
                 self.here = rows;
                 self.game_list = ListState::new(self.here.len(), self.geometry.visible);
-                self.game_list.select(crumb.selected);
+                // The remembered row first, found again by what it is; the
+                // crumb's index when there is none or it is gone. A fresh
+                // crumb says zero, so a folder never visited starts at the
+                // top, and select() clamps whatever comes out.
+                let remembered = self.open_system.as_deref().and_then(|system| {
+                    crate::state::recall_left_at(&self.left_at, system, &crumb.place.key())
+                });
+                let at = reselect(&self.here, remembered, crumb.selected);
+                self.game_list.select(at);
                 self.browsing = Browsing::Games;
                 self.message = None;
                 self.apply_geometry();
@@ -2195,6 +2259,17 @@ impl App {
                 self.dirty = true;
             }
         }
+    }
+
+    /// List the folder on screen again after something about it changed.
+    ///
+    /// The live cursor is written down first, because `show_here` restores
+    /// the remembered row: re-listing without remembering landed on
+    /// whatever row the folder was entered on, which is how favouriting or
+    /// hiding a game deep in a long list snapped the cursor away from it.
+    fn relist_here(&mut self) {
+        self.remember_here();
+        self.show_here();
     }
 
     /// The system that is open, found by its id.
@@ -2824,18 +2899,18 @@ impl App {
                 // The folder on screen and the list of systems were both
                 // filtered by the old answer.
                 self.rebuild_system_list();
-                self.show_here();
+                self.relist_here();
             }
             OptionId::FoldersLast => {
                 self.folders_last = !self.folders_last;
                 self.settings.folders_last = Some(self.folders_last);
-                self.show_here();
+                self.relist_here();
             }
             OptionId::FavoritesFirst => {
                 self.favorites_first = !self.favorites_first;
                 self.settings.favorites_first = Some(self.favorites_first);
                 // The folder on screen was ordered by the old answer.
-                self.show_here();
+                self.relist_here();
             }
             OptionId::RandomLaunches => {
                 self.random_launches = !self.random_launches;
@@ -2853,7 +2928,7 @@ impl App {
                 self.save_settings();
                 self.corrected_counts.clear();
                 self.rebuild_system_list();
-                self.show_here();
+                self.relist_here();
                 self.message = Some(format!("{held} shown again"));
                 self.dirty = true;
             }
@@ -3272,7 +3347,7 @@ impl App {
             }
             self.screen = Screen::Browse;
             self.apply_geometry();
-            self.show_here();
+            self.relist_here();
             if let Some(error) = refresh_error {
                 // Set after show_here, which clears the message field as
                 // part of its redraw; set before, the error would never be
@@ -3317,7 +3392,7 @@ impl App {
         }
         self.screen = Screen::Browse;
         self.apply_geometry();
-        self.show_here();
+        self.relist_here();
         if let Some(error) = refresh_error {
             // Set after show_here, which clears the message field as
             // part of its redraw; set before, the error would never be
@@ -3349,7 +3424,7 @@ impl App {
         }
         self.screen = Screen::Browse;
         self.apply_geometry();
-        self.show_here();
+        self.relist_here();
         if let Some(error) = refresh_error {
             // Set after show_here, which clears the message field as
             // part of its redraw; set before, the error would never be
@@ -4398,6 +4473,7 @@ impl App {
             self.open_category.as_deref().unwrap_or_default(),
             &trail,
             self.game_list.selected(),
+            &self.left_at,
         )
     }
 
@@ -4431,6 +4507,10 @@ impl App {
         self.system_list.go_first();
         self.system_list.move_items(index as isize);
         self.browsing = Browsing::Systems;
+        // Seeded before the walk, so every folder the walk lists resolves
+        // its remembered row on the way down, and an ordinary re-entry
+        // after the resume agrees with the resume itself.
+        self.left_at = saved.left_at.clone();
         self.open_system_now();
         if self.open_system.is_none() {
             return;
@@ -4449,6 +4529,10 @@ impl App {
         for (crumb, saved_place) in self.trail.iter_mut().zip(saved.trail.iter()) {
             crumb.selected = saved_place.selected();
         }
+        // The walk also wrote places down as it stepped, from cursors that
+        // were the walk's own rather than the user's. The saved memory is
+        // the truthful one, so it goes back in whole.
+        self.left_at = saved.left_at.clone();
         self.game_list.select(saved.selected);
         self.touch_selection();
         self.apply_geometry();
@@ -4940,5 +5024,55 @@ mod tests {
         let plain = Geometry::compute(Layout::List, true, true, true, 352, 240, &config);
         assert_eq!(plain.chrome, 20.0, "title bar height on the tube");
         assert_eq!(plain.small_font, 10.0, "plain small text on the tube");
+    }
+
+    fn listed(names: &[&str]) -> Vec<browse::Row> {
+        names
+            .iter()
+            .map(|name| browse::Row {
+                name: (*name).into(),
+                sort_key: name.to_lowercase(),
+                kind: browse::Kind::Play(browse::Launch::File(PathBuf::from(format!(
+                    "/games/{name}.d64"
+                )))),
+                cover: None,
+                genre: None,
+                favorite: false,
+                below: None,
+                details: browse::Details::default(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_remembered_row_wins_over_the_crumb_index() {
+        let rows = listed(&["Alpha", "Beta", "Gamma"]);
+        let key = row_key(&rows[1]);
+        assert_eq!(reselect(&rows, Some(&key), 0), 1);
+    }
+
+    #[test]
+    fn a_remembered_row_is_found_where_it_moved_to() {
+        // The folder was resorted since it was left: a favourite gathered
+        // to the top must still be the row the cursor lands on, not the
+        // row now sitting where it used to.
+        let rows = listed(&["Alpha", "Beta", "Gamma"]);
+        let key = row_key(&rows[2]);
+        let resorted = listed(&["Gamma", "Alpha", "Beta"]);
+        assert_eq!(reselect(&resorted, Some(&key), 2), 0);
+    }
+
+    #[test]
+    fn a_row_that_is_gone_falls_back_to_the_crumb_index() {
+        // Gone covers hidden too: a row hidden since the last visit is
+        // dropped before this runs, and the memory must not resurrect it.
+        let rows = listed(&["Alpha", "Beta"]);
+        assert_eq!(reselect(&rows, Some("f:/games/Gone.d64"), 1), 1);
+    }
+
+    #[test]
+    fn a_folder_never_visited_lands_where_the_crumb_says() {
+        let rows = listed(&["Alpha", "Beta"]);
+        assert_eq!(reselect(&rows, None, 0), 0, "the top, for a fresh crumb");
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2267,8 +2267,18 @@ impl App {
     /// the remembered row: re-listing without remembering landed on
     /// whatever row the folder was entered on, which is how favouriting or
     /// hiding a game deep in a long list snapped the cursor away from it.
+    ///
+    /// The crumb's index is refreshed too, because it is the fallback when
+    /// the remembered row cannot be found again, and the action being
+    /// re-listed for can be the one that removed that very row: hiding the
+    /// game under the cursor must leave the cursor where it stood, on
+    /// whatever slid into its place, not send it back to where the folder
+    /// was entered.
     fn relist_here(&mut self) {
         self.remember_here();
+        if let Some(crumb) = self.trail.last_mut() {
+            crumb.selected = self.game_list.selected();
+        }
         self.show_here();
     }
 
@@ -5074,5 +5084,23 @@ mod tests {
     fn a_folder_never_visited_lands_where_the_crumb_says() {
         let rows = listed(&["Alpha", "Beta"]);
         assert_eq!(reselect(&rows, None, 0), 0, "the top, for a fresh crumb");
+    }
+
+    #[test]
+    fn hiding_the_row_under_the_cursor_leaves_the_cursor_in_place() {
+        // relist_here refreshes the crumb to the live cursor before
+        // re-listing, so when the remembered row is the very one that
+        // vanished, the fallback is where the cursor stood: the row that
+        // slid into its place, not the row the folder was entered on.
+        let before = listed(&["Alpha", "Beta", "Gamma"]);
+        let key = row_key(&before[1]);
+        let after = listed(&["Alpha", "Gamma"]);
+        assert_eq!(reselect(&after, Some(&key), 1), 1, "Gamma slid into place");
+
+        // Hiding the last row parks that fallback one past the end; the
+        // clamp in select() is what keeps it on the new last row.
+        let mut list = ListState::new(2, 10);
+        list.select(reselect(&after, Some("f:/games/Gone.d64"), 2));
+        assert_eq!(list.selected(), 1, "clamped to the new last row");
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -799,6 +799,10 @@ pub struct App {
     /// game. Saved with the position at launch and gone after a power
     /// cycle, like the rest of where the user was standing.
     left_at: Vec<crate::state::LeftAt>,
+    /// The system each group was left standing on, by the group's name.
+    /// By id, not index: the list is rebuilt per group, and a position
+    /// taken in Computer points at a different machine in Console.
+    category_system: std::collections::BTreeMap<String, String>,
     /// The rows of the folder being shown.
     here: Vec<browse::Row>,
     game_list: ListState,
@@ -1052,6 +1056,7 @@ impl App {
             names,
             trail: Vec::new(),
             left_at: Vec::new(),
+            category_system: std::collections::BTreeMap::new(),
             here: Vec::new(),
             game_list: ListState::new(0, geometry.visible),
             menu_list: ListState::new(0, geometry.visible),
@@ -1687,6 +1692,7 @@ impl App {
     /// still screen with no explanation, so the message is drawn first and
     /// the work happens after it is on screen.
     fn open_selected_system(&mut self) {
+        self.remember_system_here();
         let Some(system) = self.systems.get(self.system_list.selected()) else {
             return;
         };
@@ -1760,6 +1766,20 @@ impl App {
                 row: row_key(row),
             },
         );
+    }
+
+    /// Write down the system the open group is standing on, so coming
+    /// back to this group lands there again, whatever was visited in
+    /// between: the systems list is one ListState shared by every group,
+    /// and its bare index means a different machine in each one.
+    fn remember_system_here(&mut self) {
+        let Some(category) = self.open_category.clone() else {
+            return;
+        };
+        let Some(system) = self.systems.get(self.system_list.selected()) else {
+            return;
+        };
+        self.category_system.insert(category, system.def.id.clone());
     }
 
     /// Walk into a folder and show it.
@@ -2792,8 +2812,17 @@ impl App {
         let Some((name, _)) = self.categories.get(self.category_list.selected()) else {
             return;
         };
+        let name = name.clone();
         self.open_category = Some(name.clone());
         self.rebuild_system_list();
+        // Back to the system this group was left on, found by id in the
+        // freshly filtered list; a group never left keeps the clamped
+        // index the rebuild produced, exactly as before.
+        if let Some(id) = self.category_system.get(name.as_str()) {
+            if let Some(at) = self.systems.iter().position(|s| &s.def.id == id) {
+                self.system_list.select(at);
+            }
+        }
         self.browsing = Browsing::Systems;
 
         // A group holding one system is a door with a corridor behind it.
@@ -3106,6 +3135,7 @@ impl App {
                     if self.skipped_systems {
                         // We stepped through this group on the way in.
                         self.skipped_systems = false;
+                        self.remember_system_here();
                         self.browsing = Browsing::Categories;
                         self.open_category = None;
                         self.rebuild_system_list();
@@ -3119,6 +3149,7 @@ impl App {
                     self.touch_selection();
                 }
                 Browsing::Systems => {
+                    self.remember_system_here();
                     self.browsing = Browsing::Categories;
                     self.open_category = None;
                     self.rebuild_system_list();
@@ -4484,6 +4515,7 @@ impl App {
             &trail,
             self.game_list.selected(),
             &self.left_at,
+            &self.category_system,
         )
     }
 
@@ -4497,6 +4529,9 @@ impl App {
         if saved.system.is_empty() {
             return;
         }
+        // Each group's own memory first, so backing out of the restored
+        // system recalls the other groups exactly as before the exit.
+        self.category_system = saved.category_system.clone();
         if !saved.category.is_empty() {
             self.open_category = Some(saved.category.clone());
             self.rebuild_system_list();

--- a/src/state.rs
+++ b/src/state.rs
@@ -92,6 +92,47 @@ impl SavedPlace {
     }
 }
 
+/// The row a folder was left standing on, written down by what the row is
+/// rather than where it sat. An index goes stale the moment the folder's
+/// contents change; the row's own key finds it again wherever it moved.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LeftAt {
+    /// The system the folder belongs to. Part of the identity because two
+    /// systems can hold folders whose keys read the same: every system's
+    /// root, for one, is the same key.
+    pub system: String,
+    /// The folder, by [`Place::key`].
+    pub place: String,
+    /// The selected row, by its own key.
+    pub row: String,
+}
+
+/// How many left-at places are kept. A sitting touches a handful of
+/// folders; two hundred covers that many times over, while a card holding
+/// thousands of folders cannot grow the file without bound.
+pub const LEFT_AT_CAP: usize = 200;
+
+/// Write a place down, most recent last. A folder already in the list
+/// moves to the end rather than appearing twice, and the oldest entry
+/// makes room once the cap is reached. Age is why these live in a Vec and
+/// not a map: a map could not say which entry to let go.
+pub fn remember_left_at(list: &mut Vec<LeftAt>, entry: LeftAt) {
+    list.retain(|held| held.system != entry.system || held.place != entry.place);
+    list.push(entry);
+    if list.len() > LEFT_AT_CAP {
+        let excess = list.len() - LEFT_AT_CAP;
+        list.drain(..excess);
+    }
+}
+
+/// The row this folder was left on, if it was ever written down.
+pub fn recall_left_at<'a>(list: &'a [LeftAt], system: &str, place: &str) -> Option<&'a str> {
+    list.iter()
+        .rev()
+        .find(|held| held.system == system && held.place == place)
+        .map(|held| held.row.as_str())
+}
+
 /// Everything needed to put the user back where they were.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct State {
@@ -106,10 +147,20 @@ pub struct State {
     /// Where the cursor sat in the folder on screen.
     #[serde(default)]
     pub selected: usize,
+    /// The row every visited folder was left on, so coming back to one
+    /// lands where browsing left off, not only after a game.
+    #[serde(default)]
+    pub left_at: Vec<LeftAt>,
 }
 
 impl State {
-    pub fn record(system: &str, category: &str, trail: &[(Place, usize)], selected: usize) -> Self {
+    pub fn record(
+        system: &str,
+        category: &str,
+        trail: &[(Place, usize)],
+        selected: usize,
+        left_at: &[LeftAt],
+    ) -> Self {
         State {
             system: system.to_string(),
             category: category.to_string(),
@@ -118,6 +169,7 @@ impl State {
                 .map(|(place, selected)| SavedPlace::of(place, *selected))
                 .collect(),
             selected,
+            left_at: left_at.to_vec(),
         }
     }
 
@@ -210,6 +262,10 @@ mod tests {
         .unwrap();
         let read = State::load(&path);
         assert_eq!(read.system, "C64");
+        assert!(
+            read.left_at.is_empty(),
+            "a file with no left-at table reads as one with an empty table"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -218,7 +274,7 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("degauss-cold-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("state.toml");
-        State::record("C64", "Computer", &[], 12)
+        State::record("C64", "Computer", &[], 12, &[])
             .save(&path)
             .unwrap();
         assert!(path.exists());
@@ -239,7 +295,7 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("degauss-warm-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("state.toml");
-        State::record("C64", "Computer", &[], 12)
+        State::record("C64", "Computer", &[], 12, &[])
             .save(&path)
             .unwrap();
 
@@ -251,6 +307,84 @@ mod tests {
             "kept, in case the next game comes from here too"
         );
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    fn place(folder: &str, row: &str) -> LeftAt {
+        LeftAt {
+            system: "C64".into(),
+            place: folder.to_string(),
+            row: row.to_string(),
+        }
+    }
+
+    #[test]
+    fn the_left_at_places_survive_being_written_down() {
+        let dir = std::env::temp_dir().join(format!("degauss-leftat-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("state.toml");
+        let places = vec![place("d:/games/Amiga", "f:/games/Amiga/SuperFrog.lha")];
+        State::record("C64", "Computer", &[], 0, &places)
+            .save(&path)
+            .unwrap();
+
+        let read = State::load(&path);
+        assert_eq!(read.left_at, places);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_full_list_lets_the_oldest_place_go() {
+        let mut list = Vec::new();
+        for n in 0..=LEFT_AT_CAP {
+            remember_left_at(&mut list, place(&format!("d:/{n}"), &format!("f:/{n}")));
+        }
+        assert_eq!(list.len(), LEFT_AT_CAP);
+        assert!(
+            recall_left_at(&list, "C64", "d:/0").is_none(),
+            "the oldest made room"
+        );
+        assert!(recall_left_at(&list, "C64", &format!("d:/{LEFT_AT_CAP}")).is_some());
+    }
+
+    #[test]
+    fn coming_back_to_a_folder_refreshes_its_age_rather_than_doubling_it() {
+        let mut list = Vec::new();
+        remember_left_at(&mut list, place("d:/a", "f:/1"));
+        remember_left_at(&mut list, place("d:/b", "f:/2"));
+        remember_left_at(&mut list, place("d:/a", "f:/3"));
+        assert_eq!(list.len(), 2, "one entry per folder");
+        assert_eq!(recall_left_at(&list, "C64", "d:/a"), Some("f:/3"));
+        assert_eq!(
+            list.last().map(|held| held.place.as_str()),
+            Some("d:/a"),
+            "moved to the back of the queue, so it is the last to be evicted"
+        );
+    }
+
+    #[test]
+    fn two_systems_do_not_share_a_place() {
+        // Every system's root folder carries the same key, so without the
+        // system in the identity, leaving the root of one system would
+        // move the remembered row of every other.
+        let mut list = Vec::new();
+        remember_left_at(
+            &mut list,
+            LeftAt {
+                system: "Amiga".into(),
+                place: "r:".into(),
+                row: "f:/one".into(),
+            },
+        );
+        remember_left_at(
+            &mut list,
+            LeftAt {
+                system: "C64".into(),
+                place: "r:".into(),
+                row: "f:/two".into(),
+            },
+        );
+        assert_eq!(recall_left_at(&list, "Amiga", "r:"), Some("f:/one"));
+        assert_eq!(recall_left_at(&list, "C64", "r:"), Some("f:/two"));
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -151,6 +151,10 @@ pub struct State {
     /// lands where browsing left off, not only after a game.
     #[serde(default)]
     pub left_at: Vec<LeftAt>,
+    /// The system each group was left standing on, by the group's name and
+    /// the system's id. The groups are few, so no cap is needed.
+    #[serde(default)]
+    pub category_system: std::collections::BTreeMap<String, String>,
 }
 
 impl State {
@@ -160,10 +164,12 @@ impl State {
         trail: &[(Place, usize)],
         selected: usize,
         left_at: &[LeftAt],
+        category_system: &std::collections::BTreeMap<String, String>,
     ) -> Self {
         State {
             system: system.to_string(),
             category: category.to_string(),
+            category_system: category_system.clone(),
             trail: trail
                 .iter()
                 .map(|(place, selected)| SavedPlace::of(place, *selected))
@@ -274,9 +280,16 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("degauss-cold-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("state.toml");
-        State::record("C64", "Computer", &[], 12, &[])
-            .save(&path)
-            .unwrap();
+        State::record(
+            "C64",
+            "Computer",
+            &[],
+            12,
+            &[],
+            &std::collections::BTreeMap::new(),
+        )
+        .save(&path)
+        .unwrap();
         assert!(path.exists());
 
         assert!(
@@ -295,9 +308,16 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("degauss-warm-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("state.toml");
-        State::record("C64", "Computer", &[], 12, &[])
-            .save(&path)
-            .unwrap();
+        State::record(
+            "C64",
+            "Computer",
+            &[],
+            12,
+            &[],
+            &std::collections::BTreeMap::new(),
+        )
+        .save(&path)
+        .unwrap();
 
         let saved = take_position(true, &path).expect("a position");
         assert_eq!(saved.system, "C64");
@@ -318,14 +338,39 @@ mod tests {
     }
 
     #[test]
+    fn the_system_each_group_was_left_on_survives_being_written_down() {
+        // Walking out of Console and into Computer must not cost Console
+        // its place: each group remembers its own system, by id, across
+        // an exit and a restart.
+        let dir = std::env::temp_dir().join(format!("degauss-groups-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("state.toml");
+        let mut groups = std::collections::BTreeMap::new();
+        groups.insert("Console".to_string(), "NeoGeo".to_string());
+        groups.insert("Computer".to_string(), "AO486".to_string());
+        let state = State::record("NeoGeo", "Console", &[], 3, &[], &groups);
+        state.save(&path).unwrap();
+        let read = State::load(&path);
+        assert_eq!(read.category_system, groups);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn the_left_at_places_survive_being_written_down() {
         let dir = std::env::temp_dir().join(format!("degauss-leftat-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("state.toml");
         let places = vec![place("d:/games/Amiga", "f:/games/Amiga/SuperFrog.lha")];
-        State::record("C64", "Computer", &[], 0, &places)
-            .save(&path)
-            .unwrap();
+        State::record(
+            "C64",
+            "Computer",
+            &[],
+            0,
+            &places,
+            &std::collections::BTreeMap::new(),
+        )
+        .save(&path)
+        .unwrap();
 
         let read = State::load(&path);
         assert_eq!(read.left_at, places);


### PR DESCRIPTION
Fixes #6: Come back to where you were in a folder you have already been in.

## What this changes

Every folder you visit remembers the row you left it on, and coming back
lands there again. The memory is by the row itself, not its position: a
folder that was resorted or changed in between still comes back to the
same game, found by what it launches. When that exact row is gone, the
cursor lands where it stood, on whatever slid into its place.

- Kept per folder, keyed by system and place, up to 200 folders, oldest
  dropped first. Saved in `state.toml` with the resume state, so it
  rides along when a game takes the screen and starts fresh on a cold
  start, like the rest of where you were standing.
- Restoring after a game applies the saved cursor only when the whole
  saved walk could be replayed: a folder that vanished in between means
  the number belongs to a folder never reached, so the surviving parent
  re-lists on its own remembered row instead.
- Favouriting or hiding a game deep in a long list no longer snaps the
  cursor away: the folder is re-listed around the row you were on,
  including when the row you were on is the one that was hidden.
- The groups remember too: Console left on Neo Geo comes back to
  Neo Geo even after a walk through Computer, because each group writes
  down the system it was left on by id. The systems list is one shared
  list state, so its bare index meant a different machine in every
  group.

## Why

Opening a folder of thousands, walking to the game you care about, then
stepping out for a moment cost the whole walk again. The crumbs already
remembered an index for walking straight back out; an index goes stale
whenever rows are added, hidden or resorted, so this remembers identity
and falls back to position only when the row itself is gone.

## How it was checked

- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --target armv7-unknown-linux-musleabihf --all-targets -- -D warnings`
- [x] Run on a real MiSTer
- [x] On a CRT, if it changes anything drawn

## Licensing

By opening this pull request I agree that my contribution is licensed under
the [PolyForm Noncommercial License 1.0.0](../LICENSE), the same licence as
the rest of Degauss, and that I have the right to license it that way.

Changes to `MiSTer_Degauss` do not belong here: it is a separate GPLv3
program in its own repository,
[Degauss-Main](https://github.com/giancarloerra/Degauss-Main).

- [x] I agree
