### PR TITLE
Choose what left and right do while browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Source available, written in Rust and using Slint, and licensed for non-commerci
 | Control | Does |
 |---|---|
 | **up / down** | move through lists |
-| **left / right** | scroll speed, 0.5x to 12x. In a menu, change the setting |
+| **left / right** | scroll speed, 0.5x to 12x, or what the **Left and right** setting says: letter jumps, page jumps, or plain movement. In a menu, change the setting |
 | **A** (enter) | open a folder, launch a game |
 | **B** (escape) | back, out of the folder |
 | **X** (tab) | context menu: random game, random favourite, keep or drop a favourite, jump to letter, search, hide a row, rebuild this system, change view, etc. |
@@ -254,6 +254,7 @@ card.
 | Setting | Does |
 |---|---|
 | Scroll speed | How fast a held direction moves through the list |
+| Left and right | What left and right do while browsing: Speed (the default), Letter, Page or Direction. Direction frees up and down to move a whole row in Tiled |
 | Skip artwork faster than | Above this speed, pictures wait until the list stops |
 | Rebuild all system lists | Read the whole card again. Run it after adding games, cores or artwork; for one system, the contextual menu's **Rebuild this system** is quicker |
 | View | Details, Tiled, List or Carousel |

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ card.
 | Setting | Does |
 |---|---|
 | Scroll speed | How fast a held direction moves through the list |
-| Left and right | What left and right do while browsing: Speed (the default), Letter, Page or Direction. Direction frees up and down to move a whole row in Tiled |
+| Left and right | What left and right do while browsing: Scroll speed change (the default), Letter, Page or Direction. Letter and Page repeat while held; Direction frees up and down to move a whole row in Tiled |
 | Skip artwork faster than | Above this speed, pictures wait until the list stops |
 | Rebuild all system lists | Read the whole card again. Run it after adding games, cores or artwork; for one system, the contextual menu's **Rebuild this system** is quicker |
 | View | Details, Tiled, List or Carousel |

--- a/degauss.toml
+++ b/degauss.toml
@@ -41,6 +41,19 @@ art_limit = 3
 # Which view to open in: details, tiled, list or carousel.
 layout = "details"
 
+# What left and right do while browsing: speed, letter, page or direction.
+#
+# speed changes the scroll speed, exactly as before. letter jumps to the
+# previous or next first letter in the folder. page moves a screenful at a
+# time. direction moves the selection itself, and in the Tiled view frees
+# up and down to move a whole row.
+#
+# Left commented out on purpose: versions of Degauss from before this key
+# existed refuse settings they do not know, so an active line here would
+# stop an older build from starting after a downgrade. Change it from the
+# Options screen instead, which writes it to settings.toml.
+#left_right = "speed"
+
 # Which typeface to set the interface in.
 #
 # smooth is DejaVu Sans, anti-aliased. pixel is Px437 DOS/V re. JPN12, drawn

--- a/deploy/Scripts/.config/degauss/degauss.toml
+++ b/deploy/Scripts/.config/degauss/degauss.toml
@@ -41,6 +41,19 @@ art_limit = 3
 # Which view to open in: details, tiled, list or carousel.
 layout = "details"
 
+# What left and right do while browsing: speed, letter, page or direction.
+#
+# speed changes the scroll speed, exactly as before. letter jumps to the
+# previous or next first letter in the folder. page moves a screenful at a
+# time. direction moves the selection itself, and in the Tiled view frees
+# up and down to move a whole row.
+#
+# Left commented out on purpose: versions of Degauss from before this key
+# existed refuse settings they do not know, so an active line here would
+# stop an older build from starting after a downgrade. Change it from the
+# Options screen instead, which writes it to settings.toml.
+#left_right = "speed"
+
 # Which typeface to set the interface in.
 #
 # smooth is DejaVu Sans, anti-aliased. pixel is Px437 DOS/V re. JPN12, drawn

--- a/src/app.rs
+++ b/src/app.rs
@@ -182,6 +182,85 @@ impl Layout {
     }
 }
 
+/// What left and right do while browsing.
+///
+/// Speed is how Degauss always behaved and stays the default. The other
+/// three exist because the two most reachable directions on the stick were
+/// permanently spent on a value many people set once: in a folder of
+/// twelve thousand games a letter or a page is worth more than a speed
+/// change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Horizontal {
+    /// Step the scroll speed up and down the ladder.
+    #[default]
+    Speed,
+    /// Jump to the previous or next first letter in the list.
+    Letter,
+    /// Move a screenful at a time.
+    Page,
+    /// Move the cursor itself. In the Tiled view this frees up and down to
+    /// move a whole row, which is how a grid wants to be driven.
+    Direction,
+}
+
+impl Horizontal {
+    /// Every mode, in the order the option steps through them.
+    pub const ALL: [Horizontal; 4] = [
+        Horizontal::Speed,
+        Horizontal::Letter,
+        Horizontal::Page,
+        Horizontal::Direction,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Horizontal::Speed => "speed",
+            Horizontal::Letter => "letter",
+            Horizontal::Page => "page",
+            Horizontal::Direction => "direction",
+        }
+    }
+
+    pub fn parse(text: &str) -> Option<Self> {
+        match text {
+            "speed" => Some(Horizontal::Speed),
+            "letter" => Some(Horizontal::Letter),
+            "page" => Some(Horizontal::Page),
+            "direction" => Some(Horizontal::Direction),
+            _ => None,
+        }
+    }
+
+    fn index(self) -> usize {
+        Horizontal::ALL
+            .iter()
+            .position(|&mode| mode == self)
+            .unwrap_or(0)
+    }
+
+    /// The word after the arrows in the wide bottom bar, which must say
+    /// what the keys actually do now that it depends on a setting.
+    fn legend_word(self) -> &'static str {
+        match self {
+            Horizontal::Speed => "Speed",
+            Horizontal::Letter => "Letter",
+            Horizontal::Page => "Page",
+            Horizontal::Direction => "Move",
+        }
+    }
+
+    /// The Help line for the stick's sideways travel, filled into HELP at
+    /// draw time because what it describes depends on this setting.
+    fn help_line(self) -> &'static str {
+        match self {
+            Horizontal::Speed => "Stick left/right: change speed or setting",
+            Horizontal::Letter => "Stick left/right: letter jump or setting",
+            Horizontal::Page => "Stick left/right: page jump or setting",
+            Horizontal::Direction => "Stick left/right: move or change setting",
+        }
+    }
+}
+
 /// How long a title sits still before it starts to walk, and how long the
 /// walk takes. Both are also written into the interface, which does the
 /// animation; these are here to say when to turn it round.
