### PR TITLE
Add held-X favourite shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Video showing version 0.2.0 (themes/looks/options changed since then, but the sp
 | **left / right** | scroll speed, 0.5x to 12x, or what the **Left and right** setting says: letter jumps, page jumps, or plain movement. In a menu, change the setting |
 | **A** (enter) | open a folder, launch a game |
 | **B** (escape) | back, out of the folder |
-| **X** (tab) | context menu: random game, random favourite, keep or drop a favourite, jump to letter, search, hide a row, rebuild this system, change view, etc. |
+| **X** (tab) | context menu: random game, random favourite, keep or drop a favourite, jump to letter, search, hide a row, rebuild this system, change view, etc. With **Hold X (1s) to add/remove fav** enabled, hold X for one second over a game to use the favourite shortcut |
 | **Y** (space) | menu: options, help, about, exit |
 
 A gamepad needs no setup and a keyboard is never needed. While Degauss
@@ -274,6 +274,7 @@ One screen holds everything, in groups a blank row apart, top to bottom:
 | Artwork | Turn pictures off entirely |
 | Bottom bar while browsing | The strip with the time and the buttons. Menus always keep it |
 | Favourites first | Gather a folder's favourites at its top, in the same alphabet |
+| Hold X (1s) to add/remove fav | Off by default. Hold X for one second over a game to open the normal favourite-folder chooser, or to remove it when it is already a favourite. The shortcut does nothing in the master Favourites system |
 | Folders before games | On, folders lead a system's listing; off, the games come first |
 | Random game behaviour | Whether a random pick starts the game, or only moves to it so you can look first |
 | Show Other folder | Show the Other group, the cores that are not games |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1645,7 +1645,7 @@ impl App {
         if self.screen == Screen::Advanced {
             &ADVANCED
         } else {
-            &OPTIONS
+            OPTIONS
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -371,6 +371,39 @@ const ADD_FAVORITE: &str = "Add to favourites";
 /// Take it out again.
 const REMOVE_FAVORITE: &str = "Remove from favourites";
 
+/// What the optional held-X gesture can do to the selected row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FavoriteChange {
+    Add,
+    Remove,
+}
+
+/// Decide the held-X operation without touching the card, so the boundaries
+/// that protect folders, other screens and the master Favourites system can
+/// be pinned by tests.
+fn favorite_change(
+    enabled: bool,
+    screen: Screen,
+    browsing: Browsing,
+    in_favorites: bool,
+    has_game: bool,
+    favorite: bool,
+) -> Option<FavoriteChange> {
+    if !enabled
+        || screen != Screen::Browse
+        || browsing != Browsing::Games
+        || in_favorites
+        || !has_game
+    {
+        return None;
+    }
+    Some(if favorite {
+        FavoriteChange::Remove
+    } else {
+        FavoriteChange::Add
+    })
+}
+
 /// The entry that spells out a folder name rather than picking one.
 const NEW_FOLDER: &str = "New folder...";
 
@@ -1053,6 +1086,8 @@ pub struct App {
     favorites: crate::favorites::Favorites,
     /// Whether favourites are gathered at the top of a folder.
     favorites_first: bool,
+    /// Whether a one-second X hold adds or removes the selected favourite.
+    hold_x_favorite: bool,
     /// The typeface everything is set in.
     font: Font,
     /// The themes the folder held at startup, in the order the Options row
@@ -1287,6 +1322,7 @@ impl App {
             empty_systems: None,
             favorites: crate::favorites::Favorites::default(),
             favorites_first: settings.favorites_first.unwrap_or(true),
+            hold_x_favorite: settings.hold_x_favorite.unwrap_or(false),
             // The file the user edits, then the one Degauss writes, then the
             // typeface that always exists. A name neither of them recognises
             // is not worth refusing to start over.
@@ -3439,6 +3475,10 @@ impl App {
                 // The folder on screen was ordered by the old answer.
                 self.relist_here();
             }
+            OptionId::HoldXFavorite => {
+                self.hold_x_favorite = !self.hold_x_favorite;
+                self.settings.hold_x_favorite = Some(self.hold_x_favorite);
+            }
             OptionId::RandomLaunches => {
                 self.random_launches = !self.random_launches;
                 self.settings.random_launches = Some(self.random_launches);
@@ -3528,6 +3568,7 @@ impl App {
             OptionId::ShowUtility => on_off(self.show_utility),
             OptionId::ShowBar => on_off(self.show_bar),
             OptionId::FavoritesFirst => on_off(self.favorites_first),
+            OptionId::HoldXFavorite => on_off(self.hold_x_favorite),
             OptionId::RandomLaunches => if self.random_launches {
                 "Launches"
             } else {
@@ -3887,10 +3928,37 @@ impl App {
         }
     }
 
+    /// The operation a held X would perform now. The same answer enables the
+    /// timer and handles its result, so a row that cannot be changed never
+    /// acquires a delayed X press.
+    fn favorite_change(&self) -> Option<FavoriteChange> {
+        let selected = self.selected_game();
+        let favorite = selected
+            .as_deref()
+            .is_some_and(|game| self.favorites.holds(game));
+        favorite_change(
+            self.hold_x_favorite,
+            self.screen,
+            self.browsing,
+            self.in_favorites(),
+            selected.is_some(),
+            favorite,
+        )
+    }
+
     /// Offer the folders MiSTer's favourites are already kept in, and the
     /// chance to name another.
     fn open_favorite_folders(&mut self) {
-        let mut entries = crate::favorites::folders(&self.favorites_root());
+        let mut entries = match crate::favorites::folders(&self.favorites_root()) {
+            Ok(entries) => entries,
+            Err(e) => {
+                self.screen = Screen::Browse;
+                self.apply_geometry();
+                self.message = Some(format!("{e}"));
+                self.dirty = true;
+                return;
+            }
+        };
         entries.push(NEW_FOLDER.to_string());
         self.menu = entries;
         self.menu_list = ListState::new(self.menu.len(), self.geometry.visible);
@@ -4290,6 +4358,11 @@ impl App {
                     return self.go_back();
                 }
             }
+            Action::FavoriteShortcut => match self.favorite_change() {
+                Some(FavoriteChange::Add) => self.open_favorite_folders(),
+                Some(FavoriteChange::Remove) => self.remove_favorite(),
+                None => {}
+            },
             Action::CyclePresent => self.pending_present_switch = true,
             Action::Accept => match self.screen {
                 Screen::Screensaver => self.leave_screensaver(),
@@ -4924,13 +4997,11 @@ impl App {
             // and again before the repeats so a screen opened under a held
             // stick stops the repeat instead of taking one more step there.
             repeater.set_horizontal_repeats(self.horizontal_scrolls());
+            repeater.set_favorite_hold(self.favorite_change().is_some());
             for edge in input.poll() {
                 let action = match edge {
                     KeyEdge::Down(action) => repeater.press(action, now),
-                    KeyEdge::Up(action) => {
-                        repeater.release(action);
-                        None
-                    }
+                    KeyEdge::Up(action) => repeater.release(action, now),
                 };
                 if let Some(action) = action {
                     if let Some(outcome) = self.handle(action) {
@@ -4940,6 +5011,7 @@ impl App {
                 }
             }
             repeater.set_horizontal_repeats(self.horizontal_scrolls());
+            repeater.set_favorite_hold(self.favorite_change().is_some());
             for action in repeater.tick(now) {
                 if let Some(outcome) = self.handle(action) {
                     self.save_settings();
@@ -5849,6 +5921,41 @@ mod tests {
         let over_favourite = context_entries(Browsing::Games, false, Some(true), None);
         assert!(over_favourite.iter().any(|e| e == REMOVE_FAVORITE));
         assert!(!over_favourite.iter().any(|e| e == ADD_FAVORITE));
+    }
+
+    #[test]
+    fn the_held_x_shortcut_is_opt_in_and_only_changes_games_outside_favourites() {
+        // Existing installations have no setting, so the shortcut is absent.
+        assert_eq!(
+            favorite_change(false, Screen::Browse, Browsing::Games, false, true, false),
+            None
+        );
+        // A normal game adds through the existing folder chooser; one already
+        // held removes through the existing contextual-menu operation.
+        assert_eq!(
+            favorite_change(true, Screen::Browse, Browsing::Games, false, true, false),
+            Some(FavoriteChange::Add)
+        );
+        assert_eq!(
+            favorite_change(true, Screen::Browse, Browsing::Games, false, true, true),
+            Some(FavoriteChange::Remove)
+        );
+        // The master shelf owns favourite files rather than source games;
+        // only its ordinary contextual menu is allowed to change them.
+        assert_eq!(
+            favorite_change(true, Screen::Browse, Browsing::Games, true, true, true),
+            None
+        );
+        assert_eq!(
+            favorite_change(true, Screen::Browse, Browsing::Games, false, false, false),
+            None,
+            "folders are not games"
+        );
+        assert_eq!(
+            favorite_change(true, Screen::Context, Browsing::Games, false, true, false),
+            None,
+            "the shortcut exists only while browsing"
+        );
     }
 
     #[test]

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -165,18 +165,28 @@ fn target_of_mgl(path: &Path) -> Option<PathBuf> {
 }
 
 /// The folders inside the favourites folder, as somebody would read them.
-pub fn folders(root: &Path) -> Vec<String> {
-    let Ok(listing) = std::fs::read_dir(root) else {
-        return Vec::new();
+pub fn folders(root: &Path) -> Result<Vec<String>> {
+    let listing = match std::fs::read_dir(root) {
+        Ok(listing) => listing,
+        // A card with no favourites yet has no root. The New folder entry is
+        // how the first one is created, so absence is an empty collection.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(DegaussError::io("reading favourite folders", root, e)),
     };
-    let mut names: Vec<String> = listing
-        .flatten()
-        .filter(|item| item.file_type().is_ok_and(|kind| kind.is_dir()))
-        .map(|item| item.file_name().to_string_lossy().into_owned())
-        .filter(|name| !name.starts_with('.'))
-        .collect();
+    let mut names = Vec::new();
+    for item in listing {
+        let item = item.map_err(|e| DegaussError::io("reading favourite folders", root, e))?;
+        let path = item.path();
+        let kind = item
+            .file_type()
+            .map_err(|e| DegaussError::io("reading a favourite folder", &path, e))?;
+        let name = item.file_name().to_string_lossy().into_owned();
+        if kind.is_dir() && !name.starts_with('.') {
+            names.push(name);
+        }
+    }
     names.sort_by_key(|name| name.to_lowercase());
-    names
+    Ok(names)
 }
 
 /// Characters MiSTer's own script refuses in a favourite's name, so a name
@@ -281,6 +291,44 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("degauss-fav-{name}-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn a_card_with_no_favourites_root_offers_an_empty_folder_list() {
+        // The folder chooser appends New folder. Treating a genuinely absent
+        // root as empty is what lets the first favourite create it.
+        let root = std::env::temp_dir().join(format!("degauss-fav-missing-{}", std::process::id()));
+        std::fs::remove_dir_all(&root).ok();
+        assert_eq!(
+            folders(&root).expect("absence is a new card"),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn favourite_folders_are_sorted_and_non_folders_are_not_offered() {
+        let root = temp("folder-list");
+        std::fs::create_dir_all(root.join("zeta")).unwrap();
+        std::fs::create_dir_all(root.join("Arcade")).unwrap();
+        std::fs::create_dir_all(root.join(".private")).unwrap();
+        std::fs::write(root.join("loose.mgl"), "x").unwrap();
+
+        assert_eq!(
+            folders(&root).expect("folder list reads"),
+            ["Arcade".to_string(), "zeta".to_string()]
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn a_favourites_path_that_cannot_be_a_directory_is_reported() {
+        // A storage/path failure must not look like an empty collection and
+        // offer New folder as if nothing were wrong.
+        let root = temp("folder-error");
+        let file = root.join("not-a-directory");
+        std::fs::write(&file, "x").unwrap();
+        assert!(folders(&file).is_err());
+        std::fs::remove_dir_all(&root).ok();
     }
 
     /// A game that needs a companion disc has the disc written into the MGL

--- a/src/input.rs
+++ b/src/input.rs
@@ -62,6 +62,8 @@ pub enum Action {
     Menu,
     /// Open the contextual menu: what can be done with the folder on screen.
     Context,
+    /// Add or remove the selected game as a favourite after X is held.
+    FavoriteShortcut,
 }
 
 impl Action {
@@ -93,6 +95,9 @@ pub const SPEED_STEPS: [(f32, u64); 7] = [
 /// A fresh start sits at 3x: quick enough to feel the point of the
 /// exercise, slow enough to read on the way past.
 pub const SPEED_START: usize = 3;
+
+/// How long X is held before the optional favourite shortcut fires.
+pub const FAVORITE_HOLD: Duration = Duration::from_secs(1);
 
 /// Held-key repeat cadence.
 #[derive(Debug, Clone, Copy)]
@@ -137,6 +142,10 @@ pub struct Repeater {
     /// up or down does. In every other setting they step a ladder or a
     /// choice, where one press must mean one step.
     horizontal_repeats: bool,
+    /// Whether X is being treated as a short/long gesture. This is enabled
+    /// only while the optional favourite shortcut can act on the selected
+    /// row, leaving X immediate everywhere else.
+    favorite_hold: bool,
 }
 
 impl Repeater {
@@ -145,6 +154,22 @@ impl Repeater {
             config,
             held: Vec::new(),
             horizontal_repeats: false,
+            favorite_hold: false,
+        }
+    }
+
+    /// Delay X until release so a one-second hold can be distinguished from
+    /// the ordinary contextual-menu press. Disabling the gesture also drops
+    /// an X still held, so a shortcut that opened another screen cannot fire
+    /// the short action when the button is released there.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub fn set_favorite_hold(&mut self, enabled: bool) {
+        if self.favorite_hold == enabled {
+            return;
+        }
+        self.favorite_hold = enabled;
+        if !enabled {
+            self.held.retain(|held| held.action != Action::Context);
         }
     }
 
@@ -158,7 +183,9 @@ impl Repeater {
         }
         self.horizontal_repeats = enabled;
         if !enabled {
-            self.held.retain(|held| held.action.repeats());
+            self.held.retain(|held| {
+                held.action.repeats() || (self.favorite_hold && held.action == Action::Context)
+            });
         }
     }
 
@@ -177,12 +204,28 @@ impl Repeater {
     /// A key went down. Returns the action to perform immediately.
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub fn press(&mut self, action: Action, now: Instant) -> Option<Action> {
+        if self.favorite_hold && action != Action::Context {
+            // The shortcut acts on the selected row. Moving or pressing
+            // anything else while X is down cancels it, so the eventual
+            // hold cannot add or remove a different row.
+            self.held.retain(|held| held.action != Action::Context);
+        }
+        if self.favorite_hold
+            && action == Action::Context
+            && self.held.iter().any(|held| held.action != Action::Context)
+        {
+            // A direction already held can move the cursor during the next
+            // second. Keep X as the immediate contextual-menu action rather
+            // than arming a shortcut whose target would no longer be fixed.
+            return Some(Action::Context);
+        }
         if self.held.iter().any(|h| h.action == action) {
             return None;
         }
-        let repeats = action.repeats()
-            || (self.horizontal_repeats && matches!(action, Action::Slower | Action::Faster));
-        if repeats {
+        let retained = action.repeats()
+            || (self.horizontal_repeats && matches!(action, Action::Slower | Action::Faster))
+            || (self.favorite_hold && action == Action::Context);
+        if retained {
             self.held.push(Held {
                 action,
                 pressed_at: now,
@@ -190,12 +233,30 @@ impl Repeater {
                 repeating: false,
             });
         }
-        Some(action)
+        if self.favorite_hold && action == Action::Context {
+            None
+        } else {
+            Some(action)
+        }
     }
 
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-    pub fn release(&mut self, action: Action) {
-        self.held.retain(|h| h.action != action);
+    pub fn release(&mut self, action: Action, now: Instant) -> Option<Action> {
+        let held = self
+            .held
+            .iter()
+            .position(|held| held.action == action)
+            .map(|at| self.held.remove(at));
+        let held = held?;
+        if self.favorite_hold && action == Action::Context && !held.repeating {
+            if now.duration_since(held.pressed_at) >= FAVORITE_HOLD {
+                Some(Action::FavoriteShortcut)
+            } else {
+                Some(Action::Context)
+            }
+        } else {
+            None
+        }
     }
 
     /// Actions due because a key is still held.
@@ -203,6 +264,13 @@ impl Repeater {
     pub fn tick(&mut self, now: Instant) -> Vec<Action> {
         let mut due = Vec::new();
         for held in &mut self.held {
+            if self.favorite_hold && held.action == Action::Context {
+                if !held.repeating && now.duration_since(held.pressed_at) >= FAVORITE_HOLD {
+                    held.repeating = true;
+                    due.push(Action::FavoriteShortcut);
+                }
+                continue;
+            }
             let ready = if held.repeating {
                 now.duration_since(held.last_fired) >= self.config.interval
             } else {
@@ -832,7 +900,10 @@ mod tests {
             vec![Action::Faster],
             "a held right must keep scrolling"
         );
-        repeater.release(Action::Faster);
+        assert_eq!(
+            repeater.release(Action::Faster, t0 + Duration::from_millis(10)),
+            None
+        );
         assert!(repeater.tick(t0 + Duration::from_secs(1)).is_empty());
     }
 
@@ -886,9 +957,143 @@ mod tests {
         let mut repeater = Repeater::new(RepeatConfig::default());
         let t0 = Instant::now();
         repeater.press(Action::Down, t0);
-        repeater.release(Action::Down);
+        assert_eq!(
+            repeater.release(Action::Down, t0 + Duration::from_millis(1)),
+            None
+        );
         assert!(repeater.tick(t0 + Duration::from_secs(5)).is_empty());
         assert!(!repeater.anything_held());
+    }
+
+    #[test]
+    fn x_stays_immediate_when_the_favourite_shortcut_is_off() {
+        // Off is the upgrade default. A user who never enables the setting
+        // must keep the exact press-time contextual-menu behaviour.
+        let mut repeater = Repeater::new(RepeatConfig::default());
+        let t0 = Instant::now();
+        assert_eq!(repeater.press(Action::Context, t0), Some(Action::Context));
+        assert!(repeater.tick(t0 + FAVORITE_HOLD).is_empty());
+        assert_eq!(repeater.release(Action::Context, t0 + FAVORITE_HOLD), None);
+    }
+
+    #[test]
+    fn a_short_x_release_keeps_the_contextual_menu() {
+        // Enabling the shortcut adds a long gesture; it must not take away
+        // the ordinary X action used throughout Degauss.
+        let mut repeater = Repeater::new(RepeatConfig::default());
+        repeater.set_favorite_hold(true);
+        let t0 = Instant::now();
+        assert_eq!(repeater.press(Action::Context, t0), None);
+        assert!(repeater
+            .tick(t0 + FAVORITE_HOLD - Duration::from_millis(1))
+            .is_empty());
+        assert_eq!(
+            repeater.release(
+                Action::Context,
+                t0 + FAVORITE_HOLD - Duration::from_millis(1)
+            ),
+            Some(Action::Context)
+        );
+    }
+
+    #[test]
+    fn x_held_for_one_second_fires_the_favourite_shortcut_once() {
+        // A destructive removal must not repeat while X remains down.
+        let mut repeater = Repeater::new(RepeatConfig::default());
+        repeater.set_favorite_hold(true);
+        let t0 = Instant::now();
+        assert_eq!(repeater.press(Action::Context, t0), None);
+        assert_eq!(
+            repeater.tick(t0 + FAVORITE_HOLD),
+            vec![Action::FavoriteShortcut]
+        );
+        assert!(repeater
+            .tick(t0 + FAVORITE_HOLD + Duration::from_secs(2))
+            .is_empty());
+        assert_eq!(
+            repeater.release(Action::Context, t0 + FAVORITE_HOLD + Duration::from_secs(2)),
+            None,
+            "release after a long hold must not open the context menu"
+        );
+    }
+
+    #[test]
+    fn release_at_the_threshold_cannot_turn_a_long_hold_into_a_short_press() {
+        // Input edges are drained before timed actions. If X comes up exactly
+        // at one second, release itself has to emit the long action.
+        let mut repeater = Repeater::new(RepeatConfig::default());
+        repeater.set_favorite_hold(true);
+        let t0 = Instant::now();
+        assert_eq!(repeater.press(Action::Context, t0), None);
+        assert_eq!(
+            repeater.release(Action::Context, t0 + FAVORITE_HOLD),
+            Some(Action::FavoriteShortcut)
+        );
+    }
+
+    #[test]
+    fn leaving_an_eligible_row_cancels_x_without_leaking_a_context_press() {
+        // A long hold can open the folder chooser. Disabling the gesture on
+        // that new screen must consume the eventual button release there.
+        let mut repeater = Repeater::new(RepeatConfig::default());
+        repeater.set_favorite_hold(true);
+        let t0 = Instant::now();
+        assert_eq!(repeater.press(Action::Context, t0), None);
+        assert_eq!(
+            repeater.tick(t0 + FAVORITE_HOLD),
+            vec![Action::FavoriteShortcut]
+        );
+        repeater.set_favorite_hold(false);
+        assert_eq!(repeater.release(Action::Context, t0 + FAVORITE_HOLD), None);
+    }
+
+    #[test]
+    fn another_button_cancels_the_held_x_target() {
+        // The favourite action belongs to the row selected when X went down.
+        // A movement while it is held must not apply it to the new row.
+        let mut repeater = Repeater::new(RepeatConfig::default());
+        repeater.set_favorite_hold(true);
+        let t0 = Instant::now();
+        assert_eq!(repeater.press(Action::Context, t0), None);
+        assert_eq!(
+            repeater.press(Action::Down, t0 + Duration::from_millis(100)),
+            Some(Action::Down)
+        );
+        assert!(
+            !repeater
+                .tick(t0 + FAVORITE_HOLD)
+                .contains(&Action::FavoriteShortcut),
+            "movement may repeat, but the cancelled favourite action must not fire"
+        );
+        assert_eq!(repeater.release(Action::Context, t0 + FAVORITE_HOLD), None);
+    }
+
+    #[test]
+    fn x_does_not_arm_the_shortcut_while_movement_is_already_held() {
+        // The reverse input order has the same target risk: a held direction
+        // can move after X goes down. X remains available as the ordinary
+        // context action, but no delayed favourite action may be retained.
+        let mut repeater = Repeater::new(RepeatConfig::default());
+        repeater.set_favorite_hold(true);
+        let t0 = Instant::now();
+        assert_eq!(repeater.press(Action::Down, t0), Some(Action::Down));
+        assert_eq!(
+            repeater.press(Action::Context, t0 + Duration::from_millis(100)),
+            Some(Action::Context)
+        );
+        assert!(
+            !repeater
+                .tick(t0 + FAVORITE_HOLD + Duration::from_millis(100))
+                .contains(&Action::FavoriteShortcut),
+            "X pressed during movement must not retain a changing target"
+        );
+        assert_eq!(
+            repeater.release(
+                Action::Context,
+                t0 + FAVORITE_HOLD + Duration::from_millis(100)
+            ),
+            None
+        );
     }
 
     #[test]

--- a/src/options.rs
+++ b/src/options.rs
@@ -37,6 +37,8 @@ pub enum OptionId {
     RebuildCache,
     /// Gather favourites at the top of a folder.
     FavoritesFirst,
+    /// Add or remove a favourite by holding X for one second.
+    HoldXFavorite,
     RandomLaunches,
     /// List folders after the games rather than before them.
     FoldersLast,
@@ -62,7 +64,7 @@ pub enum OptionId {
 /// through lists, what the screen looks like, how a folder is ordered,
 /// what is shown at all, fitting the physical screen, the machine-wide
 /// acts, and the door to the diagnostics.
-pub const OPTIONS: [OptionId; 29] = [
+pub const OPTIONS: [OptionId; 30] = [
     OptionId::Speed,
     OptionId::ArtLimit,
     OptionId::LeftRight,
@@ -74,6 +76,7 @@ pub const OPTIONS: [OptionId; 29] = [
     OptionId::ShowBar,
     OptionId::Spacer,
     OptionId::FavoritesFirst,
+    OptionId::HoldXFavorite,
     OptionId::FoldersLast,
     OptionId::RandomLaunches,
     OptionId::Spacer,
@@ -115,6 +118,7 @@ impl OptionId {
             OptionId::ShowBar => "Bottom bar while browsing",
             OptionId::RebuildCache => "Rebuild all system lists",
             OptionId::FavoritesFirst => "Favourites first",
+            OptionId::HoldXFavorite => "Hold X (1s) to add/remove fav",
             OptionId::RandomLaunches => "Random game behaviour",
             OptionId::FoldersLast => "Folders before games",
             OptionId::ResetHidden => "Unhide everything",
@@ -166,6 +170,9 @@ impl OptionId {
             }
             OptionId::FavoritesFirst => {
                 "Gather a folder's favourites at its top, in the same alphabet."
+            }
+            OptionId::HoldXFavorite => {
+                "Hold X for one second over a game to add or remove it. Off in the master Favourites system."
             }
             OptionId::RandomLaunches => {
                 "Whether a random pick starts the game, or only moves to it so you can look first."
@@ -243,8 +250,8 @@ mod tests {
         }
         let rows = OPTIONS.iter().filter(|o| **o != OptionId::Spacer).count();
         assert!(
-            rows <= 23,
-            "the options list has grown to {rows} real rows; new diagnostics belong behind Developer"
+            rows <= 24,
+            "the options list has grown to {rows} real rows; review the 240-line layout before adding another"
         );
         for option in ADVANCED {
             assert!(!OPTIONS.contains(&option), "{option:?} is in both lists");
@@ -276,6 +283,22 @@ mod tests {
             assert!(!seen.contains(&option), "{option:?} listed twice");
             seen.push(option);
         }
+    }
+
+    #[test]
+    fn the_held_x_option_follows_favourites_first() {
+        // Both settings govern favourites while browsing. Keeping the
+        // shortcut here, rather than behind Developer, makes the placement
+        // part of the Options contract instead of an incidental array order.
+        let favourites = OPTIONS
+            .iter()
+            .position(|option| *option == OptionId::FavoritesFirst)
+            .expect("Favourites first is in Options");
+        assert_eq!(OPTIONS.get(favourites + 1), Some(&OptionId::HoldXFavorite));
+        assert_eq!(
+            OptionId::HoldXFavorite.label(),
+            "Hold X (1s) to add/remove fav"
+        );
     }
 
     #[test]

--- a/src/options.rs
+++ b/src/options.rs
@@ -64,7 +64,7 @@ pub enum OptionId {
 /// through lists, what the screen looks like, how a folder is ordered,
 /// what is shown at all, fitting the physical screen, the machine-wide
 /// acts, and the door to the diagnostics.
-pub const OPTIONS: [OptionId; 30] = [
+pub const OPTIONS: &[OptionId] = &[
     OptionId::Speed,
     OptionId::ArtLimit,
     OptionId::LeftRight,
@@ -250,7 +250,7 @@ mod tests {
         }
         let rows = OPTIONS.iter().filter(|o| **o != OptionId::Spacer).count();
         assert!(
-            rows <= 24,
+            rows <= 25,
             "the options list has grown to {rows} real rows; review the 240-line layout before adding another"
         );
         for option in ADVANCED {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -41,6 +41,11 @@ pub struct Settings {
     pub theme: Option<String>,
     /// Whether favourites are gathered at the top of a folder.
     pub favorites_first: Option<bool>,
+    /// Whether holding X for one second adds or removes the selected game.
+    /// Absent is off, preserving the immediate X behaviour from releases
+    /// before the shortcut existed.
+    #[serde(default)]
+    pub hold_x_favorite: Option<bool>,
     /// Whether picking a random game starts it, or only moves the cursor to
     /// it. Absent means only moving the cursor.
     #[serde(default)]
@@ -124,6 +129,10 @@ mod tests {
         assert_eq!(settings.overscan_x, Some(5));
         assert_eq!(settings.hidden, ["PDP1", "VC4000"]);
         assert_eq!(settings.folder_views.len(), 2);
+        assert_eq!(
+            settings.hold_x_favorite, None,
+            "an older settings file must leave the opt-in shortcut off"
+        );
     }
 
     fn temp_path(tag: &str) -> std::path::PathBuf {
@@ -150,6 +159,7 @@ mod tests {
             layout: Some("covers".into()),
             left_right: Some("letter".into()),
             theme: Some("amber".into()),
+            hold_x_favorite: Some(true),
             show_stats: Some(true),
             overscan_x: Some(24),
             ..Default::default()


### PR DESCRIPTION
## What this changes

- Adds an opt-in **Hold X (1s) to add/remove fav** setting directly after **Favourites first**.
- Keeps the setting Off when it is absent from an existing `settings.toml`.
- Opens the existing favourite-folder chooser after a one-second X hold on a non-favourite game.
- Uses the existing removal path after a one-second X hold on a favourite game.
- Keeps X as the normal contextual-menu action in the master Favourites system and on rows where the shortcut cannot act.
- Cancels a pending shortcut when another input can change its target.
- Reports favourite-folder read failures instead of presenting them as an empty folder list.

## Why

Closes #25.

This removes the repeated context-menu step when reviewing long game lists while retaining the existing X behaviour by default.

## How it was checked

- [x] `cargo test` (265 passed)
- [x] `cargo fmt --check`
- [x] `cargo clippy --target armv7-unknown-linux-musleabihf --all-targets -- -D warnings`
- [x] Run on a real MiSTer
- [x] On a CRT, if it changes anything drawn
- [x] `./scripts/rehearse-migration.sh` (all 9 rehearsals passed)
- [x] Options screen rendered and inspected at 352x240

## Licensing

By opening this pull request I agree that my contribution is licensed under
the [PolyForm Noncommercial License 1.0.0](../LICENSE), the same licence as
the rest of Degauss, and that I have the right to license it that way.

Changes to `MiSTer_Degauss` do not belong here: it is a separate GPLv3
program in its own repository,
[Degauss-Main](https://github.com/giancarloerra/Degauss-Main).

- [x] I agree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional X-button shortcut for adding or removing favourites after a one-second hold.
  - The shortcut uses the standard favourite-folder chooser and is disabled by default.
  - Added an Options setting to enable or disable the shortcut.
  - The shortcut is unavailable in folders, other screens and the Favourites shelf.

- **Bug Fixes**
  - Favourite folders now handle missing directories gracefully and show filesystem errors clearly.
  - Short X-button presses continue to open the contextual menu as expected.

- **Documentation**
  - Documented the shortcut, timing, behaviour, exclusions and related setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->