### PR TITLE
Find games where MiSTer finds them: USB, network, CIFS, card

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ Its source is at
 To remove Degauss, delete the `main=` line and the files above. Nothing
 else on the card is touched.
 
+### External storage
+
+Games on a USB stick, the network share or the CIFS mount are found
+without any setup, in the order MiSTer's own loader searches:
+`/media/usb0` to `usb5`, then `/media/network`, then `/media/fat/cifs`,
+then the card, each under its `games` folder. For each system folder the
+first place that has it wins, so a system kept on both the stick and the
+card browses from the stick, exactly as the stock menu would load it.
+Different folders of one system may resolve in different places.
+
+Two things to know. Storage is looked for when Degauss starts, so plug
+the stick in first (or restart after); and moving a system between
+storages changes its paths, so its listing is stale until **Rebuild this
+system** or a full rebuild. A layout the defaults do not cover is one
+`game_roots` edit in `degauss.toml` away.
+
 The first run reads the card and writes an index, about a minute for a
 full one of 97k+ games. It never does that again on its own: **Options → Rebuild all system lists**
 is how you tell it the card has changed (for example after adding new games). New images and metadata are read on the fly.

--- a/degauss.toml
+++ b/degauss.toml
@@ -9,10 +9,25 @@
 # systems.toml. That file is generated from public community data and is
 # yours to edit.
 
-# Where to look for games. The first root that has a system's folder wins.
-# /media/fat is listed too because Arcade lives at /media/fat/_Arcade
-# rather than under games.
-game_roots = ["/media/fat/games", "/media/fat"]
+# Where to look for games, in the order MiSTer's own loader searches:
+# USB sticks first, then the network share, then the CIFS mount, then the
+# card. For each folder name the first root that has it wins; a root that
+# is not mounted is skipped. /media/fat is listed too because Arcade lives
+# at /media/fat/_Arcade rather than under games. Storage must be mounted
+# before Degauss starts: what appears later is picked up on the next
+# start, or by Rebuild this system.
+game_roots = [
+    "/media/usb0/games",
+    "/media/usb1/games",
+    "/media/usb2/games",
+    "/media/usb3/games",
+    "/media/usb4/games",
+    "/media/usb5/games",
+    "/media/network/games",
+    "/media/fat/cifs/games",
+    "/media/fat/games",
+    "/media/fat",
+]
 
 # The top of the card, where the _-prefixed menu folders live. Read once at
 # startup to find which group each installed core belongs to, so systems are

--- a/deploy/Scripts/.config/degauss/degauss.toml
+++ b/deploy/Scripts/.config/degauss/degauss.toml
@@ -9,10 +9,25 @@
 # systems.toml. That file is generated from public community data and is
 # yours to edit.
 
-# Where to look for games. The first root that has a system's folder wins.
-# /media/fat is listed too because Arcade lives at /media/fat/_Arcade
-# rather than under games.
-game_roots = ["/media/fat/games", "/media/fat"]
+# Where to look for games, in the order MiSTer's own loader searches:
+# USB sticks first, then the network share, then the CIFS mount, then the
+# card. For each folder name the first root that has it wins; a root that
+# is not mounted is skipped. /media/fat is listed too because Arcade lives
+# at /media/fat/_Arcade rather than under games. Storage must be mounted
+# before Degauss starts: what appears later is picked up on the next
+# start, or by Rebuild this system.
+game_roots = [
+    "/media/usb0/games",
+    "/media/usb1/games",
+    "/media/usb2/games",
+    "/media/usb3/games",
+    "/media/usb4/games",
+    "/media/usb5/games",
+    "/media/network/games",
+    "/media/fat/cifs/games",
+    "/media/fat/games",
+    "/media/fat",
+]
 
 # The top of the card, where the _-prefixed menu folders live. Read once at
 # startup to find which group each installed core belongs to, so systems are

