### PR TITLE
Add physical-display artwork scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ One screen holds everything, in groups a blank row apart, top to bottom:
 | View | Details, Tiled, List or Carousel |
 | Text | The typeface: Smooth, Pixel (a DOS font on whole pixels), and the bolder Smooth 2 and Pixel 2 |
 | Artwork | Turn pictures off entirely |
+| Artwork scale factor | Framebuffer keeps the original square-pixel fit and is the default. 4:3 and 16:9 correct game artwork for that physical display shape in Details, Tiled and Carousel. Category logos, system logos and the screensaver are unchanged |
 | Bottom bar while browsing | The strip with the time and the buttons. Menus always keep it |
 | Favourites first | Gather a folder's favourites at its top, in the same alphabet |
 | Folders before games | On, folders lead a system's listing; off, the games come first |

--- a/src/app.rs
+++ b/src/app.rs
@@ -183,6 +183,74 @@ impl Layout {
     }
 }
 
+/// How game artwork is corrected when framebuffer pixels are not square on
+/// the physical display. The stored names are part of the settings format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ArtworkScale {
+    /// Preserve the original behaviour: fit artwork in framebuffer pixels.
+    #[default]
+    Framebuffer,
+    /// Correct artwork for a display whose physical picture is 4:3.
+    FourThree,
+    /// Correct artwork for a display whose physical picture is 16:9.
+    SixteenNine,
+}
+
+impl ArtworkScale {
+    const ALL: [ArtworkScale; 3] = [
+        ArtworkScale::Framebuffer,
+        ArtworkScale::FourThree,
+        ArtworkScale::SixteenNine,
+    ];
+
+    fn setting(self) -> &'static str {
+        match self {
+            ArtworkScale::Framebuffer => "framebuffer",
+            ArtworkScale::FourThree => "4:3",
+            ArtworkScale::SixteenNine => "16:9",
+        }
+    }
+
+    fn shown(self) -> &'static str {
+        match self {
+            ArtworkScale::Framebuffer => "Framebuffer",
+            ArtworkScale::FourThree => "4:3",
+            ArtworkScale::SixteenNine => "16:9",
+        }
+    }
+
+    fn parse(text: &str) -> Option<Self> {
+        match text {
+            "framebuffer" => Some(ArtworkScale::Framebuffer),
+            "4:3" => Some(ArtworkScale::FourThree),
+            "16:9" => Some(ArtworkScale::SixteenNine),
+            _ => None,
+        }
+    }
+
+    fn index(self) -> usize {
+        ArtworkScale::ALL
+            .iter()
+            .position(|&scale| scale == self)
+            .expect("every artwork scale is listed")
+    }
+
+    /// Horizontal scale in framebuffer coordinates that makes source
+    /// artwork retain its own aspect ratio on the selected physical display.
+    fn horizontal(self, width: u32, height: u32) -> f32 {
+        let display_aspect = match self {
+            ArtworkScale::Framebuffer => return 1.0,
+            ArtworkScale::FourThree => 4.0 / 3.0,
+            ArtworkScale::SixteenNine => 16.0 / 9.0,
+        };
+        assert!(
+            width > 0 && height > 0,
+            "framebuffer dimensions are non-zero"
+        );
+        (width as f32 / height as f32) / display_aspect
+    }
+}
+
 /// What left and right do while browsing.
 ///
 /// Speed is how Degauss always behaved and stays the default. The other