@@ -426,6 +505,59 @@ fn jump_target(entries: &[(char, bool)], key: char) -> Option<usize> {
         .or_else(|| entries.iter().position(|(first, _)| *first > key))
 }
 
+/// Where stepping a letter at a time lands: the first row of the next or
+/// previous run of rows sharing a first letter.
+///
+/// The runs are taken in the order the list shows them, not in an
+/// alphabet: folders sort before files, so the first letters climb twice,
+/// and a step that sorted them would jump between the two climbs. Past
+/// either end the step wraps to the run at the other end, the way a move
+/// from the edge of the list already does.
+///
+/// The caller guarantees a non-empty list and a selection inside it.
+fn letter_target(letters: &[char], selected: usize, delta: isize) -> usize {
+    let current = letters[selected];
+    if delta > 0 {
+        (selected + 1..letters.len())
+            .find(|&at| letters[at] != current)
+            .unwrap_or(0)
+    } else {
+        // Back over the rest of the current run, then over the whole of
+        // the run before it, to land on that run's first row.
+        let mut start = selected;
+        while start > 0 && letters[start - 1] == current {
+            start -= 1;
+        }
+        let end = if start == 0 {
+            letters.len() - 1
+        } else {
+            start - 1
+        };
+        let target = letters[end];
+        let mut at = end;
+        while at > 0 && letters[at - 1] == target {
+            at -= 1;
+        }
+        at
+    }
+}
+
+/// How far one press of up or down moves.
+///
+/// One row everywhere, except in a grid it depends on what left and right
+/// are doing. While they move the cursor sideways, up and down can step a
+/// whole visual row, which is how a grid reads. In every other mode they
+/// step one cover at a time, because left and right are spent on the
+/// setting and a whole-row step would leave the covers beside the
+/// selected one with no key that reaches them.
+fn vertical_step(grid: bool, direction_mode: bool, stride: usize) -> isize {
+    if grid && !direction_mode {
+        1
+    } else {
+        stride as isize
+    }
+}
+
 /// The path inside a row's written-down name.
 ///
 /// The name carries what kind of thing it is, because a folder and a game
@@ -554,6 +686,11 @@ fn menu_entries(browsing: Browsing, system: Option<&str>) -> Vec<String> {
     entries
 }
 
