### PR TITLE
One options screen, grouped, with honest names and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Enter, Escape, Space and Tab.
   tool and the browser follows: nothing has to be re-imported or re-tagged.
   The index it keeps is only a copy of what the card already says, and
   **Options -> Rebuild all system lists** brings it back in step,
-  and the contextual menu's **Rebuild this system** does one system alone.
+  and the contextual menu's **Rebuild this system list** does one system alone.
 - **Full metadata.** Description, publisher, developer, release date,
   players and language, read from `gamelist.xml`.
 - **Favourites are MiSTer's favourites**, written into `_@Favorites` in
@@ -185,7 +185,7 @@ The first run reads the card and writes an index, about a minute for a
 full one of 97k+ games. It never does that again on its own: **Options → Rebuild all system lists**
 is how you tell it the card has changed (for example after adding new games). New images and metadata are read on the fly.
 Adding games to one system does not need the whole card read again:
-**X → Rebuild this system** inside that system reads just its folders.
+**X → Rebuild this system list** inside that system reads just its folders.
 
 ### Optional: starting Degauss from the stock menu on-demand
 
@@ -257,7 +257,7 @@ top of their folder.
 **Hide this**, in the contextual menu, takes any row out of the list: a
 game, a folder, or a whole system while you are looking at the system
 list. That is separate from the folders and systems left out because they
-hold no games at all, which **Show empty folders** governs. **Show what
+hold no games at all, which **Show systems with no games** governs. **Show what
 you hid** shows the rows you hid without unhiding them, and **Unhide
 everything** puts them all back.
 
@@ -268,36 +268,38 @@ card.
 
 **Options**
 
+One screen holds everything, in groups a blank row apart, top to bottom:
+
 | Setting | Does |
 |---|---|