@@ -1021,6 +1089,7 @@ pub struct App {
 
     speed: usize,
     show_art: bool,
+    artwork_scale: ArtworkScale,
     show_stats: bool,
     show_hidden: bool,
     /// Every system found, before hiding is applied. `systems` is the
@@ -1229,6 +1298,11 @@ impl App {
             .and_then(Horizontal::parse)
             .or_else(|| Horizontal::parse(&config.app.left_right))
             .unwrap_or_default();
+        let artwork_scale = settings
+            .artwork_scale
+            .as_deref()
+            .and_then(ArtworkScale::parse)
+            .unwrap_or_default();
         // Margins are saved when changed and read back here. Without this the
         // Options screen would show the saved figure while the screen kept
         // the one from the config file, and the two would disagree.
@@ -1275,6 +1349,7 @@ impl App {
                 .unwrap_or(SPEED_START)
                 .min(SPEED_STEPS.len() - 1),
             show_art: settings.show_art.unwrap_or(true),
+            artwork_scale,
             show_stats: settings.show_stats.unwrap_or(config.app.show_stats),
             show_hidden: settings.show_hidden.unwrap_or(false),
             all_systems: Vec::new(),
@@ -1609,7 +1684,7 @@ impl App {
         if self.screen == Screen::Advanced {
             &ADVANCED
         } else {
-            &OPTIONS
+            OPTIONS
         }
     }
 
@@ -3361,6 +3436,12 @@ impl App {
                 self.settings.show_art = Some(self.show_art);
                 self.touch_selection();
             }
+            OptionId::ArtworkScale => {
+                let at = step(self.artwork_scale.index(), delta, ArtworkScale::ALL.len());
+                self.artwork_scale = ArtworkScale::ALL[at];
+                self.settings.artwork_scale = Some(self.artwork_scale.setting().to_string());
+                self.touch_selection();
+            }
             OptionId::ShowStats => {
                 self.show_stats = !self.show_stats;
                 self.settings.show_stats = Some(self.show_stats);
@@ -3520,6 +3601,7 @@ impl App {
                 None => "Standard".to_string(),
             },
             OptionId::ShowArt => on_off(self.show_art),
+            OptionId::ArtworkScale => self.artwork_scale.shown().to_string(),
             OptionId::ShowStats => on_off(self.show_stats),
             OptionId::Present => capitalised(self.present_label),
             OptionId::ShowHidden => on_off(self.show_hidden),
@@ -4411,9 +4493,9 @@ impl App {
         self.open_system.as_deref() == Some(FAVORITES_ID)
     }
 
-    /// The picture, the words under it, and whether the heart should stand
-    /// in for both.
-    fn current_art(&self) -> (Option<PathBuf>, String, bool) {
+    /// The picture, the words under it, whether the heart should stand in
+    /// for both, and whether the picture is game artwork rather than a logo.
+    fn current_art(&self) -> (Option<PathBuf>, String, bool, bool) {
         match (self.screen, self.browsing) {
             (Screen::Browse, Browsing::Games) => {
                 match self.here.get(self.game_list.selected()) {
@@ -4423,6 +4505,8 @@ impl App {
                         // name is already the row: the mark says more.
                         let heart =
                             self.in_favorites() && matches!(row.kind, browse::Kind::Enter(_));
+                        let game_art =
+                            matches!(&row.kind, browse::Kind::Play(_)) && row.cover.is_some();
                         (
                             row.cover.clone().or_else(|| {
                                 if heart {
@@ -4434,9 +4518,10 @@ impl App {
                             }),
                             row.name.clone(),
                             heart,
+                            game_art,
                         )
                     }
-                    None => (None, String::new(), false),
+                    None => (None, String::new(), false, false),
                 }
             }
             (Screen::Browse, Browsing::Systems) => {
@@ -4444,9 +4529,9 @@ impl App {
                     Some(system) => {
                         let heart = system.def.id == FAVORITES_ID;
                         let logo = if heart { None } else { system.logo() };
-                        (logo, system.name().to_string(), heart)
+                        (logo, system.name().to_string(), heart, false)
                     }
-                    None => (None, String::new(), false),
+                    None => (None, String::new(), false, false),
                 }
             }
             (Screen::Browse, Browsing::Categories) => {
@@ -4458,12 +4543,12 @@ impl App {
                         } else {
                             self.category_logo(name)
                         };
-                        (logo, name.clone(), heart)
+                        (logo, name.clone(), heart, false)
                     }
-                    None => (None, String::new(), false),
+                    None => (None, String::new(), false, false),
                 }
             }
-            _ => (None, String::new(), false),
+            _ => (None, String::new(), false, false),
         }
     }
 
@@ -4489,9 +4574,15 @@ impl App {
         }
 
         let started = Instant::now();
-        let (path, caption, heart) = self.current_art();
+        let (path, caption, heart, game_art) = self.current_art();
         self.ui.set_art_caption(SharedString::from(caption));
         self.ui.set_art_heart(heart);
+        self.ui.set_art_scale_x(artwork_horizontal(
+            self.artwork_scale,
+            self.width,
+            self.height,
+            game_art,
+        ));
         match path.and_then(|path| self.cover_for(&path)) {
             Some(image) => {
                 self.ui.set_art(image);
@@ -4521,6 +4612,7 @@ impl App {
                         favorite: false,
                         cover: slint::Image::default(),
                         has_cover: false,
+                        art_scale_x: 1.0,
                         value: SharedString::new(),
                     });
                 }
@@ -4545,6 +4637,7 @@ impl App {
                             favorite: false,
                             cover,
                             has_cover,
+                            art_scale_x: 1.0,
                             value: SharedString::new(),
                         });
                     }
@@ -4573,6 +4666,7 @@ impl App {
                                 favorite: false,
                                 cover,
                                 has_cover,
+                                art_scale_x: 1.0,
                                 value: SharedString::new(),
                             });
                         }
@@ -4597,6 +4691,7 @@ impl App {
                                 favorite: false,
                                 cover,
                                 has_cover,
+                                art_scale_x: 1.0,
                                 value: match held {
                                     Some(games) => SharedString::from(games.to_string()),
                                     None => SharedString::new(),
@@ -4615,6 +4710,15 @@ impl App {
                             None
                         };
                         for index in range {
+                            let game_art = with_art
+                                && matches!(&self.here[index].kind, browse::Kind::Play(_))
+                                && self.here[index].cover.is_some();
+                            let art_scale_x = artwork_horizontal(
+                                self.artwork_scale,
+                                self.width,
+                                self.height,
+                                game_art,
+                            );
                             let wanted = if with_art {
                                 // Inside favourites a folder is a shelf the
                                 // user made, and the panel marks it with a
@@ -4651,6 +4755,7 @@ impl App {
                                 favorite: row.favorite,
                                 cover,
                                 has_cover,
+                                art_scale_x,
                                 // How much is in there, where somebody has
                                 // counted. Folders only: a game is one game.
                                 value: match row.below {
@@ -5373,12 +5478,24 @@ fn plain_row(title: &str, value: &str) -> Row {
         favorite: false,
         cover: slint::Image::default(),
         has_cover: false,
+        art_scale_x: 1.0,
         value: SharedString::from(value),
     }
 }
 
 fn on_off(value: bool) -> String {
     if value { "On" } else { "Off" }.to_string()
+}
+
+/// Apply display correction only to real game artwork. System and category
+/// logos, folder stand-ins and screensaver pictures retain their existing
+/// framebuffer geometry.
+fn artwork_horizontal(scale: ArtworkScale, width: u32, height: u32, is_game_art: bool) -> f32 {
+    if is_game_art {
+        scale.horizontal(width, height)
+    } else {
+        1.0
+    }
 }
 
 /// A setting's value with its first letter raised.
@@ -5598,6 +5715,55 @@ mod tests {
         for one in all {
             assert_eq!(Layout::parse(one.label()), Some(one));
         }
+    }
+
+    #[test]
+    fn every_artwork_scale_is_reachable_and_round_trips() {
+        // The option cycles only through ALL and persists the setting token.
+        // Missing either side would make a choice unreachable or forget it
+        // at the next start.
+        for (at, scale) in ArtworkScale::ALL.iter().copied().enumerate() {
+            assert_eq!(scale.index(), at);
+            assert_eq!(ArtworkScale::parse(scale.setting()), Some(scale));
+        }
+        assert_eq!(ArtworkScale::parse("nonsense"), None);
+        assert_eq!(
+            ArtworkScale::default(),
+            ArtworkScale::Framebuffer,
+            "an absent setting must retain the original geometry"
+        );
+    }
+
+    #[test]
+    fn artwork_scale_preserves_source_aspect_on_the_selected_display() {
+        // A 400x200 framebuffer has 2:1 pixel geometry. On a 4:3 display its
+        // pixels are narrower, so 4:3 source art needs a 1.5x raw width; on a
+        // 16:9 display it needs 1.125x. Both must appear physically 4:3.
+        let source_aspect = 4.0 / 3.0;
+        for (scale, display_aspect) in [
+            (ArtworkScale::FourThree, 4.0 / 3.0),
+            (ArtworkScale::SixteenNine, 16.0 / 9.0),
+        ] {
+            let raw_aspect = source_aspect * scale.horizontal(400, 200);
+            let physical_aspect = raw_aspect * display_aspect / 2.0;
+            assert!((physical_aspect - source_aspect).abs() < 0.0001);
+        }
+        assert!((ArtworkScale::FourThree.horizontal(400, 200) - 1.5).abs() < 0.0001);
+        assert!((ArtworkScale::SixteenNine.horizontal(400, 200) - 1.125).abs() < 0.0001);
+    }
+
+    #[test]
+    fn artwork_scale_does_not_change_logos_or_screensaver_geometry() {
+        // Callers classify only browse game covers as game artwork. Every
+        // logo, folder stand-in and screensaver picture passes false and
+        // keeps the same one-to-one framebuffer geometry in every mode.
+        for scale in ArtworkScale::ALL {
+            assert_eq!(artwork_horizontal(scale, 400, 200, false), 1.0);
+        }
+        assert_eq!(
+            artwork_horizontal(ArtworkScale::FourThree, 400, 200, true),
+            1.5
+        );
     }
 
     #[test]

--- a/src/options.rs
+++ b/src/options.rs
@@ -25,6 +25,9 @@ pub enum OptionId {
     /// Which named palette from the themes folder is on, if any.
     Theme,
     ShowArt,
+    /// Correct game artwork for the physical aspect ratio of a display
+    /// whose framebuffer pixels are not square.
+    ArtworkScale,
     ShowHidden,
     ShowEmpty,
     /// Show the group holding the cores that are not games.
@@ -62,7 +65,7 @@ pub enum OptionId {
 /// through lists, what the screen looks like, how a folder is ordered,
 /// what is shown at all, fitting the physical screen, the machine-wide
 /// acts, and the door to the diagnostics.
-pub const OPTIONS: [OptionId; 29] = [
+pub const OPTIONS: &[OptionId] = &[
     OptionId::Speed,
     OptionId::ArtLimit,
     OptionId::LeftRight,
@@ -71,6 +74,7 @@ pub const OPTIONS: [OptionId; 29] = [
     OptionId::Layout,
     OptionId::Font,
     OptionId::ShowArt,
+    OptionId::ArtworkScale,
     OptionId::ShowBar,
     OptionId::Spacer,
     OptionId::FavoritesFirst,
@@ -108,6 +112,7 @@ impl OptionId {
             OptionId::Font => "Text",
             OptionId::Theme => "Theme",
             OptionId::ShowArt => "Artwork",
+            OptionId::ArtworkScale => "Artwork scale factor",
             OptionId::ShowHidden => "Show what you hid",
             OptionId::ShowEmpty => "Show systems with no games",
             OptionId::ShowOther => "Show Other folder",
@@ -149,6 +154,9 @@ impl OptionId {
                 "A palette from the themes folder, read at start. Standard is degauss.toml."
             }
             OptionId::ShowArt => "Turn artwork off entirely.",
+            OptionId::ArtworkScale => {
+                "Correct game artwork for a 4:3 or 16:9 display. Logos and the screensaver stay unchanged."
+            }
             OptionId::ShowHidden => {
                 "Show what you hid yourself, from Hide this. Not the same as empty ones."
             }
@@ -243,7 +251,7 @@ mod tests {
         }
         let rows = OPTIONS.iter().filter(|o| **o != OptionId::Spacer).count();
         assert!(
-            rows <= 23,
+            rows <= 25,
             "the options list has grown to {rows} real rows; new diagnostics belong behind Developer"
         );
         for option in ADVANCED {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -57,6 +57,11 @@ pub struct Settings {
     pub hidden_paths: Vec<String>,
     pub show_stats: Option<bool>,
     pub show_art: Option<bool>,
+    /// How game artwork is horizontally corrected for the physical display:
+    /// "framebuffer", "4:3" or "16:9". Absent keeps the original
+    /// framebuffer-pixel behaviour.
+    #[serde(default)]
+    pub artwork_scale: Option<String>,
     pub present: Option<String>,
     /// Systems the user has hidden, by id. Hiding is per-system and
     /// reversible; nothing is ever removed from the table.
@@ -121,6 +126,7 @@ mod tests {
         let settings: Settings = toml::from_str(text).expect("v0.2.0 settings must keep parsing");
         assert_eq!(settings.font.as_deref(), Some("pixel"));
         assert_eq!(settings.layout.as_deref(), Some("details"));
+        assert!(settings.artwork_scale.is_none());
         assert_eq!(settings.overscan_x, Some(5));
         assert_eq!(settings.hidden, ["PDP1", "VC4000"]);
         assert_eq!(settings.folder_views.len(), 2);
@@ -148,6 +154,7 @@ mod tests {
             hidden: vec!["PSX".to_string()],
             art_limit: Some(0),
             layout: Some("covers".into()),
+            artwork_scale: Some("4:3".into()),
             left_right: Some("letter".into()),
             theme: Some("amber".into()),
             show_stats: Some(true),

--- a/ui/degauss.slint
+++ b/ui/degauss.slint
@@ -138,11 +138,49 @@ component DetailPanel inherits Rectangle {
     }
 }
 
+// Game artwork can be corrected for a physical display whose framebuffer
+// pixels are not square. A factor of one retains the original contain path;
+// other factors alter only the fitted width, without cropping the source.
+component ArtworkImage inherits Rectangle {
+    in property <image> source;
+    in property <bool> has-source;
+    in property <float> horizontal-scale: 1.0;
+
+    clip: true;
+    property <float> source-aspect: source.height > 0
+        ? (source.width / source.height) * horizontal-scale
+        : 1.0;
+    property <float> box-aspect: root.height > 0px ? root.width / root.height : 1.0;
+
+    if root.horizontal-scale == 1.0: Image {
+        source: root.source;
+        visible: root.has-source;
+        image-fit: contain;
+        width: parent.width;
+        height: parent.height;
+    }
+
+    if root.horizontal-scale != 1.0: Image {
+        source: root.source;
+        visible: root.has-source;
+        image-fit: fill;
+        width: root.source-aspect >= root.box-aspect
+            ? parent.width
+            : parent.height * root.source-aspect;
+        height: root.source-aspect >= root.box-aspect
+            ? parent.width / root.source-aspect
+            : parent.height;
+        x: (parent.width - self.width) / 2;
+        y: (parent.height - self.height) / 2;
+    }
+}
+
 struct Row {
     title: string,
     favorite: bool,
     cover: image,
     has-cover: bool,
+    art-scale-x: float,
     // Options rows carry their current value here; browse rows leave it empty.
     value: string,
 }
@@ -216,6 +254,7 @@ export component DegaussWindow inherits Window {
     // The large artwork: a screenshot, a system logo, or nothing.
     in property <image> art;
     in property <bool> has-art;
+    in property <float> art-scale-x: 1.0;
     in property <length> art-width;
     // Drawn in the artwork panel when there is no picture for this row and
     // no logo in the logos folder: the system or game name, set large.
@@ -528,10 +567,10 @@ export component DegaussWindow inherits Window {
                     background: root.c-surface;
                     property <length> panel: root.detail-height;
 
-                    Image {
+                    ArtworkImage {
                         source: root.art;
-                        visible: root.has-art;
-                        image-fit: contain;
+                        has-source: root.has-art;
+                        horizontal-scale: root.art-scale-x;
                         x: 1px;
                         y: 1px;
                         width: parent.width - 2px;
@@ -595,10 +634,10 @@ export component DegaussWindow inherits Window {
                     width: root.tile-width;
                     height: root.tile-height;
                     background: index == root.selected ? root.c-accent : root.c-background;
-                    Image {
+                    ArtworkImage {
                         source: row.cover;
-                        visible: row.has-cover;
-                        image-fit: contain;
+                        has-source: row.has-cover;
+                        horizontal-scale: row.art-scale-x;
                         x: 2px;
                         y: 2px;
                         width: parent.width - 4px;
@@ -871,10 +910,10 @@ export component DegaussWindow inherits Window {
                 width: root.tile-width;
                 height: parent.height - parent.panel;
 
-                Image {
+                ArtworkImage {
                     source: row.cover;
-                    visible: row.has-cover;
-                    image-fit: contain;
+                    has-source: row.has-cover;
+                    horizontal-scale: row.art-scale-x;
                     x: root.pad;
                     y: root.pad;
                     width: parent.width - root.pad * 2;


### PR DESCRIPTION
## What this changes

- Adds **Artwork scale factor** after **Artwork**, with **Framebuffer**, **4:3** and **16:9** choices.
- Keeps **Framebuffer** as the default when the setting is absent, preserving existing installations.
- Corrects game-art width for the selected physical display shape in Details, Tiled and Carousel.
- Leaves category logos, system logos, folder stand-ins and the screensaver unchanged.
- Persists the choice in `settings.toml` as an optional field older installations do not need.

## Why

Closes #23.

A framebuffer such as 400x200 can be displayed at a different physical aspect ratio. The new modes compensate for that pixel shape without cropping the game artwork.

## Merge order

This is a stacked PR based on #26. Merge #26 first. After #26 reaches `main`, change this PR's base to `main`; its diff then contains only the artwork-scaling feature.

## How it was checked

- [x] `cargo test` (268 passed with both features present)
- [x] `cargo fmt --check`
- [x] `cargo clippy --target armv7-unknown-linux-musleabihf --all-targets -j 1 -- -D warnings`
- [x] Run on a real MiSTer
- [x] On a CRT, if it changes anything drawn
- [x] `./scripts/rehearse-migration.sh` (all 9 rehearsals passed)
- [x] Details, Tiled and Carousel rendered and inspected at 400x200
- [x] Both new Options rows rendered and inspected together at 352x240

## Licensing

By opening this pull request I agree that my contribution is licensed under
the [PolyForm Noncommercial License 1.0.0](../LICENSE), the same licence as
the rest of Degauss, and that I have the right to license it that way.

Changes to `MiSTer_Degauss` do not belong here: it is a separate GPLv3
program in its own repository,
[Degauss-Main](https://github.com/giancarloerra/Degauss-Main).

- [x] I agree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Artwork Scale Factor option supporting framebuffer, 4:3 and 16:9 display modes.
  * Artwork scaling preferences are saved and restored automatically.
  * Display correction applies to game artwork while logos, folder images and screensaver artwork retain standard scaling.
  * Artwork is centred and clipped appropriately when corrected for different aspect ratios.

* **Documentation**
  * Added guidance explaining artwork scaling behaviour and supported display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->