+/// Which HELP row describes the stick's sideways travel. What that row
+/// says depends on the Left and right setting, so it is filled in when
+/// the screen is drawn rather than written into the array.
+const HELP_LR_ROW: usize = 4;
+
 /// Kept to about forty characters a line: the narrowest screen this runs on
 /// is 352 pixels, and anything longer is silently cut off.
 const HELP: [&str; 10] = [
@@ -561,7 +698,8 @@ const HELP: [&str; 10] = [
     "buttons. No keyboard needed.",
     "",
     "Stick up/down: move through the list",
-    "Stick left/right: change speed or setting",
+    // HELP_LR_ROW: replaced at draw time by Horizontal::help_line().
+    "",
     "",
     "A                open a folder, play a game",
     "B                go back, out of a folder",
@@ -824,6 +962,8 @@ pub struct App {
     screen: Screen,
     browsing: Browsing,
     layout: Layout,
+    /// What left and right do while browsing.
+    horizontal: Horizontal,
     geometry: Geometry,
     width: u32,
     height: u32,
@@ -996,6 +1136,12 @@ impl App {
             .and_then(Layout::parse)
             .or_else(|| Layout::parse(&config.app.layout))
             .unwrap_or(Layout::Details);
+        let horizontal = settings
+            .left_right
+            .as_deref()
+            .and_then(Horizontal::parse)
+            .or_else(|| Horizontal::parse(&config.app.left_right))
+            .unwrap_or_default();
         // Margins are saved when changed and read back here. Without this the
         // Options screen would show the saved figure while the screen kept
         // the one from the config file, and the two would disagree.
@@ -1099,6 +1245,7 @@ impl App {
             screen: Screen::Splash,
             browsing: Browsing::Categories,
             layout,
+            horizontal,
             geometry,
             width,
             height,
@@ -1378,6 +1525,14 @@ impl App {
         SPEED_STEPS[self.speed.min(SPEED_STEPS.len() - 1)].1
     }
 
+    /// True while a held left or right should scroll: browsing in the
+    /// Direction setting, where the two keys are movement rather than a
+    /// ladder to step.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    fn horizontal_scrolls(&self) -> bool {
+        self.screen == Screen::Browse && self.horizontal == Horizontal::Direction
+    }
+
     fn shift_x(&self) -> i32 {
         self.settings.shift_x.unwrap_or(0).clamp(-64, 64)
     }
@@ -1409,19 +1564,16 @@ impl App {
         self.dirty = true;
     }
 
-    /// How far up and down move.
-    ///
-    /// One row in a list, and one cover in a grid. A grid is read the way a
-    /// page is: along the row, then down to the start of the next. Moving a
-    /// whole row at a time would leave the covers beside this one with no
-    /// key that reaches them, since left and right are the scroll speed
-    /// here as they are everywhere else.
+    /// How far up and down move. The decision itself lives in
+    /// [`vertical_step`]: whether a grid steps one cover or a whole row
+    /// depends on whether left and right are free to reach the covers
+    /// either side of the selected one.
     fn browse_step(&self) -> isize {
-        if self.screen == Screen::Browse && self.layout.is_grid() {
-            1
-        } else {
-            self.active_list().stride() as isize
-        }
+        vertical_step(
+            self.screen == Screen::Browse && self.layout.is_grid(),
+            self.horizontal == Horizontal::Direction,
+            self.active_list().stride(),
+        )
     }
 
     /// A picture for a group: whichever system lent its logo this time, or
@@ -3028,6 +3180,11 @@ impl App {
                 self.remember_view();
                 self.apply_geometry();
             }
+            OptionId::LeftRight => {
+                let at = step(self.horizontal.index(), delta, Horizontal::ALL.len());
+                self.horizontal = Horizontal::ALL[at];
+                self.settings.left_right = Some(self.horizontal.label().to_string());
+            }
             OptionId::Font => {
                 self.font = self.font.next();
                 self.settings.font = Some(self.font.label().to_string());
@@ -3190,6 +3347,7 @@ impl App {
                 }
             }
             OptionId::Layout => capitalised(self.layout.label()),
+            OptionId::LeftRight => capitalised(self.horizontal.label()),
             OptionId::Font => capitalised(self.font.label()),
             OptionId::ShowArt => on_off(self.show_art),
             OptionId::ShowStats => on_off(self.show_stats),
@@ -3422,6 +3580,45 @@ impl App {
             }
             #[allow(unreachable_patterns)]
             _ => {}
+        }
+    }
+
+    /// Move to the previous or next run of rows sharing a first letter,
+    /// in whatever list is on screen, narrowed or not.
+    fn letter_step(&mut self, delta: isize) {
+        let letters: Vec<char> = match self.browsing {
+            Browsing::Games => self
+                .here
+                .iter()
+                .map(|row| first_letter(&row.sort_key))
+                .collect(),
+            Browsing::Systems => self
+                .systems
+                .iter()
+                .map(|system| first_letter(&system.name().to_lowercase()))
+                .collect(),
+            // The groups are a handful of fixed names; the letter grid
+            // does not offer them either.
+            Browsing::Categories => return,
+        };
+        if letters.is_empty() {
+            return;
+        }
+        let target = letter_target(&letters, self.active_list().selected(), delta);
+        if target != self.active_list().selected() {
+            self.active_list_mut().select(target);
+            self.touch_selection();
+        }
+    }
+
+    /// Move a screenful at a time. From the middle of the list this stops
+    /// at the ends and wraps only from them, which is the edge rule
+    /// [`ListState::move_items`] already applies to every move.
+    fn page_step(&mut self, delta: isize) {
+        let visible = self.active_list().visible() as isize;
+        if self.active_list_mut().move_items(delta * visible) {
+            self.skip_blank_menu(delta);
+            self.touch_selection();
         }
     }
 
@@ -3763,7 +3960,9 @@ impl App {
         // be typed through it and pressing A twice on an unlaunchable game
         // re-raises the message instead of looking stuck. Build progress is
         // the exception: it repaints its own text every frame and the
-        // controls stay live under it.
+        // controls stay live under it. The Left and right modes in the
+        // dispatch below depend on this return coming first: a press that
+        // dismisses a message must not also jump a letter or a page.
         if self.message.is_some() && self.build.is_none() {
             self.message = None;
             self.dirty = true;
@@ -3809,10 +4008,53 @@ impl App {
                 } else if self.screen == Screen::Context {
                     self.adjust_context(delta);
                 } else {
-                    self.speed = step(self.speed, delta, SPEED_STEPS.len());
-                    self.settings.speed_step = Some(self.speed);
-                    self.speed_shown_at = Some(Instant::now());
+                    // The Left and right setting applies only while
+                    // browsing. The other screens that fall through to
+                    // here, Menu, Help, About and the favourite folder
+                    // picker, keep changing the speed as they always have.
+                    let mode = if self.screen == Screen::Browse {
+                        self.horizontal
+                    } else {
+                        Horizontal::Speed
+                    };
+                    match mode {
+                        Horizontal::Speed => {
+                            self.speed = step(self.speed, delta, SPEED_STEPS.len());
+                            self.settings.speed_step = Some(self.speed);
+                            // The badge answers "what speed is it now".
+                            // The other modes move the list, which is its
+                            // own confirmation, so this is the only arm
+                            // that raises it.
+                            self.speed_shown_at = Some(Instant::now());
+                            self.dirty = true;
+                        }
+                        Horizontal::Letter => self.letter_step(delta),
+                        Horizontal::Page => self.page_step(delta),
+                        Horizontal::Direction => {
+                            if self.active_list_mut().move_items(delta) {
+                                self.touch_selection();
+                            }
+                        }
+                    }
+                }
+            }
+            Action::PageUp | Action::PageDown => {
+                // Keyboard only, and always a page whatever Left and right
+                // is set to: two keys named after the movement should not
+                // change meaning under a setting about the stick.
+                let delta = if matches!(action, Action::PageDown) {
+                    1
+                } else {
+                    -1
+                };
+                if self.screen == Screen::Find {
+                    // The letter grid has no pages. One cell is what these
+                    // keys moved when they shared the left and right
+                    // actions, and it stays.
+                    self.find_list.move_items(delta);
                     self.dirty = true;
+                } else {
+                    self.page_step(delta);
                 }
             }
             Action::Home => {
@@ -4261,7 +4503,12 @@ impl App {
             }
             Screen::Help => {
                 for index in range {
-                    rows.push(plain_row(HELP[index], ""));
+                    let line = if index == HELP_LR_ROW {
+                        self.horizontal.help_line()
+                    } else {
+                        HELP[index]
+                    };
+                    rows.push(plain_row(line, ""));
                 }
             }
         }
@@ -4365,6 +4612,10 @@ impl App {
             self.speed_shown_at
                 .is_some_and(|at| at.elapsed() < Duration::from_millis(Self::SPEED_BADGE_MS)),
         );
+        // Only the word travels to the interface; the arrows beside it are
+        // written in the .slint file so their glyphs get embedded.
+        self.ui
+            .set_lr_word(SharedString::from(self.horizontal.legend_word()));
 
         let list = self.active_list();
         let (heading, status) = match self.screen {
@@ -4481,6 +4732,13 @@ impl App {
 
             slint::platform::update_timers_and_animations();
 
+            // A held left or right scrolls only where it moves the cursor:
+            // while browsing in the Direction setting. Everywhere else,
+            // and in every other setting, one press stays one step. Decided
+            // before the presses so the first press of a hold is retained,
+            // and again before the repeats so a screen opened under a held
+            // stick stops the repeat instead of taking one more step there.
+            repeater.set_horizontal_repeats(self.horizontal_scrolls());
             for edge in input.poll() {
                 let action = match edge {
                     KeyEdge::Down(action) => repeater.press(action, now),
@@ -4496,6 +4754,7 @@ impl App {
                     }
                 }
             }
+            repeater.set_horizontal_repeats(self.horizontal_scrolls());
             for action in repeater.tick(now) {
                 if let Some(outcome) = self.handle(action) {
                     self.save_settings();
@@ -5138,6 +5397,101 @@ mod tests {
         for one in all {
             assert_eq!(Layout::parse(one.label()), Some(one));
         }
+    }
+
+    #[test]
+    fn every_left_right_mode_is_reachable_and_round_trips() {
+        // The option only ever steps through ALL, so a mode missing from
+        // it could never be chosen, and a label that does not parse back
+        // would silently reset the setting on the next start.
+        for (at, mode) in Horizontal::ALL.iter().copied().enumerate() {
+            assert_eq!(mode.index(), at);
+            assert_eq!(Horizontal::parse(mode.label()), Some(mode));
+        }
+        assert_eq!(Horizontal::parse("nonsense"), None);
+        assert_eq!(
+            Horizontal::default(),
+            Horizontal::Speed,
+            "nothing may change for anyone who does not go looking"
+        );
+    }
+
+    #[test]
+    fn the_stick_line_of_the_help_fits_every_mode() {
+        for mode in Horizontal::ALL {
+            let line = mode.help_line();
+            assert!(
+                line.starts_with("Stick left/right:"),
+                "the line must still say which control it explains: {line:?}"
+            );
+            // The narrowest screen this runs on is 352 pixels wide.
+            assert!(line.len() <= 46, "too long to fit: {line:?}");
+        }
+        assert_eq!(
+            HELP[HELP_LR_ROW], "",
+            "the row is filled in at draw time, not written twice"
+        );
+    }
+
+    #[test]
+    fn a_letter_step_lands_on_the_start_of_the_next_run() {
+        let letters = ['a', 'a', 'b', 'b', 'c'];
+        assert_eq!(letter_target(&letters, 0, 1), 2);
+        assert_eq!(letter_target(&letters, 1, 1), 2, "from inside a run too");
+        assert_eq!(letter_target(&letters, 2, 1), 4);
+    }
+
+    #[test]
+    fn a_letter_step_back_lands_on_the_start_of_the_previous_run() {
+        let letters = ['a', 'a', 'b', 'b', 'c'];
+        assert_eq!(letter_target(&letters, 4, -1), 2);
+        assert_eq!(
+            letter_target(&letters, 3, -1),
+            0,
+            "back from inside a run skips over its own start"
+        );
+        assert_eq!(letter_target(&letters, 2, -1), 0);
+    }
+
+    #[test]
+    fn a_letter_step_wraps_at_either_end_of_the_list() {
+        // The stick has no way to say "start again"; standing at an end
+        // and pressing on is unambiguous, like a move from the list edge.
+        let letters = ['a', 'b', 'b', 'c', 'c'];
+        assert_eq!(letter_target(&letters, 3, 1), 0);
+        assert_eq!(letter_target(&letters, 4, 1), 0);
+        assert_eq!(letter_target(&letters, 0, -1), 3);
+    }
+
+    #[test]
+    fn a_letter_step_follows_the_list_even_where_letters_climb_twice() {
+        // Folders sort before files, so first letters climb through the
+        // folders and again through the files. The step walks the list as
+        // it stands on screen rather than a merged alphabet.
+        let letters = ['a', 'c', 'a', 'b'];
+        assert_eq!(letter_target(&letters, 1, 1), 2);
+        assert_eq!(letter_target(&letters, 2, -1), 1);
+    }
+
+    #[test]
+    fn a_list_of_one_letter_steps_to_its_start_rather_than_spinning() {
+        let letters = ['m', 'm', 'm'];
+        assert_eq!(letter_target(&letters, 2, 1), 0);
+        assert_eq!(letter_target(&letters, 0, -1), 0);
+        assert_eq!(letter_target(&['x'], 0, 1), 0);
+    }
+
+    #[test]
+    fn a_grid_steps_one_cover_until_the_sideways_keys_are_free() {
+        // In every mode but Direction, left and right are spent on the
+        // setting, so a whole-row step would leave the covers beside the
+        // selected one unreachable. Direction frees them, and the grid
+        // can be driven the way a grid reads.
+        assert_eq!(vertical_step(true, false, 5), 1);
+        assert_eq!(vertical_step(true, true, 5), 5);
+        // A plain list moves a row at a time whatever the setting says.
+        assert_eq!(vertical_step(false, false, 1), 1);
+        assert_eq!(vertical_step(false, true, 1), 1);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -221,6 +221,18 @@ impl Horizontal {
         }
     }
 
+    /// The name the Options row shows. Separate from `label`, which is
+    /// the token settings.toml stores: the stored word must never change,
+    /// or a written-down choice stops meaning anything on the next start.
+    pub fn shown(self) -> &'static str {
+        match self {
+            Horizontal::Speed => "Scroll speed change",
+            Horizontal::Letter => "Letter",
+            Horizontal::Page => "Page",
+            Horizontal::Direction => "Direction",
+        }
+    }
+
     pub fn parse(text: &str) -> Option<Self> {
         match text {
             "speed" => Some(Horizontal::Speed),
@@ -1525,12 +1537,14 @@ impl App {
         SPEED_STEPS[self.speed.min(SPEED_STEPS.len() - 1)].1
     }
 
-    /// True while a held left or right should scroll: browsing in the
-    /// Direction setting, where the two keys are movement rather than a
-    /// ladder to step.
+    /// True while a held left or right should repeat: browsing in every
+    /// setting except the speed ladder. Direction scrolls like a held
+    /// stick, and a held Letter or Page walks on at the same cadence;
+    /// only the ladder stays one step per press, because a held repeat
+    /// would run the whole ladder off one touch.
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     fn horizontal_scrolls(&self) -> bool {
-        self.screen == Screen::Browse && self.horizontal == Horizontal::Direction
+        self.screen == Screen::Browse && self.horizontal != Horizontal::Speed
     }
 
     fn shift_x(&self) -> i32 {
@@ -3347,7 +3361,7 @@ impl App {
                 }
             }
             OptionId::Layout => capitalised(self.layout.label()),
-            OptionId::LeftRight => capitalised(self.horizontal.label()),
+            OptionId::LeftRight => self.horizontal.shown().to_string(),
             OptionId::Font => capitalised(self.font.label()),
             OptionId::ShowArt => on_off(self.show_art),
             OptionId::ShowStats => on_off(self.show_stats),

--- a/src/app.rs
+++ b/src/app.rs
@@ -5335,6 +5335,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn the_config_accepts_exactly_the_left_right_modes_that_exist() {
+        // The config validates left_right against its own word list, so
+        // that list and the interface's modes must never drift apart: a
+        // mode the config refused could not be written down, and a word
+        // the interface ignores would pass validation and mean nothing.
+        assert_eq!(
+            crate::config::LEFT_RIGHT_VALUES.len(),
+            Horizontal::ALL.len()
+        );
+        for mode in Horizontal::ALL {
+            assert!(
+                crate::config::LEFT_RIGHT_VALUES.contains(&mode.label()),
+                "{} is not in the config's list",
+                mode.label()
+            );
+            assert!(Horizontal::parse(mode.label()).is_some());
+        }
+    }
+
+    #[test]
     fn a_setting_cycles_round_its_choices() {
         // Left and right are the only controls a setting has. One that
         // stopped at its last choice could be walked one way and never

--- a/src/config.rs
+++ b/src/config.rs
@@ -224,6 +224,16 @@ pub struct AppSettings {
     /// Which view to open in: "details", "tiled", "list" or "carousel".
     #[serde(default = "default_layout")]
     pub layout: String,
+    /// What left and right do while browsing: "speed", "letter", "page" or
+    /// "direction".
+    ///
+    /// The shipped degauss.toml documents this key as a commented line
+    /// rather than an active one: `[app]` rejects keys it does not know,
+    /// so an active key that older versions never heard of would stop
+    /// them from starting after a downgrade. The live value is written to
+    /// settings.toml by the Options screen, which tolerates unknown keys.
+    #[serde(default = "default_left_right")]
+    pub left_right: String,
     /// Which typeface to set the interface in: "smooth" or "pixel".
     #[serde(default = "default_font")]
     pub font: String,
@@ -242,6 +252,10 @@ pub struct AppSettings {
 
 fn default_layout() -> String {
     "details".to_string()
+}
+
+fn default_left_right() -> String {
+    "speed".to_string()
 }
 
 fn default_font() -> String {
@@ -361,6 +375,7 @@ favorite = "#fe2e1d"
         assert_eq!(config.colors.accent, Color::new(0xff, 0xcd, 0x09));
         assert_eq!(config.app.cover_size, 160, "defaults fill in");
         assert_eq!(config.app.layout, "details");
+        assert_eq!(config.app.left_right, "speed");
         assert_eq!(config.app.font, "smooth");
         assert!(
             config.game_roots.iter().any(|r| r == "/media/fat/games"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -318,13 +318,41 @@ impl Config {
     pub fn parse(text: &str, origin: &Path) -> Result<Self> {
         let config: Config = toml::from_str(text)
             .map_err(|e| DegaussError::malformed("config", origin, e.to_string()))?;
+        // Validated like the colours: a value nothing answers to would
+        // otherwise silently mean the default, which reads as the
+        // setting not working.
+        if !LEFT_RIGHT_VALUES.contains(&config.app.left_right.as_str()) {
+            return Err(DegaussError::malformed(
+                "config",
+                origin,
+                format!(
+                    "left_right {:?}: the choices are speed, letter, page and direction",
+                    config.app.left_right
+                ),
+            ));
+        }
         Ok(config)
     }
 }
 
+/// The words `left_right` accepts, the config-side twin of the modes the
+/// interface steps through; a test in app.rs holds the two together.
+pub const LEFT_RIGHT_VALUES: [&str; 4] = ["speed", "letter", "page", "direction"];
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_left_right_value_nothing_answers_to_is_refused_by_name() {
+        // Silently meaning the default would read as the setting not
+        // working; the refusal names the word and the choices.
+        let err = Config::parse("[app]\nleft_right = \"leftr\"\n", Path::new("t"))
+            .expect_err("a typo'd mode must not parse");
+        let text = format!("{err}");
+        assert!(text.contains("leftr"), "got: {text}");
+        assert!(text.contains("letter"), "the choices are named: {text}");
+    }
 
     #[test]
     fn a_config_from_every_release_that_used_the_old_folder_still_parses() {

--- a/src/input.rs
+++ b/src/input.rs
@@ -43,6 +43,11 @@ pub enum Action {
     /// matters, because the question is how fast the list can move before it
     /// stops looking smooth.
     Faster,
+    /// A screenful back. Keyboard only, and always a page whatever the
+    /// Left and right setting makes of the stick.
+    PageUp,
+    /// A screenful on.
+    PageDown,
     Home,
     End,
     /// Launch the selected entry.
@@ -60,9 +65,11 @@ pub enum Action {
 }
 
 impl Action {
-    /// Whether holding the key should repeat. Only movement repeats:
+    /// Whether holding the key always repeats. Only movement repeats:
     /// repeating "launch" would be dangerous, and repeating a speed change
-    /// would run the whole ladder off one press.
+    /// would run the whole ladder off one press. Left and right join in
+    /// only through the [`Repeater`]'s own flag, while the Direction
+    /// setting turns them into movement too.
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     fn repeats(self) -> bool {
         matches!(self, Action::Up | Action::Down)
@@ -124,6 +131,11 @@ struct Held {
 pub struct Repeater {
     config: RepeatConfig,
     held: Vec<Held>,
+    /// Whether holding left or right repeats. In the Direction setting
+    /// they move the cursor, and a held stick should scroll the way a held
+    /// up or down does. In every other setting they step a ladder or a
+    /// choice, where one press must mean one step.
+    horizontal_repeats: bool,
 }
 
 impl Repeater {
@@ -131,6 +143,21 @@ impl Repeater {
         Repeater {
             config,
             held: Vec::new(),
+            horizontal_repeats: false,
+        }
+    }
+
+    /// Turn held-key repeat for left and right on or off. Turning it off
+    /// also drops either of them if it is held right now, so a key pressed
+    /// while browsing cannot keep firing into a screen opened under it.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub fn set_horizontal_repeats(&mut self, enabled: bool) {
+        if self.horizontal_repeats == enabled {
+            return;
+        }
+        self.horizontal_repeats = enabled;
+        if !enabled {
+            self.held.retain(|held| held.action.repeats());
         }
     }
 
@@ -152,7 +179,9 @@ impl Repeater {
         if self.held.iter().any(|h| h.action == action) {
             return None;
         }
-        if action.repeats() {
+        let repeats = action.repeats()
+            || (self.horizontal_repeats && matches!(action, Action::Slower | Action::Faster));
+        if repeats {
             self.held.push(Held {
                 action,
                 pressed_at: now,
@@ -219,11 +248,14 @@ pub fn action_for_key(code: u16) -> Option<Action> {
     Some(match code {
         KEY_UP => Action::Up,
         KEY_DOWN => Action::Down,
-        // Left and right change the SCROLL SPEED rather than jumping a
-        // page. Paging is not what is being tested: the question is how
-        // fast a continuous scroll can run and still look smooth.
-        KEY_LEFT | KEY_PAGEUP => Action::Slower,
-        KEY_RIGHT | KEY_PAGEDOWN => Action::Faster,
+        // Left and right change the scroll speed unless the Left and right
+        // setting says otherwise. PageUp and PageDown are their own
+        // actions rather than aliases of these, so a keyboard keeps two
+        // keys that always page whatever the stick is set to do.
+        KEY_LEFT => Action::Slower,
+        KEY_RIGHT => Action::Faster,
+        KEY_PAGEUP => Action::PageUp,
+        KEY_PAGEDOWN => Action::PageDown,
         KEY_HOME => Action::Home,
         KEY_END => Action::End,
         KEY_ENTER | KEY_KPENTER => Action::Accept,
@@ -697,6 +729,16 @@ mod tests {
         assert_eq!(action_for_key(108), Some(Action::Down));
         assert_eq!(action_for_key(105), Some(Action::Slower));
         assert_eq!(action_for_key(106), Some(Action::Faster));
+        assert_eq!(
+            action_for_key(104),
+            Some(Action::PageUp),
+            "PageUp pages on its own, not as an alias of left"
+        );
+        assert_eq!(
+            action_for_key(109),
+            Some(Action::PageDown),
+            "PageDown pages on its own, not as an alias of right"
+        );
         assert_eq!(action_for_key(28), Some(Action::Accept));
         assert_eq!(action_for_key(1), Some(Action::Quit));
         assert_eq!(
@@ -771,6 +813,46 @@ mod tests {
         let t0 = Instant::now();
         assert_eq!(repeater.press(Action::Faster, t0), Some(Action::Faster));
         assert!(repeater.tick(t0 + Duration::from_secs(1)).is_empty());
+    }
+
+    #[test]
+    fn left_and_right_repeat_while_held_only_when_they_move_the_cursor() {
+        // In the Direction setting a held left or right is a scroll, and
+        // must repeat the way a held up or down does.
+        let mut repeater = Repeater::new(RepeatConfig {
+            delay: Duration::from_millis(10),
+            interval: Duration::from_millis(10),
+        });
+        let t0 = Instant::now();
+        repeater.set_horizontal_repeats(true);
+        assert_eq!(repeater.press(Action::Faster, t0), Some(Action::Faster));
+        assert_eq!(
+            repeater.tick(t0 + Duration::from_millis(10)),
+            vec![Action::Faster],
+            "a held right must keep scrolling"
+        );
+        repeater.release(Action::Faster);
+        assert!(repeater.tick(t0 + Duration::from_secs(1)).is_empty());
+    }
+
+    #[test]
+    fn turning_horizontal_repeat_off_drops_a_left_or_right_still_held() {
+        // Leaving the browse screen with the stick held must not keep
+        // firing speed changes into whatever screen opened under it.
+        let mut repeater = Repeater::new(RepeatConfig {
+            delay: Duration::from_millis(10),
+            interval: Duration::from_millis(10),
+        });
+        let t0 = Instant::now();
+        repeater.set_horizontal_repeats(true);
+        repeater.press(Action::Slower, t0);
+        repeater.press(Action::Down, t0);
+        repeater.set_horizontal_repeats(false);
+        assert_eq!(
+            repeater.tick(t0 + Duration::from_millis(10)),
+            vec![Action::Down],
+            "only the key that always repeats may keep firing"
+        );
     }
 
     #[test]

--- a/src/list_state.rs
+++ b/src/list_state.rs
@@ -33,7 +33,6 @@ impl ListState {
         self.selected = index.min(self.count.saturating_sub(1));
     }
 
-    #[allow(dead_code)]
     pub fn visible(&self) -> usize {
         self.visible
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -14,6 +14,9 @@ use crate::input::SPEED_STEPS;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OptionId {
     Speed,
+    /// What left and right do while browsing: speed, letter, page or
+    /// direction.
+    LeftRight,
     /// The scroll speed above which artwork stops being loaded per row.
     ArtLimit,
     Layout,
@@ -51,8 +54,9 @@ pub enum OptionId {
 }
 
 /// What most people will ever want to change.
-pub const OPTIONS: [OptionId; 16] = [
+pub const OPTIONS: [OptionId; 17] = [
     OptionId::Speed,
+    OptionId::LeftRight,
     OptionId::ArtLimit,
     OptionId::RebuildCache,
     OptionId::Layout,
@@ -86,6 +90,7 @@ impl OptionId {
     pub fn label(self) -> &'static str {
         match self {
             OptionId::Speed => "Scroll speed",
+            OptionId::LeftRight => "Left and right",
             OptionId::ArtLimit => "Skip artwork faster than",
             OptionId::Layout => "View",
             OptionId::Font => "Text",
@@ -116,6 +121,9 @@ impl OptionId {
     pub fn help(self) -> &'static str {
         match self {
             OptionId::Speed => "How fast a held direction moves through the list.",
+            OptionId::LeftRight => {
+                "What left and right do in a folder. Direction lets up and down move a whole row in Tiled."
+            }
             OptionId::ArtLimit => {
                 "Above this scroll speed, pictures wait until the list stops moving."
             }
@@ -206,10 +214,12 @@ mod tests {
         // Options nobody uses push out the ones people do. Anything that
         // exists for measurement belongs behind Advanced.
         //
-        // Ten rows fit on screen, so the list already scrolls. Anything
-        // further belongs behind Advanced.
+        // Ten rows fit on screen, so the list already scrolls. The cap was
+        // moved from 16 to 17 deliberately when Left and right arrived: a
+        // browse control belongs beside Scroll speed, not behind Advanced.
+        // The next addition should go behind Advanced instead.
         assert!(
-            OPTIONS.len() <= 16,
+            OPTIONS.len() <= 17,
             "the main options list has grown to {}",
             OPTIONS.len()
         );

--- a/src/options.rs
+++ b/src/options.rs
@@ -56,8 +56,8 @@ pub enum OptionId {
 /// What most people will ever want to change.
 pub const OPTIONS: [OptionId; 17] = [
     OptionId::Speed,
-    OptionId::LeftRight,
     OptionId::ArtLimit,
+    OptionId::LeftRight,
     OptionId::RebuildCache,
     OptionId::Layout,
     OptionId::Font,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -26,6 +26,11 @@ pub struct Settings {
     /// into the speed ladder.
     pub art_limit: Option<usize>,
     pub layout: Option<String>,
+    /// What left and right do while browsing: "speed", "letter", "page"
+    /// or "direction". Absent means speed, which is how Degauss always
+    /// behaved.
+    #[serde(default)]
+    pub left_right: Option<String>,
     /// Which typeface the interface is set in. Absent means whatever the
     /// shipped configuration says.
     #[serde(default)]
@@ -139,6 +144,7 @@ mod tests {
             hidden: vec!["PSX".to_string()],
             art_limit: Some(0),
             layout: Some("covers".into()),
+            left_right: Some("letter".into()),
             show_stats: Some(true),
             overscan_x: Some(24),
             ..Default::default()

--- a/ui/degauss.slint
+++ b/ui/degauss.slint
@@ -236,6 +236,10 @@ export component DegaussWindow inherits Window {
     /// Shown for a moment after it changes, then gone again.
     in property <string> speed-badge;
     in property <bool> speed-visible;
+    /// The word after the arrows in the wide legend: what left and right
+    /// do while browsing. Only the word comes from Rust; the arrows must
+    /// stay written in this file or their glyphs are never embedded.
+    in property <string> lr-word: "Speed";
     in property <bool> wide-bar;
     in property <bool> show-bar;
     /// True on the master list, which is short enough to look stranded
@@ -719,7 +723,9 @@ export component DegaussWindow inherits Window {
             // One literal per form, because the glyphs that end up in the
             // binary are the ones the compiler finds written here. A string
             // built in Rust can ask for an arrow that was never embedded,
-            // and a missing glyph draws nothing at all.
+            // and a missing glyph draws nothing at all. The word spliced in
+            // after the arrows is safe: it is plain ASCII, which every
+            // other literal already embeds.
             Text {
                 text: root.show-stats
                     ? root.stats
@@ -732,7 +738,7 @@ export component DegaussWindow inherits Window {
                             ? "\u{2191}\u{2193} Choose   \u{2190}\u{2192} Change   A Select   B Back"
                             : "\u{2190}\u{2192} Change  A Select  B Back")
                         : (root.wide-bar
-                            ? "\u{2191}\u{2193} Choose   \u{2190}\u{2192} Speed   A Select   B Back   X This folder   Y Menu"
+                            ? "\u{2191}\u{2193} Choose   \u{2190}\u{2192} " + root.lr-word + "   A Select   B Back   X This folder   Y Menu"
                             : "A Select  B Back  X Folder  Y Menu");
                 color: root.show-stats ? root.c-state : root.c-text-dim;
                 font-size: root.bar-glyph;


### PR DESCRIPTION
Fixes #4: Option to change left/right behaviour.

## What this changes

A new **Left and right** row in Options decides what the two buttons do
while browsing games: **speed** (scroll speed, exactly as before, the
default), **letter** (previous or next first letter in the folder),
**page** (a screenful at a time), or **direction** (move the selection
itself; in the Tiled view this frees up and down to move a whole row).
Live from Options, kept in `settings.toml`.

- Letter and Page repeat while the key is held, at the same cadence a
  held up or down uses; only the speed ladder stays one step per press,
  where a held repeat would run the whole ladder off one touch.
- The row sits below Skip artwork faster than, and its default value
  shows as Scroll speed change; the token settings.toml stores is
  unchanged, so a written-down choice keeps meaning the same thing.
- PgUp and PgDn now page on every screen, not only while browsing games.
  The Find grid moves by one cell instead, its rows not being pages.
  Before this they did nothing off the games list.
- A press that dismisses a message is consumed by the dismissal and does
  not also jump: dismissing must never move the list underneath the
  message.
- `degauss.toml` documents the key commented out on purpose: versions
  from before this key refuse settings they do not know, so an active
  line would stop an older build from starting after a downgrade. The
  Options screen is the way to set it.

## Why

Left and right were fixed on scroll speed. On a folder of thousands the
speed is set once and the two best-placed buttons on the pad then do
nothing; a letter jump or a page at a time is what that walk actually
needs, and which one is a matter of taste, so it is a setting.

## How it was checked

- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --target armv7-unknown-linux-musleabihf --all-targets -- -D warnings`
- [x] Run on a real MiSTer
- [x] On a CRT, if it changes anything drawn

## Licensing

By opening this pull request I agree that my contribution is licensed under
the [PolyForm Noncommercial License 1.0.0](../LICENSE), the same licence as
the rest of Degauss, and that I have the right to license it that way.

Changes to `MiSTer_Degauss` do not belong here: it is a separate GPLv3
program in its own repository,
[Degauss-Main](https://github.com/giancarloerra/Degauss-Main).

- [x] I agree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable left/right browsing modes: speed, letter jumps, page jumps, and directional movement.
  - Added a **Left and right** setting in Options, with the selected behaviour shown in help and navigation hints.
  - Added dedicated Page Up and Page Down actions.
  - Directional mode supports horizontal movement and row-by-row navigation in tiled views.

- **Bug Fixes**
  - Preserved speed behaviour as the default when no preference is configured.
  - Improved horizontal key-repeat handling for each browsing mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->