-| Scroll speed | How fast a held direction moves through the list |
-| Left and right | What left and right do while browsing: Scroll speed change (the default), Letter, Page or Direction. Letter and Page repeat while held; Direction frees up and down to move a whole row in Tiled |
-| Skip artwork faster than | Above this speed, pictures wait until the list stops |
-| Rebuild all system lists | Read the whole card again. Run it after adding games, cores or artwork; for one system, the contextual menu's **Rebuild this system** is quicker |
+| Scroll speed | How fast a held direction moves through the list. 3x out of the box |
+| Skip artwork faster than | Above this speed, pictures wait until the list stops. 6x out of the box |
+| Left and right behaviour | What left and right do while browsing: Scroll speed change (the default), Letter, Page or Direction. Letter and Page repeat while held; Direction frees up and down to move a whole row in Tiled |
+| Theme | A palette from the `themes/` folder, or Standard for the colours in `degauss.toml`. See [Themes and colours](#themes-and-colours) |
 | View | Details, Tiled, List or Carousel |
 | Text | The typeface: Smooth, Pixel (a DOS font on whole pixels), and the bolder Smooth 2 and Pixel 2 |
-| Theme | A palette from the `themes/` folder, or Standard for the colours in `degauss.toml`. See [Themes and colours](#themes-and-colours) |
-| Bottom bar while browsing | The strip with the time and the buttons. Menus always keep it |
 | Artwork | Turn pictures off entirely |
+| Bottom bar while browsing | The strip with the time and the buttons. Menus always keep it |
 | Favourites first | Gather a folder's favourites at its top, in the same alphabet |
-| Random | Whether a random pick starts the game, or only moves to it so you can look first |
-| Folders | Where folders sit inside a system: first, or after the games |
-| Show empty folders | Show folders and systems with no games in them. These are left out on their own. Off by default |
+| Folders before games | On, folders lead a system's listing; off, the games come first |
+| Random game behaviour | Whether a random pick starts the game, or only moves to it so you can look first |
+| Show Other folder | Show the Other group, the cores that are not games |
+| Show Utility folder | Show the Utility group, test patterns and measurement cores |
+| Show systems with no games | Systems and folders holding nothing are left out on their own; this shows them. Off by default |
 | Show what you hid | Show what you hid yourself with **Hide this** |
 | Unhide everything | Put back everything you hid yourself, in every folder and every system |
-| Show Other | Shows Others folder, usually the group holding cores that are not games |
-| Show Utility | Shows the Utility folder, usually the group holding tests and measurement cores |
-| Advanced | The screen below |
-
-**Advanced**
-
-| Setting | Does |
-|---|---|
-| Screensaver | How long with nothing pressed before pictures start |
 | Edge margin, sides | Keep this much of each side clear of the bezel |
 | Edge margin, top and bottom | The same, vertically |
 | Screen position, sideways | Nudge the picture, for a screen that sits off centre |
 | Screen position, up and down | The same, vertically |
+| Screensaver | How long with nothing pressed before pictures start |
+| Rebuild all system lists | Read the whole card again. Run it after adding games, cores or artwork; for one system, the contextual menu's **Rebuild this system list** is quicker |
+| Developer | The screen below |
+
+**Developer**
+
+| Setting | Does |
+|---|---|
 | Drawing path | Draw into the screen directly, or into memory first |
 | Performance readout | Replace the key hints with frame timings |
 
@@ -720,7 +722,7 @@ It is worth asking your agent to check the whole card for this once.
 #### After any change
 
 Rebuild the cache from the Degauss menu, or just the changed system with
-**X → Rebuild this system** while inside it. Artwork is never cached, so
+**X → Rebuild this system list** while inside it. Artwork is never cached, so
 pictures appear as soon as they are on the card. Favourites are shared with
 MiSTer's own `_@Favorites` folder, so an agent can add one and the stock
 menu will agree with it, and vice versa.

--- a/degauss.toml
+++ b/degauss.toml
@@ -15,7 +15,7 @@
 # is not mounted is skipped. /media/fat is listed too because Arcade lives
 # at /media/fat/_Arcade rather than under games. Storage must be mounted
 # before Degauss starts: what appears later is picked up on the next
-# start, or by Rebuild this system.
+# start, or by Rebuild this system list.
 game_roots = [
     "/media/usb0/games",
     "/media/usb1/games",
@@ -47,11 +47,11 @@ cover_size = 320
 art_cache = 200
 
 # The fastest scroll speed that still loads a picture for every row, as a
-# step on the speed ladder: 0 is the slowest, 6 the fastest, 3 is 3x. Above
+# step on the speed ladder: 0 is the slowest, 6 the fastest, 4 is 6x. Above
 # it, pictures wait for the list to stop moving. Decoding a screenshot costs
 # milliseconds, so past a certain rate fetching one per row is what stops the
 # scrolling being smooth, and nothing is readable at that speed anyway.
-art_limit = 3
+art_limit = 4
 
 # Which view to open in: details, tiled, list or carousel.
 layout = "details"

--- a/deploy/Scripts/.config/degauss/degauss.toml
+++ b/deploy/Scripts/.config/degauss/degauss.toml
@@ -15,7 +15,7 @@
 # is not mounted is skipped. /media/fat is listed too because Arcade lives
 # at /media/fat/_Arcade rather than under games. Storage must be mounted
 # before Degauss starts: what appears later is picked up on the next
-# start, or by Rebuild this system.
+# start, or by Rebuild this system list.
 game_roots = [
     "/media/usb0/games",
     "/media/usb1/games",
@@ -47,11 +47,11 @@ cover_size = 320
 art_cache = 200
 
 # The fastest scroll speed that still loads a picture for every row, as a
-# step on the speed ladder: 0 is the slowest, 6 the fastest, 3 is 3x. Above
+# step on the speed ladder: 0 is the slowest, 6 the fastest, 4 is 6x. Above
 # it, pictures wait for the list to stop moving. Decoding a screenshot costs
 # milliseconds, so past a certain rate fetching one per row is what stops the
 # scrolling being smooth, and nothing is readable at that speed anyway.
-art_limit = 3
+art_limit = 4
 
 # Which view to open in: details, tiled, list or carousel.
 layout = "details"

--- a/src/app.rs
+++ b/src/app.rs
@@ -360,7 +360,7 @@ const HIDE_THIS: &str = "Hide this";
 
 /// Read the system being browsed off the card again, leaving every other
 /// system's listing as it was.
-const REBUILD_SYSTEM: &str = "Rebuild this system";
+const REBUILD_SYSTEM: &str = "Rebuild this system list";
 
 /// Put it back.
 const SHOW_THIS: &str = "Show this";
@@ -2302,20 +2302,33 @@ impl App {
         }
     }
 
-    /// Step over the blank lines that separate groups in a menu.
+    /// Step over the blank lines that separate groups in a menu, and the
+    /// spacer rows that do the same on the options screen.
     ///
     /// They are there to be read, not chosen. Bounded by the number of
-    /// entries, so a menu that somehow held nothing else cannot spin.
+    /// entries, so a list that somehow held nothing else cannot spin.
     fn skip_blank_menu(&mut self, delta: isize) {
-        if !matches!(self.screen, Screen::Menu | Screen::Context) {
-            return;
-        }
-        for _ in 0..self.menu.len() {
-            let at = self.menu_list.selected();
-            if self.menu.get(at).is_none_or(|entry| !entry.is_empty()) {
-                return;
+        match self.screen {
+            Screen::Menu | Screen::Context => {
+                for _ in 0..self.menu.len() {
+                    let at = self.menu_list.selected();
+                    if self.menu.get(at).is_none_or(|entry| !entry.is_empty()) {
+                        return;
+                    }
+                    self.menu_list.move_items(delta);
+                }
             }
-            self.menu_list.move_items(delta);
+            Screen::Options | Screen::Advanced => {
+                let ids = self.option_ids();
+                for _ in 0..ids.len() {
+                    let at = self.active_list().selected();
+                    if ids.get(at) != Some(&OptionId::Spacer) {
+                        return;
+                    }
+                    self.active_list_mut().move_items(delta);
+                }
+            }
+            _ => {}
         }
     }
 
@@ -3292,6 +3305,9 @@ impl App {
             return;
         };
         match option {
+            // The cursor never rests on one, but a stale index after a
+            // screen change must do nothing rather than something.
+            OptionId::Spacer => {}
             OptionId::Speed => {
                 self.speed = step(self.speed, delta, SPEED_STEPS.len());
                 self.settings.speed_step = Some(self.speed);
@@ -3507,12 +3523,9 @@ impl App {
                 "Selects"
             }
             .to_string(),
-            OptionId::FoldersLast => if self.folders_last {
-                "After games"
-            } else {
-                "First"
-            }
-            .to_string(),
+            // The label reads Folders before games, so On is the leading
+            // position and the stored folders_last flag inverts.
+            OptionId::FoldersLast => on_off(!self.folders_last),
             OptionId::ResetHidden => {
                 match self.settings.hidden.len() + self.settings.hidden_paths.len() {
                     0 => "Nothing hidden".to_string(),
@@ -3531,6 +3544,7 @@ impl App {
             OptionId::ShiftX => format!("{:+} px", self.shift_x()),
             OptionId::ShiftY => format!("{:+} px", self.shift_y()),
             OptionId::Advanced => ">".to_string(),
+            OptionId::Spacer => String::new(),
             OptionId::OverscanX => format!(
                 "{}%",
                 self.settings

--- a/src/config.rs
+++ b/src/config.rs
@@ -278,7 +278,8 @@ fn default_art_cache() -> usize {
 /// enough to cover normal browsing with a picture on every row, slow enough
 /// that the decoding keeps up.
 fn default_art_limit() -> usize {
-    3
+    // The 6x step: artwork keeps up to there on the measured hardware.
+    4
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -90,8 +90,9 @@ pub const SPEED_STEPS: [(f32, u64); 7] = [
     (12.0, 7),
 ];
 
-/// A fresh start sits at 1x, so the first thing felt is the familiar rate.
-pub const SPEED_START: usize = 1;
+/// A fresh start sits at 3x: quick enough to feel the point of the
+/// exercise, slow enough to read on the way past.
+pub const SPEED_START: usize = 3;
 
 /// Held-key repeat cadence.
 #[derive(Debug, Clone, Copy)]

--- a/src/options.rs
+++ b/src/options.rs
@@ -51,63 +51,72 @@ pub enum OptionId {
     ShiftY,
     /// How long the machine is left alone before pictures take the screen.
     Screensaver,
-    /// Not a setting: the door to the advanced list.
+    /// Not a setting: the door to the developer list.
     Advanced,
+    /// Not a setting: a blank line separating one group from the next.
+    /// There to be read, never chosen; the cursor steps over it.
+    Spacer,
 }
 
-/// What most people will ever want to change.
-pub const OPTIONS: [OptionId; 18] = [
+/// Everything on the one screen, in groups a blank row apart: moving
+/// through lists, what the screen looks like, how a folder is ordered,
+/// what is shown at all, fitting the physical screen, the machine-wide
+/// acts, and the door to the diagnostics.
+pub const OPTIONS: [OptionId; 29] = [
     OptionId::Speed,
     OptionId::ArtLimit,
     OptionId::LeftRight,
-    OptionId::RebuildCache,
+    OptionId::Spacer,
+    OptionId::Theme,
     OptionId::Layout,
     OptionId::Font,
-    OptionId::Theme,
-    OptionId::ShowBar,
     OptionId::ShowArt,
+    OptionId::ShowBar,
+    OptionId::Spacer,
     OptionId::FavoritesFirst,
-    OptionId::RandomLaunches,
     OptionId::FoldersLast,
-    OptionId::ShowEmpty,
-    OptionId::ResetHidden,
-    OptionId::ShowHidden,
+    OptionId::RandomLaunches,
+    OptionId::Spacer,
     OptionId::ShowOther,
     OptionId::ShowUtility,
+    OptionId::ShowEmpty,
+    OptionId::ShowHidden,
+    OptionId::ResetHidden,
+    OptionId::Spacer,
+    OptionId::OverscanX,
+    OptionId::OverscanY,
+    OptionId::ShiftX,
+    OptionId::ShiftY,
+    OptionId::Spacer,
+    OptionId::Screensaver,
+    OptionId::RebuildCache,
+    OptionId::Spacer,
     OptionId::Advanced,
 ];
 
 /// Tuning and diagnostics: things you set once, or only while measuring.
 /// Kept behind a door so the main list stays about using the thing.
-pub const ADVANCED: [OptionId; 7] = [
-    OptionId::Screensaver,
-    OptionId::OverscanX,
-    OptionId::OverscanY,
-    OptionId::ShiftX,
-    OptionId::ShiftY,
-    OptionId::Present,
-    OptionId::ShowStats,
-];
+pub const ADVANCED: [OptionId; 2] = [OptionId::Present, OptionId::ShowStats];
 
 impl OptionId {
     pub fn label(self) -> &'static str {
         match self {
             OptionId::Speed => "Scroll speed",
-            OptionId::LeftRight => "Left and right",
+            OptionId::LeftRight => "Left and right behaviour",
             OptionId::ArtLimit => "Skip artwork faster than",
             OptionId::Layout => "View",
             OptionId::Font => "Text",
             OptionId::Theme => "Theme",
             OptionId::ShowArt => "Artwork",
             OptionId::ShowHidden => "Show what you hid",
-            OptionId::ShowEmpty => "Show empty folders",
-            OptionId::ShowOther => "Show Other",
-            OptionId::ShowUtility => "Show Utility",
+            OptionId::ShowEmpty => "Show systems with no games",
+            OptionId::ShowOther => "Show Other folder",
+            OptionId::ShowUtility => "Show Utility folder",
             OptionId::ShowBar => "Bottom bar while browsing",
             OptionId::RebuildCache => "Rebuild all system lists",
             OptionId::FavoritesFirst => "Favourites first",
-            OptionId::RandomLaunches => "Random",
-            OptionId::FoldersLast => "Folders",
+            OptionId::RandomLaunches => "Random game behaviour",
+            OptionId::FoldersLast => "Folders before games",
             OptionId::ResetHidden => "Unhide everything",
             OptionId::ShowStats => "Performance readout",
             OptionId::Present => "Drawing path",
@@ -116,7 +125,8 @@ impl OptionId {
             OptionId::ShiftX => "Screen position, sideways",
             OptionId::ShiftY => "Screen position, up and down",
             OptionId::Screensaver => "Screensaver",
-            OptionId::Advanced => "Advanced",
+            OptionId::Advanced => "Developer",
+            OptionId::Spacer => "",
         }
     }
 
@@ -149,7 +159,7 @@ impl OptionId {
             OptionId::ShowUtility => "Show the Utility group: test patterns and measurement cores.",
             OptionId::ShowBar => "The strip with the time and the buttons. Menus always keep it.",
             OptionId::FoldersLast => {
-                "Where folders sit inside a system: before the games or after them."
+                "On, folders lead a system's listing; off, the games come first."
             }
             OptionId::ResetHidden => {
                 "Put back everything you hid yourself, in every folder and every system."
@@ -174,7 +184,8 @@ impl OptionId {
             OptionId::Screensaver => {
                 "How long to wait, with nothing pressed, before showing pictures."
             }
-            OptionId::Advanced => "Tuning and diagnostics.",
+            OptionId::Advanced => "Diagnostics: the drawing path and the readout.",
+            OptionId::Spacer => "",
         }
     }
 }
@@ -217,24 +228,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn the_main_list_stays_short_enough_to_be_useful() {
-        // Options nobody uses push out the ones people do. Anything that
-        // exists for measurement belongs behind Advanced.
-        //
-        // Ten rows fit on screen, so the list already scrolls. The cap was
-        // moved from 16 to 17 deliberately when Left and right arrived (a
-        // browse control belongs beside Scroll speed), and from 17 to 18
-        // when Theme arrived (what the screen looks like is everyday use,
-        // and it sits beside Text, which changes the screen the same way).
-        // The next addition should go behind Advanced instead.
+    fn the_list_is_grouped_and_the_groups_are_well_formed() {
+        // The one screen holds everything, kept readable by blank rows
+        // between groups. A spacer at either end or two in a row would
+        // draw as dead space; the door sits last; the developer list
+        // holds only the diagnostics.
+        assert!(OPTIONS.first() != Some(&OptionId::Spacer));
+        assert!(OPTIONS.last() == Some(&OptionId::Advanced));
+        for pair in OPTIONS.windows(2) {
+            assert!(
+                pair[0] != OptionId::Spacer || pair[1] != OptionId::Spacer,
+                "two spacers in a row"
+            );
+        }
+        let rows = OPTIONS.iter().filter(|o| **o != OptionId::Spacer).count();
         assert!(
-            OPTIONS.len() <= 18,
-            "the main options list has grown to {}",
-            OPTIONS.len()
-        );
-        assert!(
-            OPTIONS.contains(&OptionId::Advanced),
-            "the door must be in the list"
+            rows <= 23,
+            "the options list has grown to {rows} real rows; new diagnostics belong behind Developer"
         );
         for option in ADVANCED {
             assert!(!OPTIONS.contains(&option), "{option:?} is in both lists");
@@ -244,6 +254,9 @@ mod tests {
     #[test]
     fn every_option_has_a_label_and_an_explanation() {
         for option in OPTIONS.iter().chain(ADVANCED.iter()).copied() {
+            if option == OptionId::Spacer {
+                continue;
+            }
             assert!(!option.label().is_empty());
             assert!(
                 option.help().len() > 20,
@@ -257,16 +270,21 @@ mod tests {
     fn the_options_list_has_no_duplicates() {
         let mut seen = Vec::new();
         for option in OPTIONS.iter().chain(ADVANCED.iter()).copied() {
+            if option == OptionId::Spacer {
+                continue;
+            }
             assert!(!seen.contains(&option), "{option:?} listed twice");
             seen.push(option);
         }
     }
 
     #[test]
-    fn the_speed_reads_as_a_multiple_of_the_baseline() {
-        let baseline = crate::input::SPEED_START;
-        assert!(speed_badge(baseline).contains("1x"));
-        assert!(speed_label(baseline).contains("90 ms"));
+    fn the_speed_reads_as_a_multiple_of_the_familiar_rate() {
+        // 1x is the rate a conventional frontend scrolls at, whatever the
+        // fresh-start default is set to; the fresh start sits at 3x.
+        assert!(speed_badge(1).contains("1x"));
+        assert!(speed_label(1).contains("90 ms"));
+        assert!(speed_badge(crate::input::SPEED_START).contains("3x"));
 
         let fastest = SPEED_STEPS.len() - 1;
         assert!(speed_badge(fastest).contains("12x"));


### PR DESCRIPTION
Closes no issue: this came out of reading the Options screen after the
0.3.0 features landed and finding it grown in accretion order.

## What this changes

One screen still holds everything, now in groups a blank row apart, the
same separator idiom the menus already use: moving through lists, what
the screen looks like, how a folder is ordered, what is shown at all,
fitting the physical screen, the machine-wide acts, and last the door.

- The door is **Developer** and holds exactly the diagnostics (Drawing
  path, Performance readout). Everything else it held was ordinary use:
  Screensaver and the four screen-geometry rows moved onto the one
  screen.
- Names answer the question a reader actually has: **Left and right
  behaviour**; **Folders before games** (on/off; "Folders first" beside
  "Favourites first" begged the question of which goes before the
  other); **Random game behaviour**; **Show Other folder**; **Show
  Utility folder**; **Show systems with no games**, which is what the
  empty filter actually governs.
- The contextual menu's entry is **Rebuild this system list**, the pair
  of Rebuild all system lists.
- Stored settings tokens are untouched throughout: every written-down
  choice keeps meaning the same thing.
- Two defaults change for fresh installs only: a held direction starts
  at **3x**, and artwork keeps loading up to **6x**, which is what the
  measured hardware sustains. Saved settings win over both, as always.

The cursor steps over the blank rows exactly as it does in the menus;
the group test pins that no spacer sits at an end or doubles up, and
that the list of real rows stays bounded.

## Why

Eighteen rows in the order features happened to arrive made every
lookup a scan. Grouped, each row is findable by asking what kind of
thing is being changed, and the door stops being a mixed drawer.

## How it was checked

- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --target armv7-unknown-linux-musleabihf --all-targets -- -D warnings`
- [x] `./scripts/rehearse-migration.sh`
- [x] Run on a real MiSTer
- [x] On a CRT, if it changes anything drawn

## Licensing

By opening this pull request I agree that my contribution is licensed under
the [PolyForm Noncommercial License 1.0.0](../LICENSE), the same licence as
the rest of Degauss, and that I have the right to license it that way.

Changes to `MiSTer_Degauss` do not belong here: it is a separate GPLv3
program in its own repository,
[Degauss-Main](https://github.com/giancarloerra/Degauss-Main).

- [x] I agree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded and reorganised the Options menu with clearer browsing and developer sections.
  * Added settings for artwork speed, bottom-bar visibility, folder ordering, random-game behaviour, category visibility and screensaver placement.
  * Improved menu navigation by skipping separators and non-selectable spacer rows.

* **Updates**
  * Artwork scrolling now starts faster, with updated speed thresholds.
  * Rebuild actions now use the clearer “Rebuild this system list” wording.
  * Folder ordering and spacer options now display more clearly as On/Off or blank values.

* **Documentation**
  * Updated configuration and README guidance to reflect the revised settings and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->