--- a/src/config.rs
+++ b/src/config.rs
@@ -301,11 +301,17 @@ fn default_menu_root() -> String {
 }
 
 fn default_roots() -> Vec<String> {
-    vec![
-        "/media/fat/games".to_string(),
-        // Arcade lives at /media/fat/_Arcade, outside the games folder.
-        "/media/fat".to_string(),
-    ]
+    // The order MiSTer's own core loader searches (findPrefixDir in
+    // Main's file_io.cpp): USB sticks first, then the network share, then
+    // the CIFS mount, then the card. A root that is not mounted costs one
+    // failed stat and nothing else.
+    let mut roots: Vec<String> = (0..6).map(|n| format!("/media/usb{n}/games")).collect();
+    roots.push("/media/network/games".to_string());
+    roots.push("/media/fat/cifs/games".to_string());
+    roots.push("/media/fat/games".to_string());
+    // Arcade lives at /media/fat/_Arcade, outside the games folder.
+    roots.push("/media/fat".to_string());
+    roots
 }
 
 impl Config {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -394,25 +394,34 @@ fn core_name(stem: &str) -> String {
         .collect()
 }
 
-/// Every folder of this system's that exists, in the order the table lists
-/// them, without duplicates.
+/// Where each of a system's configured folders is, right now.
 ///
-/// All of them, not just the first: a system's games are routinely spread
-/// across the folders it names, and stopping at the first one loses whatever
-/// is in the rest.
-/// Which of a system's configured folders are on the card right now.
+/// Every folder NAME the table lists is looked for, because a system's
+/// games are routinely spread across its aliases (MegaDrive and Genesis
+/// both). For one name, the FIRST root that has it wins and the rest are
+/// not consulted: that is the priority MiSTer's own loader applies, and
+/// it is what the configuration has always promised. Different names may
+/// resolve under different roots.
 ///
 /// `discover` asks this for every system; the single-system rebuild asks
 /// it again for one, because a folder can appear or go after discovery.
 pub fn existing_folders(def: &SystemDef, roots: &[PathBuf]) -> Vec<PathBuf> {
+    // Unmounted roots are dropped before the folder walk, so a missing
+    // mount costs one failed stat per system rather than one per folder
+    // name: with six USB slots in the defaults, most of this list does
+    // not exist on most machines.
+    let live: Vec<&PathBuf> = roots.iter().filter(|root| root.is_dir()).collect();
     let mut found: Vec<PathBuf> = Vec::new();
     for folder in &def.folders {
-        for root in roots {
+        for root in &live {
             // An absolute folder in the table stands on its own; joining
             // replaces the root, which is what we want.
             let candidate = root.join(folder);
-            if candidate.is_dir() && !found.contains(&candidate) {
-                found.push(candidate);
+            if candidate.is_dir() {
+                if !found.contains(&candidate) {
+                    found.push(candidate);
+                }
+                break;
             }
         }
     }
@@ -467,6 +476,102 @@ folders = ["MegaDrive", "Genesis"]
 rbf = "_Console/MegaDrive"
 extensions = ["md", "bin"]
 "#;
+
+    fn one_system(folders: &[&str]) -> SystemDef {
+        SystemDef {
+            name: "Test".into(),
+            id: "Test".into(),
+            folders: folders.iter().map(|f| f.to_string()).collect(),
+            rbf: "_Console/Test".into(),
+            extensions: vec!["bin".into()],
+            launch: Vec::new(),
+            logo: None,
+            category: None,
+            skip_folders: Vec::new(),
+            setname: None,
+        }
+    }
+
+    #[test]
+    fn the_first_root_holding_a_folder_wins_over_the_later_ones() {
+        // MiSTer's own loader searches the USB sticks before the card, so
+        // a system present on both is the USB one. Collecting both
+        // instead showed one list stitched from two places, and
+        // contradicted what the configuration promises.
+        let base = temp_dir("root-priority");
+        std::fs::create_dir_all(base.join("usb0/games/SNES")).unwrap();
+        std::fs::create_dir_all(base.join("fat/games/SNES")).unwrap();
+        let roots = [base.join("usb0/games"), base.join("fat/games")];
+        let found = existing_folders(&one_system(&["SNES"]), &roots);
+        assert_eq!(found, vec![base.join("usb0/games/SNES")]);
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn a_folder_the_earlier_roots_lack_falls_back_to_the_card() {
+        let base = temp_dir("root-fallback");
+        std::fs::create_dir_all(base.join("usb0/games")).unwrap();
+        std::fs::create_dir_all(base.join("fat/games/SNES")).unwrap();
+        let roots = [base.join("usb0/games"), base.join("fat/games")];
+        let found = existing_folders(&one_system(&["SNES"]), &roots);
+        assert_eq!(found, vec![base.join("fat/games/SNES")]);
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn each_folder_alias_resolves_on_its_own_root() {
+        // Priority is per NAME, not per system: a card keeping MegaDrive
+        // on the stick and Genesis on the card still browses both. This
+        // is the Atari 2600 lesson in root form: games are routinely
+        // spread across a system's aliases.
+        let base = temp_dir("root-aliases");
+        std::fs::create_dir_all(base.join("usb0/games/MegaDrive")).unwrap();
+        std::fs::create_dir_all(base.join("fat/games/Genesis")).unwrap();
+        let roots = [base.join("usb0/games"), base.join("fat/games")];
+        let found = existing_folders(&one_system(&["MegaDrive", "Genesis"]), &roots);
+        assert_eq!(
+            found,
+            vec![
+                base.join("usb0/games/MegaDrive"),
+                base.join("fat/games/Genesis")
+            ]
+        );
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn roots_that_are_not_mounted_are_quietly_ignored() {
+        // Six USB slots sit in the defaults and most machines have none
+        // of them: an absent mount must cost nothing and change nothing.
+        let base = temp_dir("root-unmounted");
+        std::fs::create_dir_all(base.join("fat/games/SNES")).unwrap();
+        let roots = [
+            base.join("usb0/games"),
+            base.join("usb1/games"),
+            base.join("network/games"),
+            base.join("fat/games"),
+        ];
+        let found = existing_folders(&one_system(&["SNES"]), &roots);
+        assert_eq!(found, vec![base.join("fat/games/SNES")]);
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_folder_reached_through_a_symlink_still_counts() {
+        // Cards really do this: a folder on the stick linked under the
+        // card's own games folder. The link answers as a directory and
+        // must keep doing so.
+        let base = temp_dir("root-symlink");
+        std::fs::create_dir_all(base.join("elsewhere/SNES")).unwrap();
+        std::fs::create_dir_all(base.join("fat/games")).unwrap();
+        std::os::unix::fs::symlink(base.join("elsewhere/SNES"), base.join("fat/games/SNES"))
+            .unwrap();
+        let roots = [base.join("fat/games")];
+        let found = existing_folders(&one_system(&["SNES"]), &roots);
+        assert_eq!(found, vec![base.join("fat/games/SNES")]);
+        std::fs::remove_dir_all(&base).ok();
+    }
 
     fn temp_dir(tag: &str) -> PathBuf {
         let dir =


### PR DESCRIPTION
Closes no issue: this came out of reviewing what a card with games on a
USB stick sees, which was nothing.

## What this changes

Systems on external storage are discovered without any setup. The
default `game_roots` now walk the exact order MiSTer's own loader
searches (`findPrefixDir` in Main's `file_io.cpp`): `/media/usb0..5/
games`, `/media/network/games`, `/media/fat/cifs/games`,
`/media/fat/games`, and `/media/fat` for Arcade.

And the promise the configuration always made is now kept: for each
folder name the FIRST root that has it wins, instead of stitching one
listing from every root that matched. A system on both the stick and
the card browses from the stick, exactly as the stock menu would load
it. Folder aliases still resolve independently, each on its own root:
MegaDrive on the stick and Genesis on the card still browse as one
system.

- Unmounted roots cost one failed stat each and are skipped; an SD-only
  card resolves exactly as before, pinned by test.
- Behaviour change for a card keeping the same folder in two places: it
  used to show both stitched together, it now shows the higher-priority
  one, which is what MiSTer itself loads.
- Storage is found when Degauss starts: plug in first, or restart. A
  system moved between storages changes its paths, so its listing is
  stale until Rebuild this system or a full rebuild. The readme says
  both, in an External storage section.
- A layout the defaults do not cover remains one `game_roots` edit away;
  the format and the user's ordering are untouched.

## Why

MiSTer supports games on USB sticks, the network share and the CIFS
mount, and the stock menu finds them with zero configuration. Degauss
looked only at the card unless `game_roots` was edited by hand, which
made it the one part of the setup that did not follow the card's own
rules.

Five tests pin the semantics: USB priority, card fallback, aliases
across roots, unmounted roots ignored, a folder reached through a
symlink.

## How it was checked

- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --target armv7-unknown-linux-musleabihf --all-targets -- -D warnings`
- [x] `./scripts/rehearse-migration.sh`
- [x] Run on a real MiSTer
- [x] On a CRT, if it changes anything drawn

## Licensing

By opening this pull request I agree that my contribution is licensed under
the [PolyForm Noncommercial License 1.0.0](../LICENSE), the same licence as
the rest of Degauss, and that I have the right to license it that way.

Changes to `MiSTer_Degauss` do not belong here: it is a separate GPLv3
program in its own repository,
[Degauss-Main](https://github.com/giancarloerra/Degauss-Main).

- [x] I agree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Games can now be discovered automatically across USB storage, network shares, CIFS mounts and the console’s internal storage.
  * Storage locations are checked in a defined priority order, with fallback support when locations are unavailable.
  * Different game systems can resolve to different storage locations, including supported aliases.

* **Bug Fixes**
  * Unmounted storage locations are now ignored during game scanning, improving reliability.

* **Documentation**
  * Added guidance on external storage discovery, search precedence, startup timing, relocated games and custom storage configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->