### PR TITLE
Let --select reach the screens that carry their own lists

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -875,7 +875,19 @@ fn render_once(loaded: Loaded, args: Args, chosen: usize, path: &Path) -> Result
     // throw the query away.
     match args.find.as_deref() {
         Some(text) => app.search_for(text),
-        None => app.set_screen(args.screen),
+        None => {
+            app.set_screen(args.screen);
+            // The choice above moved the cursor in the folder, which is
+            // what a context menu needs. The screens carrying lists of
+            // their own take the choice themselves, or --select could
+            // never reach past their first visible rows.
+            if matches!(
+                args.screen,
+                Screen::Options | Screen::Advanced | Screen::Help
+            ) {
+                app.select(args.select);
+            }
+        }
     }
 
     let mut surface = MemorySurface::new(width, height, args.format);


### PR DESCRIPTION
Closes no issue: found while rendering the 0.3.0 screenshots.

## What this changes

`--render` applied `--select` while still on the browse screen, which is
deliberate and stays: a context render needs to know what the folder
cursor is on. But it meant Options, Developer and Help could never be
rendered past their first visible rows: the choice landed in the folder
and the asked-for screen came up at its top. The screens that carry
lists of their own now take the choice after the switch, so
`--render --screen options --select 16` shows the middle of the list
with the right row highlighted.

Headless rendering only; nothing the device UI does changes.

## How it was checked

- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --target armv7-unknown-linux-musleabihf --all-targets -- -D warnings`
- [x] Run on a real MiSTer (the 0.3.0 screenshot set was rendered with it)
- [x] On a CRT, if it changes anything drawn

## Licensing

By opening this pull request I agree that my contribution is licensed under
the [PolyForm Noncommercial License 1.0.0](../LICENSE), the same licence as
the rest of Degauss, and that I have the right to license it that way.

Changes to `MiSTer_Degauss` do not belong here: it is a separate GPLv3
program in its own repository,
[Degauss-Main](https://github.com/giancarloerra/Degauss-Main).

- [x] I agree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection behaviour when opening the Options, Advanced, or Help screens with `--select`.
  * Preserved the existing selection when browsing other screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->