### PR TITLE
Restore Linux 6.18 startup, ZIP libraries and core selection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Unified patch context prefixes are format bytes; validate whitespace in the applied source.
+support/ra-main/frontend.patch whitespace=-blank-at-eol,-space-before-tab
+support/ra-main/tls.patch whitespace=-blank-at-eol,-space-before-tab
+support/ra-main/controller.patch whitespace=-blank-at-eol,-space-before-tab

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,8 @@ jobs:
       - run: rustup component add clippy rustfmt
       - run: rustup target add armv7-unknown-linux-musleabihf
       - run: cargo fmt --check
+      - name: Check RA release delivery compatibility
+        run: python3 scripts/test-ra-release.py
       # Four baked typefaces make the generated interface source about
       # 258 MB, and one rustc peaks near 13 GB compiling it. The runner has
       # 16 GB of memory plus its own 4 GB swapfile, and --all-targets runs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 name: release
 
-# Builds both binaries and attaches a ready-to-copy archive to the release
-# for the tag that triggered it.
-#
-# Two binaries, because Degauss is two programs: the frontend, built here,
-# and MiSTer_Degauss, the GPLv3 fork of MiSTer Main that hands it the screen.
-# The fork lives in its own repository under its own licence and is built in
-# its own job below.
+# Build the frontend and both Main integrations, including corresponding RA
+# source and its verified CA bundle. The RA executable has its own name so the
+# upstream RA updater cannot replace it.
 on:
   push:
     tags:
@@ -80,9 +76,29 @@ jobs:
             MiSTer_Degauss
             MiSTer_Degauss.sha
 
+  ra-main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Build and test pinned RA Main
+        run: ./scripts/build-ra-main.sh ra-build
+      - name: Check the RA binary
+        run: |
+          file ra-build/MiSTer_RA_Degauss | tee /dev/stderr \
+            | grep -qE "ELF 32-bit LSB (pie )?executable, ARM"
+      - uses: actions/upload-artifact@v6
+        with:
+          name: MiSTer_RA_Degauss
+          path: |
+            ra-build/MiSTer_RA_Degauss
+            ra-build/MiSTer_RA_Degauss.cacert.pem
+            ra-build/MiSTer_RA_Degauss.SOURCE.txt
+            ra-build/MiSTer_RA_Degauss-source.tar.gz
+            ra-build/MiSTer_RA_Degauss-source.tar.gz.sha256
+
   mister:
     runs-on: ubuntu-latest
-    needs: main-fork
+    needs: [main-fork, ra-main]
     steps:
       - uses: actions/checkout@v5
 
@@ -118,6 +134,12 @@ jobs:
           name: MiSTer_Degauss
           path: fork
 
+      - name: Collect RA Main and corresponding source
+        uses: actions/download-artifact@v7
+        with:
+          name: MiSTer_RA_Degauss
+          path: ra
+
       - name: Package
         id: package
         run: |
@@ -126,6 +148,9 @@ jobs:
           mkdir -p "dist/${NAME}/degauss"
           cp -R deploy/Scripts "dist/${NAME}/Scripts"
           install -m 0755 fork/MiSTer_Degauss "dist/${NAME}/degauss/MiSTer_Degauss"
+          install -m 0755 ra/MiSTer_RA_Degauss "dist/${NAME}/degauss/MiSTer_RA_Degauss"
+          cp ra/MiSTer_RA_Degauss.cacert.pem ra/MiSTer_RA_Degauss.SOURCE.txt "dist/${NAME}/degauss/"
+          cp ra/MiSTer_RA_Degauss-source.tar.gz ra/MiSTer_RA_Degauss-source.tar.gz.sha256 dist/
           cp README.md LICENSE "dist/${NAME}/"
           # The fork is GPLv3 and its source has to be findable from the
           # thing that ships its binary.
@@ -151,10 +176,14 @@ jobs:
             && sha256sum "${NAME}.zip" > "${NAME}.zip.sha256")
           echo "name=${NAME}" >> "$GITHUB_OUTPUT"
 
-      - name: Check the archive holds both binaries
+      - name: Check the archive holds all binaries and the RA bundle
         run: |
           unzip -l dist/*.zip | grep -q "degauss/MiSTer_Degauss"
           unzip -l dist/*.zip | grep -q "Scripts/.config/degauss/degauss"
+          unzip -l dist/*.zip | grep -q "degauss/MiSTer_RA_Degauss.cacert.pem"
+          unzip -l dist/*.zip | grep -q "degauss/MiSTer_RA_Degauss.SOURCE.txt"
+          unzip -l dist/*.zip | grep -q "degauss/MiSTer_RA_Degauss$"
+          (cd dist && sha256sum -c MiSTer_RA_Degauss-source.tar.gz.sha256)
 
       # Where somebody who downloaded the two files stands, which is the only
       # place the checksum is ever used.
@@ -168,13 +197,14 @@ jobs:
 
       # The Downloader database, so `update_all` can keep Degauss current.
       # It names every file with its hash and where to fetch it, which is why
-      # the two built binaries are attached to the release on their own as
+      # the built binaries and RA bundle are attached to the release on their own as
       # well as inside the archive.
       - name: Build the Downloader database
         run: |
           cp deploy/Scripts/.config/degauss/degauss dist/degauss
           cp fork/MiSTer_Degauss dist/MiSTer_Degauss
-          python3 scripts/make-db.py "${GITHUB_REF_NAME}" deploy fork/MiSTer_Degauss dist/degauss.json
+          cp ra/MiSTer_RA_Degauss ra/MiSTer_RA_Degauss.cacert.pem ra/MiSTer_RA_Degauss.SOURCE.txt dist/
+          python3 scripts/make-db.py "${GITHUB_REF_NAME}" deploy fork/MiSTer_Degauss dist/degauss.json --ra-dir ra
           (cd dist && zip -q degauss.json.zip degauss.json && rm degauss.json)
 
       - name: Check the database is well formed
@@ -186,6 +216,9 @@ jobs:
           assert db["v"] == 1, db["v"]
           assert db["db_id"] == "degauss", db["db_id"]
           assert db["files"], "no files"
+          for name in ("MiSTer_RA_Degauss", "MiSTer_RA_Degauss.cacert.pem", "MiSTer_RA_Degauss.SOURCE.txt"):
+              assert "degauss/" + name in db["files"], name
+          assert "MiSTer_RA" not in db["files"], "must not overwrite upstream RA Main"
           for path, entry in db["files"].items():
               for field in ("hash", "size", "url"):
                   assert field in entry, (path, field)
@@ -206,3 +239,7 @@ jobs:
             dist/*.sha256
             dist/degauss
             dist/MiSTer_Degauss
+            dist/MiSTer_RA_Degauss
+            dist/MiSTer_RA_Degauss.cacert.pem
+            dist/MiSTer_RA_Degauss.SOURCE.txt
+            dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,9 @@ jobs:
           assert db["files"], "no files"
           for name in ("MiSTer_RA_Degauss", "MiSTer_RA_Degauss.cacert.pem", "MiSTer_RA_Degauss.SOURCE.txt"):
               assert "degauss/" + name in db["files"], name
-          assert "MiSTer_RA" not in db["files"], "must not overwrite upstream RA Main"
+          import posixpath
+          upstream = [p for p in db["files"] if posixpath.basename(p) == "MiSTer_RA"]
+          assert not upstream, ("must not overwrite upstream RA Main", upstream)
           for path, entry in db["files"].items():
               for field in ("hash", "size", "url"):
                   assert field in entry, (path, field)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "degauss"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytemuck",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "degauss"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.96"
 description = "A fast, software-rendered frontend for MiSTer FPGA"

--- a/README.md
+++ b/README.md
@@ -318,6 +318,28 @@ full one of 97k+ games. It never does that again on its own: **Options → Rebui
 is how you tell it the card has changed (for example after adding new games). New images and metadata are read on the fly.
 Adding games to one system does not need the whole card read again:
 **X → Rebuild this system list** inside that system reads just its folders.
+A successful rebuild reflects additions and removals. An unreadable folder or archive
+reports its error and keeps that system's previous complete list.
+
+ZIP archives open as folders, including their internal subfolders. ZIP64 is supported
+within the documented bounds. Metadata for a multi-game archive identifies each game
+by its full archive/member path; single-game archives retain legacy archive-level
+metadata. See [ZIP libraries](docs/zip-libraries.md) for details and launch limits.
+
+For a system with multiple installed core versions, **X → Core Version** chooses
+Default, Standard, RetroAchievements, or a matching Unstable build. The choice is
+saved for that system and applies to its games and recognized favourites.
+**Use Default Core Version** removes that override. Default follows **Core preference**
+and never automatically chooses an Unstable build. A missing explicitly selected
+version produces an error; it does not launch another version.
+
+The **Unstable** group browses installed `_Unstable` cores by their full build names.
+RetroAchievements requires a compatible RA installation, including its Main profile.
+Degauss releases include a separate RA Main that retains Frontend and the saved
+shortcut without being overwritten by the upstream RA updater. Select it in the
+RA Main profile as described in the [RA Main integration](support/ra-main/README.md). See the
+[small hardware test procedure](docs/testing/library-compatibility-hardware.md)
+for setup and launch/return checks.
 
 ## Views
 
@@ -379,6 +401,8 @@ One screen holds everything, in groups a blank row apart, top to bottom:
 | Random game behaviour | Whether a random pick starts the game, or only moves to it so you can look first |
 | Show Other folder | Show the Other group, the cores that are not games |
 | Show Utility folder | Show the Utility group, test patterns and measurement cores |
+| Show Unstable folder | Show installed Unstable cores. On by default |
+| Core preference | Standard first (default) or RetroAchievements first. Used by systems whose Core Version is Default; the other version is used only when the preferred version is absent |
 | Show systems with no games | Systems and folders holding nothing are left out on their own; this shows them. Off by default |
 | Show what you hid | Show what you hid yourself with **Hide this** |
 | Unhide everything | Press A and confirm to put back everything you hid yourself, in every folder and every system. Left and right do nothing |
@@ -658,6 +682,11 @@ filesystem-derived game name and leaves that artwork or field empty. It never
 fills the gap from the gamelist or ScreenScraper. Publisher and game language
 also remain empty because the database format does not provide them. Folder
 rows, system logos and category images remain independent of this choice.
+
+MRA entries are matched by their `<setname>`, including MGLs that point to an
+MRA. Large embedded hexadecimal ROM, patch and cheat payloads do not impose a
+whole-file size limit on that lookup. XML identity metadata remains bounded to
+1 MiB; this is separate from artwork image limits.
 
 Selecting an Artwork Pack never edits or removes the existing gamelist or its
 media. Choose **Gamelist** again to restore them immediately. While Artwork

--- a/README.md
+++ b/README.md
@@ -293,11 +293,6 @@ fb_terminal=1
 
 It is enabled by default in the standard MiSTer configuration.
 
-Framebuffer access adapts automatically to MiSTer Linux 5.15 and 6.18. No
-additional setting or data migration is needed. See the
-[framebuffer compatibility checks](docs/testing/framebuffer-compatibility.md)
-for diagnostics and kernel validation.
-
 Degauss can browse the collection and launch games normally when started this way. However, after leaving a game/core, MiSTer will return to the stock menu instead of reopening Degauss automatically. There's not going to be the Frontend option anymore in the cores menu, and you'll need to re-launch Degauss from the OSD if you want to go back to it.
 
 Doing it in this way, the installed `/media/fat/degauss/MiSTer_Degauss` file is not used.
@@ -326,12 +321,22 @@ Adding games to one system does not need the whole card read again:
 A successful rebuild reflects additions and removals. An unreadable folder or archive
 reports its error and keeps that system's previous complete list.
 
-ZIP archives open as folders, including their internal subfolders. ZIP64 is supported
+### ZIP libraries
+
+ZIP archives open as folders, including their internal subfolders, without extracting
+the library. Systems that already launch ZIP files as individual games keep that
+behaviour. ZIP64 is supported
 within the documented bounds. Metadata for a multi-game archive identifies each game
 by its full archive/member path; single-game archives retain legacy archive-level
 metadata. See [ZIP libraries](docs/zip-libraries.md) for details and launch limits.
 
-For a system with multiple installed core versions, **X → Core Version** chooses
+### RetroAchievements and Unstable cores
+
+Installed RetroAchievements and Unstable cores can be browsed even when there is
+no standard version of that core. Degauss discovers these installations; it does
+not install the cores or configure a RetroAchievements account.
+
+**X → Core Version** chooses
 Default, Standard, RetroAchievements, or a matching Unstable build. The choice is
 saved for that system and applies to its games and recognized favourites.
 **Use Default Core Version** removes that override. Default follows **Core preference**
@@ -342,9 +347,9 @@ The **Unstable** group browses installed `_Unstable` cores by their full build n
 RetroAchievements requires a compatible RA installation, including its Main profile.
 Degauss releases include a separate RA Main that retains Frontend and the saved
 shortcut without being overwritten by the upstream RA updater. Select it in the
-RA Main profile as described in the [RA Main integration](support/ra-main/README.md). See the
-[small hardware test procedure](docs/testing/library-compatibility-hardware.md)
-for setup and launch/return checks.
+RA Main profile as described in the [RA Main installation instructions](support/ra-main/README.md#installation-and-updates).
+It uses the same saved Frontend shortcut as normal Degauss Main. Unstable cores
+running under Degauss Main already have the Frontend menu and shortcut.
 
 ## Views
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,11 @@ fb_terminal=1
 
 It is enabled by default in the standard MiSTer configuration.
 
+Framebuffer access adapts automatically to MiSTer Linux 5.15 and 6.18. No
+additional setting or data migration is needed. See the
+[framebuffer compatibility checks](docs/testing/framebuffer-compatibility.md)
+for diagnostics and kernel validation.
+
 Degauss can browse the collection and launch games normally when started this way. However, after leaving a game/core, MiSTer will return to the stock menu instead of reopening Degauss automatically. There's not going to be the Frontend option anymore in the cores menu, and you'll need to re-launch Degauss from the OSD if you want to go back to it.
 
 Doing it in this way, the installed `/media/fat/degauss/MiSTer_Degauss` file is not used.

--- a/assets/systems.toml
+++ b/assets/systems.toml
@@ -1951,7 +1951,7 @@ delay = 1
 # it is.
 name = "Cores"
 id = "OtherCores"
-folders = ["/media/fat/_Other"]
+folders = ["_Other"]
 rbf = ""
 extensions = ["rbf", "mra", "mgl"]
 category = "Other"
@@ -1964,10 +1964,19 @@ category = "Other"
 # it describes itself.
 name = "Cores"
 id = "UtilityCores"
-folders = ["/media/fat/_Utility"]
+folders = ["_Utility"]
 rbf = ""
 extensions = ["rbf", "mra", "mgl"]
 category = "Utility"
+
+[[systems]]
+# Resolved against menu_root at runtime, including older user-edited tables.
+name = "Cores"
+id = "UnstableCores"
+folders = ["_Unstable"]
+rbf = ""
+extensions = ["rbf", "mra", "mgl"]
+category = "Unstable"
 
 [[systems]]
 # MiSTer's own favourites folder, exactly as its favourites script keeps
@@ -1976,7 +1985,7 @@ category = "Utility"
 # listed last because it is not a machine.
 name = "Favorites"
 id = "Favorites"
-folders = ["/media/fat/_@Favorites"]
+folders = ["_@Favorites"]
 rbf = ""
 extensions = ["mgl", "mra", "rbf"]
 category = "Favorites"

--- a/deploy/Scripts/.config/degauss/systems.toml
+++ b/deploy/Scripts/.config/degauss/systems.toml
@@ -1951,7 +1951,7 @@ delay = 1
 # it is.
 name = "Cores"
 id = "OtherCores"
-folders = ["/media/fat/_Other"]
+folders = ["_Other"]
 rbf = ""
 extensions = ["rbf", "mra", "mgl"]
 category = "Other"
@@ -1964,10 +1964,19 @@ category = "Other"
 # it describes itself.
 name = "Cores"
 id = "UtilityCores"
-folders = ["/media/fat/_Utility"]
+folders = ["_Utility"]
 rbf = ""
 extensions = ["rbf", "mra", "mgl"]
 category = "Utility"
+
+[[systems]]
+# Resolved against menu_root at runtime, including older user-edited tables.
+name = "Cores"
+id = "UnstableCores"
+folders = ["_Unstable"]
+rbf = ""
+extensions = ["rbf", "mra", "mgl"]
+category = "Unstable"
 
 [[systems]]
 # MiSTer's own favourites folder, exactly as its favourites script keeps
@@ -1976,7 +1985,7 @@ category = "Utility"
 # listed last because it is not a machine.
 name = "Favorites"
 id = "Favorites"
-folders = ["/media/fat/_@Favorites"]
+folders = ["_@Favorites"]
 rbf = ""
 extensions = ["mgl", "mra", "rbf"]
 category = "Favorites"

--- a/docs/testing/framebuffer-compatibility.md
+++ b/docs/testing/framebuffer-compatibility.md
@@ -1,0 +1,47 @@
+# Framebuffer compatibility
+
+MiSTer Linux 6.18's framebuffer driver does not supply the mapping callback
+required by the kernel. Mapping `/dev/fb0` therefore returns `ENODEV`.
+See the [kernel framebuffer entry point](https://github.com/MiSTer-devel/Linux-Kernel_MiSTer/blob/33a0521fd46b3991ec3a882f659bceb2c1cb4399/drivers/video/fbdev/core/fb_chrdev.c)
+and [MiSTer framebuffer driver](https://github.com/MiSTer-devel/Linux-Kernel_MiSTer/blob/33a0521fd46b3991ec3a882f659bceb2c1cb4399/drivers/video/fbdev/MiSTer_fb.c).
+
+Degauss first tries the existing framebuffer mapping. Only `ENODEV` selects
+the alternative `/dev/mem` mapping, using the physical address and capacity
+reported by the driver. Other failures retain their original cause. A kernel
+that restores native mapping automatically uses it again. The framebuffer
+descriptor stays open for vertical synchronization.
+
+Normal startup records the mapping source in `/tmp/degauss.log`. The existing
+`--selftest` records it in `/tmp/degauss-selftest.log`. No new setting, Main
+replacement, cache rebuild or settings reset is required for this fix.
+
+## Acceptance checks
+
+Use an isolated library containing a few known-working games. Preserve the
+normal launcher, configuration and boot files before changing a test setup.
+Kernel installation and reboot require separate device authorization.
+
+1. On Linux 5.15, independently probe native framebuffer mapping and confirm
+   it succeeds. Start the production ARM binary through Degauss Main and
+   through the Scripts menu. Confirm the log reports native mapping.
+2. Verify the first frame, input, list and artwork views, game launch, exit
+   and return. Run `--selftest --frames 120` against the same isolated library
+   and inspect both direct and staged presentation, including their timings.
+3. On Linux 6.18, independently confirm native mapping returns `ENODEV`.
+   Repeat the same launch, rendering, input, return and self-test checks;
+   confirm the diagnostic identifies the `/dev/mem` mapping.
+4. Exercise each connected output and geometry. Record which pixel format
+   the driver actually reports. Host format tests do not establish an
+   unavailable physical RGB565 or CRT output.
+5. In a private mount namespace, make `/dev/mem` unmappable without changing
+   global device permissions. Startup must fail with both the original
+   framebuffer `ENODEV` and the failing `/dev/mem` operation. Restore the
+   ordinary namespace and confirm recovery.
+6. Restore the normal launcher and configuration and verify their original
+   bytes. Confirm normal startup, saved controls and game return still work.
+
+The surface tests cover native success without fallback, error selection,
+physical range and alignment checks, overflow, both pixel formats, separate
+pixel and unmap addresses, mapping cleanup and actionable failure causes.
+Run the Linux-specific cases on Linux, including the ARM target. They do not
+replace the two real-kernel checks above.

--- a/docs/testing/framebuffer-compatibility.md
+++ b/docs/testing/framebuffer-compatibility.md
@@ -15,6 +15,12 @@ Normal startup records the mapping source in `/tmp/degauss.log`. The existing
 `--selftest` records it in `/tmp/degauss-selftest.log`. No new setting, Main
 replacement, cache rebuild or settings reset is required for this fix.
 
+When no valid presentation setting or explicit `--present` argument is supplied,
+physical `/dev/mem` mapping uses staged rendering. Native fbdev mapping keeps its
+existing direct default. Saved settings override this default; `--present`
+overrides both. The Options label follows the selected mode, and the runtime
+default is not written to settings.
+
 ## Acceptance checks
 
 Use an isolated library containing a few known-working games. Preserve the
@@ -29,7 +35,12 @@ Kernel installation and reboot require separate device authorization.
    and inspect both direct and staged presentation, including their timings.
 3. On Linux 6.18, independently confirm native mapping returns `ENODEV`.
    Repeat the same launch, rendering, input, return and self-test checks;
-   confirm the diagnostic identifies the `/dev/mem` mapping.
+   confirm the diagnostic identifies the `/dev/mem` mapping. With no saved
+   presentation mode, confirm normal startup uses staged presentation and its
+   Options label agrees. Check saved direct/staged settings and explicit
+   `--present direct` / `--present staged` precedence, including restart; no
+   implicit default should be added to the settings file. On native fbdev,
+   absent settings must continue to select direct presentation.
 4. Exercise each connected output and geometry. Record which pixel format
    the driver actually reports. Host format tests do not establish an
    unavailable physical RGB565 or CRT output.

--- a/docs/testing/library-compatibility-hardware.md
+++ b/docs/testing/library-compatibility-hardware.md
@@ -1,0 +1,84 @@
+# Library compatibility hardware checks
+
+Use one supported system and two or three small, known-working games in an isolated test folder. Keep the ordinary game files. Create only small copies for ZIP checks. Exercise artificial large offsets and malformed ZIP64 combinations on the host. An optional full collection check comes after the small checks, using a separate authorized test folder.
+
+Use actual standard, RetroAchievements and nightly cores for the selected system. Dummy RBF files and renamed copies of a standard core do not establish variant behavior.
+
+## Main switching and return controls
+
+Both Degauss Main and RetroAchievements Main restart into the executable selected by the loaded core's INI configuration, retaining the core and MGL arguments. An RA profile can select `degauss/MiSTer_RA_Degauss` while the normal default continues to select Degauss Main. Follow the [profile setup instructions](../../support/ra-main/README.md) to preserve existing overrides and avoid an upstream installer appending a conflicting wildcard profile. The RA launcher must carry the corresponding `setname` and actual RA core path. Sources: [Degauss executable switching](https://github.com/giancarloerra/Degauss-Main/blob/0651979d53f570c29f8772e124ae603297830954/user_io.cpp#L1488), [RA executable switching](https://github.com/odelot/Main_MiSTer/blob/48e32b43ed85b046c7cd41bce756b7bb1679782b/user_io.cpp#L1482), [RA restart arguments](https://github.com/odelot/Main_MiSTer/blob/48e32b43ed85b046c7cd41bce756b7bb1679782b/fpga_io.cpp#L620), [RA launcher/profile construction](https://github.com/sage2050/MiSTer_RetroAchievements/blob/bc19dcab7c855dc55bf61e4025a2591cd9a9a5f5/Scripts/MiSTer_RA.sh#L485-L550).
+
+**For a Degauss Main installation, RA gameplay must retain Frontend and the existing saved shortcut.** Use the separately named [RA Main integration](../../support/ra-main/README.md) with its adjacent CA bundle. Preserve the upstream RA Main and back up any profile being changed. Verify both the Frontend System-menu action and the already configured shortcut. Open shortcut capture, cancel it with the supported controller action, then capture and save the existing shortcut again; verify its configuration bytes remain unchanged. Return must reopen Degauss and allow another ordinary game launch. Upstream RA Main alone lacks these additions: its short System-menu Reboot action loads `menu.rbf`, while holding it requests a cold reboot. Preserve that existing return action as well. Loading the menu core should reselect the default Main, but actual return to Degauss requires a hardware check. Sources: [RA System menu](https://github.com/odelot/Main_MiSTer/blob/48e32b43ed85b046c7cd41bce756b7bb1679782b/menu.cpp#L2938), [RA short Reboot action](https://github.com/odelot/Main_MiSTer/blob/48e32b43ed85b046c7cd41bce756b7bb1679782b/menu.cpp#L3247), [Degauss menu startup](https://github.com/giancarloerra/Degauss-Main/blob/0651979d53f570c29f8772e124ae603297830954/menu.cpp#L1126).
+
+## Prepare a reversible test
+
+1. Record the active Main arrangement and the exact selected system's core/launcher paths. Save original bytes and hashes for files the test will change. Keep credentials and unrelated configuration out of diagnostic output.
+2. Preserve standard Main and Degauss Main. Stage RA Main under its separate name, the selected actual RA core, its launcher and only the required profile override. Preserve existing achievement configuration and sound. A one-system check does not require an all-core installer.
+3. Obtain the selected actual nightly from its official release and retain its complete filename. Compare downloaded bytes with the release digest before transfer. Reference releases include [RA Main](https://github.com/odelot/Main_MiSTer/releases), [RA NES](https://github.com/odelot/NES_MiSTer/releases) and [NES nightlies](https://github.com/MiSTer-unstable-nightlies/NES_MiSTer/releases/tag/unstable-builds).
+4. Transfer through a unique temporary file, verify the complete bytes on the device, then rename into place. Keep an exact record of introduced files for rollback.
+5. Use an isolated game directory and disposable Favorites. Never replace a real game library, rewrite existing Favorites or use real Favorites as destructive fixtures.
+
+When the selected system already has every variant installed, exercise variant-only and missing-core cases by temporarily relocating only its relevant core/launcher files outside scanned directories. Keep each original file's name, bytes and destination recorded. Do not rename a different variant to impersonate the missing one. Restore the files after each arrangement.
+
+## Core availability and saved choices
+
+Verify the selected core and running Main, game boot, input, picture, sound and return behavior for each successful launch. A visible menu row, generated MGL or completed FIFO write proves only that stage.
+
+| Arrangement | Checks |
+|---|---|
+| Standard only | Both global Core preference values use the installed standard core. Existing ordinary launches and Favorites remain unchanged. |
+| RA only | The system remains in its normal category. Default selection can launch the installed RA core with either global preference. Return through Frontend and the existing shortcut when using the Degauss Main integration; preserve the upstream short Reboot action. |
+| Standard and RA | Standard first and RetroAchievements first select their respective variants. Core Version can explicitly select each independently of the global preference. |
+| Nightly only | The nightly remains reachable in Unstable when that group is enabled. An explicit saved nightly choice launches its exact path. |
+| Standard alongside nightly | Ordinary default launch continues to use the default selection. An explicit nightly choice selects the full named build. Direct Unstable launch selects that exact row. |
+| All selected variants present | Switch among Standard, RetroAchievements and the exact nightly through Core Version. Confirm each launch and return. |
+| Saved variant missing | Temporarily remove the specifically selected core. Launch must report that selection as unavailable, without silently choosing a different core. |
+| No selected system core | Launch reports the missing core before handoff. Restore one real variant and verify recovery. |
+
+For each explicit per-system choice, leave the system, restart Degauss and verify that Core Version and the next launch retain the exact selection. A nightly choice must keep its complete path/build suffix, including when another nightly is added. Changing one system must not change another system's choice.
+
+Use **Use Default Core Version**, restart again and verify that the saved override is removed and normal default selection applies. This reset must remain available when a previously selected core is missing.
+
+Toggle **Show Unstable folder** off and on, then restart. Verify that visibility persists, build names stay distinct, and normal categories and ordinary game lists remain present. Visibility is a browsing preference; it must not rewrite a saved core path or silently change the chosen variant.
+
+## Favorites and descriptions
+
+Use the same test game through ordinary browsing, an existing Favorite, and a newly created disposable Favorite. Verify metadata, artwork, membership/removal identity, core choice and launch. Launch the newly created ordinary MGL from the stock menu as well. Existing Favorite file bytes must remain unchanged.
+
+Cover a bare target and an absolute target, plus an established parent-relative or custom MGL when available. Include a ZIP-member Favorite from the small library below. If the selected system has companion/reset actions, confirm they survive variant selection and actual launch.
+
+Provide synthetic metadata with a long first paragraph and later paragraphs containing `&amp;quot;`. Verify the first description line remains nonempty and retains the expected 160-character prefix plus truncation marker through source browsing, rebuilt cache, Favorites and restart. Double escaping in a later paragraph must not erase the description. Check the other details and external artwork independently.
+
+## Small ZIP library
+
+Use at most two or three games total, reusing the same permitted game bytes for these arrangements. Keep an uncompressed copy available as the baseline.
+
+1. **Single member:** make a small stored ZIP with one supported game and optional readme. Existing archive-level metadata must still bind. Launch and return using the selected ordinary core.
+2. **Multiple members:** make a small deflated ZIP with two supported members, including nested folders without explicit directory records. Use the same basename in two folders to verify distinct identities. Only exact `./archive.zip/folder/game.ext` metadata may bind these games; archive-level or basename-only metadata must not bleed across members.
+3. **Navigation and state:** browse root/nested folders, search, favorite, hide/unhide and restart. Verify exact member identity and saved position. Launch a filtered result whose numeric position differs in the unfiltered list; returning must reset search and select the same member. Include distinct Unicode directory names with identical lowercase forms and verify stable order across restart. Launch both root and nested members and a ZIP-member Favorite.
+4. **Replacement:** replace the disposable archive with a valid version that removes one member and adds another. Rebuild that system. The new contents replace the old list and unrelated systems remain unchanged.
+5. **Stale member:** select a member, then replace the archive with a valid version lacking it before confirmation. Confirm a specific visible failure before handoff. Repeat with the outer archive absent.
+6. **Corrupt archive:** truncate a disposable ZIP before rebuild. Expect the archive path and reason, with the previous valid cache and summary retained. Restore a valid archive and rebuild to verify recovery.
+7. **Pass-through:** when testing a system already configured to accept `zip`, verify the whole archive remains one game. Do not change production extensions merely to force this case.
+8. **Variants:** repeat a small supported ZIP-member launch with RA or a nightly alongside the standard core, and in the relevant variant-only arrangement. Verify the actual variant, not just the unchanged native target text.
+
+ZIP64 parsing, large offsets, high entry counts and malformed record combinations are exercised on the host. The small hardware library verifies native ZIP launch and user-visible behavior. See [ZIP library limits and Main's archive-comment limitation](../zip-libraries.md).
+
+## Large MRA artwork identity
+
+Use an isolated artwork-pack library with two or three MRA/MGL entries and synthetic artwork. No arcade core or ROM archive needs to be installed or launched for this check.
+
+1. Include a small descriptor and a valid descriptor larger than 1 MiB containing embedded hexadecimal payload. Cover both early and late `<setname>` positions and an MGL referencing the large descriptor.
+2. Rebuild through the actual Artwork Pack UI. Verify names and distinct artwork, then restart and verify the saved cache.
+3. Independently include one valid image larger than 1 MiB. Confirm it renders so image size is not confused with descriptor size.
+4. Test the shared path in another mapped system using an MRA entry. Ordinary Gamelist browsing must remain unchanged.
+5. Introduce a malformed descriptor before its identity, rebuild and verify an explicit failure with the previous complete cache and summary unchanged. Restore it and rebuild again.
+6. Exercise cancellation while a descriptor is still being read, using a controlled slow reader in the isolated test folder if necessary. Verify that the reader actually started, cancellation closes it, the UI reports cancellation, and the previous cache remains unchanged. Restore a regular descriptor and rebuild successfully. A read that completes before cancellation is not a cancellation test. Host tests additionally cover native `part`, `patch` and `cheat` payloads, comma separators, small read boundaries, metadata limits and underlying read failures.
+
+## Installation modes and restoration
+
+Repeat the applicable launch/return sequence for Scripts-menu use and the Degauss Main installation. For the Degauss Main installation, verify Frontend and the existing saved shortcut from both RA and nightly gameplay. For Scripts-menu use, preserve its documented return controls. Also exercise the RA short Reboot action. Verify which executable is active after returning and that the next ordinary launch works.
+
+RA's monitor-only operation without credentials can exercise core loading and executable switching. Verify certificate validation through the installed executable and adjacent CA bundle before credentials are used. Achievement login, game recognition and submission are separate account-dependent checks and must be recorded separately. The pinned RA Main uses its documented username/password configuration, not a web API key. [RA initialization](https://github.com/odelot/Main_MiSTer/blob/48e32b43ed85b046c7cd41bce756b7bb1679782b/achievements.cpp#L1666).
+
+Restore saved configuration bytes and temporarily relocated cores. Remove only disposable Favorites, test libraries and other files introduced for this test. Recheck the original Main/core hashes and ordinary launch, return, metadata and Favorites behavior. Record each tested arrangement and any untested boundary without treating missing observation as a pass.

--- a/docs/zip-libraries.md
+++ b/docs/zip-libraries.md
@@ -1,0 +1,41 @@
+# ZIP libraries
+
+A system that does not list `zip` among its launchable extensions opens each ZIP as a virtual folder. Root and nested games retain the native `archive.zip/folder/game.ext` target; neither browsing nor launch preparation extracts or modifies the archive. Directories can be explicit ZIP records or implied by member paths. A system already configured to launch `zip` keeps the whole archive as one game.
+
+The reader supports single-disk classic ZIP and ZIP64 with stored or deflated entries. Encryption, compressed-patch entries, other compression methods, nested archives, duplicate names and ASCII-case-ambiguous paths are rejected explicitly. Names must be exact UTF-8 and cannot contain traversal components, ambiguous separators or control characters. The complete native target must fit 1,023 bytes and the member filename must fit 260 bytes, matching the relevant Main buffers. An earlier `.zip` substring in the outer path is unsupported because Main splits its native ZIP target at the first such substring.
+
+Archives are bounded to 100,000 central-directory entries and 16 MiB of central-directory data. Both limits apply before allocation, regardless of overall archive size. The archive can exceed 4 GiB when these limits are met. Entry sizes and archive offsets are parsed with checked 64-bit arithmetic. These bounds constrain both frontend memory use and the central directory Main reads when opening a member.
+
+Use complete relative metadata paths for individual games:
+
+```xml
+<game>
+  <path>./library.zip/folder/game.rom</path>
+  <name>Game title</name>
+  <image>./images/game.png</image>
+</game>
+```
+
+An archive containing more than one game supported by the system uses only exact member metadata paths. A single supported game retains existing archive/title metadata matching. Scraping a single member preserves Keep/Fill policies but writes a separate exact member entry when an update is needed; it never overwrites the archive-level metadata row. Artwork remains an external file alongside the library.
+
+Replacing an archive is reflected by **Rebuild this system list** or a full rebuild. A successful scan replaces the current contents. An unreadable or malformed archive reports its path and reason; a failed rebuild preserves the previous valid cache and summary. Existing cache, Favorites and state formats remain readable.
+
+Launch confirmation reopens and validates the outer archive and selected member. It reports a missing, renamed or unsupported member before handing control to Main. Reading the central directory does not establish the integrity of compressed payloads: decompression and payload checks remain Main's responsibility.
+
+## Main archive-comment limitation
+
+The Main reader at revision [`f8dc68e3dcf4694f5593e6552aea56cd852982af`](https://github.com/MiSTer-devel/Main_MiSTer/blob/f8dc68e3dcf4694f5593e6552aea56cd852982af/lib/miniz/miniz.c) selects the last end-record signature with enough following bytes, without first validating the ZIP comment length. A valid archive comment containing that signature can therefore make Main select the wrong end record and reject the archive.
+
+Degauss correctly lists such an archive, but launch confirmation reports this Main limitation explicitly. It does not hand off a known incompatible target, extract a replacement ROM or rewrite the ZIP. Supporting that launch requires a Main reader that correctly validates end-record candidates; a Degauss-only parser change cannot repair Main's independent lookup.
+
+## Local reader smoke test
+
+With the pinned Main `lib/miniz` source already available locally:
+
+```sh
+python3 scripts/test-main-zip.py /path/to/Main_MiSTer/lib/miniz
+```
+
+The script verifies the source hashes, compiles Degauss's parser and Main's production iterator, and generates a few small synthetic archives locally. It compares exact member names, sizes and CRCs through stored, deflated and ZIP64 reads, verifies rejected unsupported archives, and verifies the explicit comment limitation. Temporary fixtures and binaries are removed automatically. There are no network requests or card writes.
+
+This test exercises host filesystem and reader behavior. It does not prove ARM32 execution, a core launch or achievement operation. Large-entry-count and sparse-file tests belong on the host; the card smoke test needs only a few games in a small isolated library.

--- a/scripts/build-ra-main.sh
+++ b/scripts/build-ra-main.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Build release-pinned RA Main with the existing Degauss frontend integration.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ $# -ne 1 || -e "$1" ]]; then
+    echo "Usage: $0 NEW_OUTPUT_DIRECTORY (must not already exist)" >&2
+    exit 1
+fi
+mkdir -p "$1"
+build_root="$(cd "$1" && pwd)"
+source_pin=48e32b43ed85b046c7cd41bce756b7bb1679782b
+archive_sha=77b2f284a675f4217be27b3fb700c06536e07f3600e14149f2231f2dceb95edb
+curl --fail --location --silent --show-error \
+    "https://codeload.github.com/odelot/Main_MiSTer/tar.gz/${source_pin}" \
+    -o "$build_root/upstream.tar.gz"
+actual_sha="$(shasum -a 256 "$build_root/upstream.tar.gz" | awk '{print $1}')"
+[[ "$actual_sha" == "$archive_sha" ]] || { echo "RA source checksum mismatch" >&2; exit 1; }
+ca_sha=f66dff1bdf8f96060b8177976f8b7d9254bc89bc4db933d769f7384d28480bc9
+curl --fail --location --silent --show-error \
+    https://curl.se/ca/cacert-2026-08-13.pem \
+    -o "$build_root/MiSTer_RA_Degauss.cacert.pem"
+actual_ca_sha="$(shasum -a 256 "$build_root/MiSTer_RA_Degauss.cacert.pem" | awk '{print $1}')"
+[[ "$actual_ca_sha" == "$ca_sha" ]] || { echo "CA bundle checksum mismatch" >&2; exit 1; }
+mkdir "$build_root/source"
+tar -xzf "$build_root/upstream.tar.gz" --strip-components=1 -C "$build_root/source"
+cd "$build_root/source"
+# The pinned release contains its achievement dependency. Never build the
+# upstream Makefile's permitted no-rcheevos variant as an RA replacement.
+test -s lib/rcheevos/include/rc_client.h
+test -s lib/rcheevos/src/rc_client.c
+patch --fuzz=0 -p1 < "$here/support/ra-main/frontend.patch"
+patch --fuzz=0 -p1 < "$here/support/ra-main/tls.patch"
+patch --fuzz=0 -p1 < "$here/support/ra-main/controller.patch"
+python3 tests/run-ra-controller-tests.py
+bash tests/run-degauss-shortcut-tests.sh
+image=degauss-ra-main-build:bullseye
+# Rebuild from the checked-in recipe (Docker may reuse matching layers), rather
+# than trusting whatever an existing local image tag happens to reference.
+docker build -t "$image" "$here/support/ra-main"
+python3 tests/run-ra-http-tests.py
+docker run --rm --network none -v "$PWD:/src" -w /src \
+    -u "$(id -u):$(id -g)" "$image" \
+    make BASE=arm-linux-gnueabihf \
+    CC="arm-linux-gnueabihf-gcc -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=hard" \
+    V=1 2>&1 | tee "$build_root/build.log"
+grep -q -- '-DHAS_RCHEEVOS=1' "$build_root/build.log"
+test -s bin/lib/rcheevos/src/rc_client.c.o
+docker run --rm --network none -v "$PWD:/src:ro" "$image" \
+    arm-linux-gnueabihf-nm -C /src/bin/MiSTer.elf > "$build_root/symbols.txt"
+for symbol in ' T rc_client_create$' ' T achievements_init\(\)$' \
+    ' T degauss_should_take_menu\(' ' T degauss_shortcut_handle_keyboard_event\('; do
+    grep -Eq "$symbol" "$build_root/symbols.txt"
+done
+cp bin/MiSTer "$build_root/MiSTer_RA_Degauss"
+shasum -a 256 "$build_root/MiSTer_RA_Degauss"
+printf 'RA Main source: %s\nDegauss integration: 0651979d53f570c29f8772e124ae603297830954\n' \
+    "$source_pin" > "$build_root/SOURCE-PINS.txt"
+printf 'CA bundle: curl Mozilla 2026-08-13 (MPL-2.0), SHA256 %s\n' "$ca_sha" >> "$build_root/SOURCE-PINS.txt"
+# Keep corresponding patched source and its build instructions with the binary.
+mkdir -p "$build_root/rebuild/scripts" "$build_root/rebuild/support"
+cp "$here/scripts/build-ra-main.sh" "$here/scripts/package-ra-main.py" "$build_root/rebuild/scripts/"
+cp -R "$here/support/ra-main" "$build_root/rebuild/support/ra-main"
+python3 "$here/scripts/package-ra-main.py" "$build_root"
+printf 'Built %s\n' "$build_root/MiSTer_RA_Degauss"

--- a/scripts/build-ra-main.sh
+++ b/scripts/build-ra-main.sh
@@ -33,7 +33,7 @@ patch --fuzz=0 -p1 < "$here/support/ra-main/tls.patch"
 patch --fuzz=0 -p1 < "$here/support/ra-main/controller.patch"
 python3 tests/run-ra-controller-tests.py
 bash tests/run-degauss-shortcut-tests.sh
-image=degauss-ra-main-build:bullseye
+image=degauss-ra-main-build:bookworm-gcc10
 # Rebuild from the checked-in recipe (Docker may reuse matching layers), rather
 # than trusting whatever an existing local image tag happens to reference.
 docker build -t "$image" "$here/support/ra-main"
@@ -41,7 +41,7 @@ python3 tests/run-ra-http-tests.py
 docker run --rm --network none -v "$PWD:/src" -w /src \
     -u "$(id -u):$(id -g)" "$image" \
     make BASE=arm-linux-gnueabihf \
-    CC="arm-linux-gnueabihf-gcc -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=hard" \
+    CC="arm-linux-gnueabihf-gcc-10 -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=hard" \
     V=1 2>&1 | tee "$build_root/build.log"
 grep -q -- '-DHAS_RCHEEVOS=1' "$build_root/build.log"
 test -s bin/lib/rcheevos/src/rc_client.c.o
@@ -51,6 +51,19 @@ for symbol in ' T rc_client_create$' ' T achievements_init\(\)$' \
     ' T degauss_should_take_menu\(' ' T degauss_shortcut_handle_keyboard_event\('; do
     grep -Eq "$symbol" "$build_root/symbols.txt"
 done
+docker run --rm --network none -v "$PWD:/src:ro" "$image" \
+    arm-linux-gnueabihf-readelf --version-info /src/bin/MiSTer.elf > "$build_root/abi-versions.txt"
+python3 - "$build_root/abi-versions.txt" <<'PYABI'
+import pathlib
+import re
+import sys
+text = pathlib.Path(sys.argv[1]).read_text()
+for namespace, limit in (("GLIBC", (2, 31)), ("GLIBCXX", (3, 4, 28))):
+    versions = {tuple(map(int, value.split(".")))
+                for value in re.findall(namespace + r"_([0-9]+(?:\.[0-9]+)+)", text)}
+    if not versions or max(versions) > limit:
+        raise SystemExit(f"RA Main ABI check failed: {namespace} requirements {sorted(versions)} exceed {limit} or are missing")
+PYABI
 cp bin/MiSTer "$build_root/MiSTer_RA_Degauss"
 shasum -a 256 "$build_root/MiSTer_RA_Degauss"
 printf 'RA Main source: %s\nDegauss integration: 0651979d53f570c29f8772e124ae603297830954\n' \

--- a/scripts/make-db.py
+++ b/scripts/make-db.py
@@ -8,13 +8,13 @@ where to fetch it. Adding one line to `downloader.ini` therefore makes
 A database can only place files. It cannot edit `MiSTer.ini`, so the `main=`
 line stays a one-off by hand, and it cannot run anything after installing.
 
-Usage: make-db.py <tag> <deploy-dir> <mister-degauss-binary> <out.json>
+Usage: make-db.py <tag> <deploy-dir> <mister-degauss-binary> <out.json> [--ra-dir BUILD_DIR]
 """
 
+import argparse
 import hashlib
 import json
 import os
-import sys
 import urllib.parse
 import time
 
@@ -22,7 +22,9 @@ OWNER = "giancarloerra"
 REPO = "Degauss"
 
 # Files that ship as release assets because they are built, not committed.
+RA_ASSETS = ("MiSTer_RA_Degauss", "MiSTer_RA_Degauss.cacert.pem", "MiSTer_RA_Degauss.SOURCE.txt")
 RELEASE_ASSETS = {"Scripts/.config/degauss/degauss", "degauss/MiSTer_Degauss"}
+RELEASE_ASSETS.update("degauss/" + name for name in RA_ASSETS)
 
 
 def md5(path):
@@ -83,9 +85,14 @@ REPO_SOURCED = {
 
 
 def main():
-    if len(sys.argv) != 5:
-        sys.exit(__doc__)
-    tag, deploy, fork_binary, out = sys.argv[1:]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tag")
+    parser.add_argument("deploy")
+    parser.add_argument("fork_binary")
+    parser.add_argument("out")
+    parser.add_argument("--ra-dir", help="Completed RA build with binary, CA bundle and source notice")
+    args = parser.parse_args()
+    tag, deploy, fork_binary, out = args.tag, args.deploy, args.fork_binary, args.out
 
     files = {}
     folders = {}
@@ -115,6 +122,9 @@ def main():
             add(card, real)
 
     add("degauss/MiSTer_Degauss", fork_binary)
+    if args.ra_dir:
+        for name in RA_ASSETS:
+            add("degauss/" + name, os.path.join(args.ra_dir, name))
 
     database = {
         "v": 1,

--- a/scripts/package-ra-main.py
+++ b/scripts/package-ra-main.py
@@ -25,6 +25,10 @@ def package(build):
         info.uid = info.gid = 0
         info.uname = info.gname = ""
         info.mtime = 0
+        if info.isdir():
+            info.mode = 0o755
+        elif info.isfile() or info.islnk():
+            info.mode = 0o755 if info.mode & 0o111 else 0o644
         return info
     with archive.open('wb') as output, gzip.GzipFile(filename='', fileobj=output, mode='wb', mtime=0) as compressed:
         with tarfile.open(fileobj=compressed, mode='w') as tar:

--- a/scripts/package-ra-main.py
+++ b/scripts/package-ra-main.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Package corresponding RA Main source from a completed, verified local build."""
+import gzip
+import hashlib
+import pathlib
+import sys
+import tarfile
+
+
+def package(build):
+    build = pathlib.Path(build)
+    required = ('MiSTer_RA_Degauss', 'MiSTer_RA_Degauss.cacert.pem',
+                'SOURCE-PINS.txt', 'source/LICENSE', 'source/Makefile',
+                'source/ra_http.cpp', 'rebuild/scripts/build-ra-main.sh',
+                'rebuild/scripts/package-ra-main.py', 'rebuild/support/ra-main/frontend.patch',
+                'rebuild/support/ra-main/tls.patch', 'rebuild/support/ra-main/controller.patch', 'rebuild/support/ra-main/Dockerfile')
+    for name in required:
+        if not (build / name).is_file():
+            raise SystemExit(f'package-ra-main: missing {name}')
+    archive = build / 'MiSTer_RA_Degauss-source.tar.gz'
+    def source_filter(info):
+        parts = pathlib.PurePosixPath(info.name).parts
+        if parts[:3] == ('ra-main-source', 'source', 'bin') or '.git' in parts or '__pycache__' in parts:
+            return None
+        info.uid = info.gid = 0
+        info.uname = info.gname = ""
+        info.mtime = 0
+        return info
+    with archive.open('wb') as output, gzip.GzipFile(filename='', fileobj=output, mode='wb', mtime=0) as compressed:
+        with tarfile.open(fileobj=compressed, mode='w') as tar:
+            for name in ('source', 'rebuild', 'SOURCE-PINS.txt', 'MiSTer_RA_Degauss.cacert.pem'):
+                tar.add(build / name, arcname=f'ra-main-source/{name}', filter=source_filter)
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    (build / (archive.name + '.sha256')).write_text(f'{digest}  {archive.name}\n')
+    notice = '''MiSTer_RA_Degauss is derived from RA Main and MiSTer Main (GPL-3.0-or-later).
+Degauss frontend, TLS and controller integration source and build instructions:
+  MiSTer_RA_Degauss-source.tar.gz, attached to the same Degauss release.
+Upstream: https://github.com/odelot/Main_MiSTer
+Degauss releases: https://github.com/giancarloerra/Degauss/releases
+
+The adjacent Mozilla CA bundle is MPL-2.0, from https://curl.se/docs/caextract.html.
+The source archive includes its bundle and source attribution.
+
+'''
+    (build / 'MiSTer_RA_Degauss.SOURCE.txt').write_text(notice + (build / 'SOURCE-PINS.txt').read_text())
+    print(archive)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        raise SystemExit('Usage: package-ra-main.py BUILD_DIRECTORY')
+    package(sys.argv[1])

--- a/scripts/test-main-zip.py
+++ b/scripts/test-main-zip.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Compare Degauss ZIP listing with Main's actual ZIP iterator, entirely locally.
+
+Usage: python3 scripts/test-main-zip.py /path/to/Main_MiSTer/lib/miniz
+The source must already be downloaded at MAIN_REVISION. No network calls,
+external services, card access, game collection or additional Python packages.
+"""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import shutil
+import struct
+import subprocess
+import tempfile
+import zipfile
+import zlib
+
+MAIN_REVISION = "f8dc68e3dcf4694f5593e6552aea56cd852982af"
+SOURCE_HASHES = {
+    "miniz.c": "bd2a5ae69adc3bc7d73fa37bf65dbabe84846758446a26009a827ff5d69a9c9c",
+    "miniz.h": "e9bc0ad11e0d67283b7fb254d907e7011509560f50072840d3c10973c2855795",
+}
+
+C_HARNESS = r'''
+#include "miniz.h"
+#include <stdio.h>
+int main(int argc, char **argv) {
+    if (argc != 2) return 10;
+    mz_zip_archive archive = {0};
+    if (!mz_zip_reader_init_file(&archive, argv[1], 0)) return 1;
+    for (mz_uint n = 0; n < mz_zip_reader_get_num_files(&archive); ++n) {
+        mz_zip_archive_file_stat st;
+        if (!mz_zip_reader_file_stat(&archive, n, &st)) return 2;
+        if (st.m_is_directory) continue;
+        if (mz_zip_reader_locate_file(&archive, st.m_filename, NULL, 0) != (int)n) return 3;
+        mz_zip_reader_extract_iter_state *iter = mz_zip_reader_extract_iter_new(&archive, n, 0);
+        if (!iter) return 4;
+        unsigned char block[4096];
+        size_t got;
+        mz_uint64 length = 0;
+        mz_ulong crc = 0;
+        while ((got = mz_zip_reader_extract_iter_read(iter, block, sizeof(block)))) {
+            length += got;
+            crc = mz_crc32(crc, block, got);
+        }
+        if (!mz_zip_reader_extract_iter_free(iter)) return 5;
+        if (length != st.m_uncomp_size || crc != st.m_crc32) return 6;
+        printf("%s\t%llu\t%08x\n", st.m_filename, (unsigned long long)length, (unsigned)crc);
+    }
+    mz_zip_reader_end(&archive);
+    return 0;
+}
+'''
+
+
+def forced_zip64(original):
+    """Keep real compressed payloads; replace central/end records with ZIP64."""
+    eocd = original.rfind(b"PK\x05\x06")
+    count = struct.unpack_from("<H", original, eocd + 10)[0]
+    offset = struct.unpack_from("<I", original, eocd + 16)[0]
+    central = bytearray()
+    cursor = offset
+    for _ in range(count):
+        header = bytearray(original[cursor:cursor + 46])
+        name_length, extra_length, comment_length = struct.unpack_from("<HHH", header, 28)
+        compressed, uncompressed = struct.unpack_from("<II", header, 20)
+        local = struct.unpack_from("<I", header, 42)[0]
+        if extra_length or comment_length:
+            raise ValueError("fixture unexpectedly has central extra fields or comments")
+        struct.pack_into("<H", header, 6, 45)
+        struct.pack_into("<II", header, 20, 0xFFFFFFFF, 0xFFFFFFFF)
+        struct.pack_into("<H", header, 30, 28)
+        struct.pack_into("<I", header, 42, 0xFFFFFFFF)
+        central.extend(header)
+        central.extend(original[cursor + 46:cursor + 46 + name_length])
+        central.extend(struct.pack("<HHQQQ", 1, 24, uncompressed, compressed, local))
+        cursor += 46 + name_length
+    result = bytearray(original[:offset])
+    result.extend(central)
+    end64 = len(result)
+    result.extend(struct.pack("<IQHHIIQQQQ", 0x06064B50, 44, 45, 45, 0, 0,
+                              count, count, len(central), offset))
+    result.extend(struct.pack("<IIQI", 0x07064B50, 0, end64, 1))
+    result.extend(struct.pack("<IHHHHIIH", 0x06054B50, 0, 0, 0xFFFF, 0xFFFF,
+                              0xFFFFFFFF, 0xFFFFFFFF, 0))
+    return result
+
+
+def run_reader(binary, archive, *extra):
+    return subprocess.run([str(binary), str(archive), *extra], check=False,
+                          text=True, capture_output=True, timeout=30)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("main_source", type=pathlib.Path, help="pinned Main lib/miniz directory")
+    args = parser.parse_args()
+    source = args.main_source.resolve()
+    for name, digest in SOURCE_HASHES.items():
+        if hashlib.sha256((source / name).read_bytes()).hexdigest() != digest:
+            raise SystemExit(f"{name} does not match Main revision {MAIN_REVISION}")
+    compiler = shutil.which("cc")
+    rustc = shutil.which("rustc")
+    if not rustc:
+        candidate = pathlib.Path.home() / ".cargo/bin/rustc"
+        rustc = str(candidate) if candidate.is_file() else None
+    if not compiler or not rustc:
+        raise SystemExit("A local C compiler and rustc are required")
+    repository = pathlib.Path(__file__).resolve().parent.parent
+    with tempfile.TemporaryDirectory(prefix="degauss-mainzip-") as temporary:
+        work = pathlib.Path(temporary)
+        c_source = work / "reader.c"
+        c_source.write_text(C_HARNESS)
+        main_reader = work / "main-reader"
+        subprocess.run([compiler, "-O2", "-I", str(source), str(c_source),
+                        str(source / "miniz.c"), "-o", str(main_reader)], check=True)
+        rust_source = work / "reader.rs"
+        rust_source.write_text(
+            '#![allow(dead_code)]\n'
+            f'#[path={json.dumps(str(repository / "src/error.rs"), ensure_ascii=False)}] mod error;\n'
+            f'#[path={json.dumps(str(repository / "src/zip.rs"), ensure_ascii=False)}] mod zip;\n'
+            'fn main() { let args: Vec<_> = std::env::args().collect(); let path = std::path::Path::new(&args[1]);\n'
+            'let result = if let Some(member) = args.get(2) { zip::validate_member_for_launch(&path.join(member)).map(|e| vec![e]) } else { zip::entries(path) };\n'
+            'match result {\n'
+            'Ok(entries) => for e in entries { println!("{}\\t{}\\t{:08x}", e.name,e.size,e.crc32); },\n'
+            'Err(_) => std::process::exit(1), } }\n')
+        degauss_reader = work / "degauss-reader"
+        subprocess.run([rustc, "--edition=2021", str(rust_source), "-o", str(degauss_reader)], check=True)
+        files = {"Root.rom": b"root fixture bytes\x00" * 32,
+                 "Nested/Game.rom": b"nested fixture bytes\xff" * 64}
+        fixtures = []
+        for name, method, contents in [
+            ("stored.zip", zipfile.ZIP_STORED, files),
+            ("deflated.zip", zipfile.ZIP_DEFLATED, files),
+            ("empty.zip", zipfile.ZIP_STORED, {"Empty.rom": b""}),
+            ("directories.zip", zipfile.ZIP_STORED, {**files, "empty/": b""}),
+        ]:
+            archive = work / name
+            with zipfile.ZipFile(archive, "w", compression=method) as writer:
+                for member, payload in contents.items():
+                    writer.writestr(member, payload)
+            fixtures.append((archive, contents))
+        archive64 = work / "deflated64.zip"
+        archive64.write_bytes(forced_zip64((work / "deflated.zip").read_bytes()))
+        fixtures.append((archive64, files))
+        members = 0
+        for archive, contents in fixtures:
+            expected = "".join(f"{name}\t{len(payload)}\t{zlib.crc32(payload):08x}\n"
+                               for name, payload in contents.items() if not name.endswith("/"))
+            for label, binary in [("Degauss", degauss_reader), ("Main iterator", main_reader)]:
+                result = run_reader(binary, archive)
+                if result.returncode or result.stdout != expected:
+                    raise SystemExit(f"{label} failed {archive.name}: exit {result.returncode}, output {result.stdout!r}")
+            members += sum(not name.endswith("/") for name in contents)
+            print(f"PASS {archive.name}: exact names, sizes and CRCs through both readers")
+        original = (work / "stored.zip").read_bytes()
+        central = original.find(b"PK\x01\x02")
+        for name, offset, value in [("unsupported-method.zip", 10, 12), ("encrypted.zip", 8, 1)]:
+            malformed = bytearray(original)
+            malformed[central + offset] = value
+            archive = work / name
+            archive.write_bytes(malformed)
+            for label, binary in [("Degauss", degauss_reader), ("Main iterator", main_reader)]:
+                if run_reader(binary, archive).returncode == 0:
+                    raise SystemExit(f"{label} incorrectly accepted {name}")
+            print(f"PASS {name}: both readers reject")
+        comment_archive = work / "comment-signature.zip"
+        with zipfile.ZipFile(comment_archive, "w") as writer:
+            writer.writestr("Root.rom", files["Root.rom"])
+            writer.comment = b"comment PK\x05\x06 with a false signature"
+        if run_reader(degauss_reader, comment_archive).returncode:
+            raise SystemExit("Degauss failed to list a structurally valid archive comment")
+        if run_reader(main_reader, comment_archive).returncode == 0:
+            raise SystemExit("Pinned Main comment behavior changed; review the launch compatibility gate")
+        if run_reader(degauss_reader, comment_archive, "Root.rom").returncode == 0:
+            raise SystemExit("Degauss did not block the known unsupported Main comment launch")
+        print("PASS comment-signature.zip: valid listing retained, incompatible Main launch blocked")
+        print(f"Verified {members} members in {len(fixtures)} small archives; 2 unsupported archives rejected.")
+        print(f"Main source: {MAIN_REVISION}. Local host coverage only; no card or core launch.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-ra-release.py
+++ b/scripts/test-ra-release.py
@@ -18,6 +18,16 @@ spec.loader.exec_module(package_ra)
 
 
 class ReleaseTests(unittest.TestCase):
+    def test_workflow_rejects_upstream_ra_at_any_card_path(self):
+        workflow = (ROOT / '.github/workflows/release.yml').read_text()
+        start = workflow.index('          import posixpath\n')
+        end = workflow.index('          for path, entry', start)
+        guard = '\n'.join(line[10:] for line in workflow[start:end].splitlines())
+        exec(guard, {'db': {'files': {'degauss/MiSTer_RA_Degauss': {}}}})
+        for path in ('MiSTer_RA', 'degauss/MiSTer_RA', 'nested/core/MiSTer_RA'):
+            with self.subTest(path=path), self.assertRaisesRegex(AssertionError, 'must not overwrite upstream RA Main'):
+                exec(guard, {'db': {'files': {path: {}}}})
+
     def test_database_preserves_legacy_and_adds_separate_ra_assets(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = pathlib.Path(tmp)

--- a/scripts/test-ra-release.py
+++ b/scripts/test-ra-release.py
@@ -3,6 +3,7 @@
 import hashlib
 import importlib.util
 import json
+import os
 import pathlib
 import subprocess
 import sys
@@ -51,6 +52,40 @@ class ReleaseTests(unittest.TestCase):
             failed = subprocess.run(command + ['--ra-dir', str(ra)], cwd=ROOT, capture_output=True)
             self.assertNotEqual(failed.returncode, 0)
             self.assertFalse(out.exists(), 'Incomplete RA package must not produce a successful database')
+
+    def test_source_archive_is_identical_across_umasks_and_preserves_executability(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archives = []
+            for mask in (0o022, 0o077):
+                root = pathlib.Path(tmp) / str(mask)
+                required = ('MiSTer_RA_Degauss', 'MiSTer_RA_Degauss.cacert.pem', 'SOURCE-PINS.txt',
+                            'source/LICENSE', 'source/Makefile', 'source/ra_http.cpp',
+                            'rebuild/scripts/build-ra-main.sh', 'rebuild/scripts/package-ra-main.py',
+                            'rebuild/support/ra-main/frontend.patch', 'rebuild/support/ra-main/tls.patch',
+                            'rebuild/support/ra-main/controller.patch', 'rebuild/support/ra-main/Dockerfile')
+                previous_mask = os.umask(mask)
+                try:
+                    for name in required:
+                        target = root / name
+                        target.parent.mkdir(parents=True, exist_ok=True)
+                        target.write_text(name)
+                    executable = root / 'rebuild/scripts/build-ra-main.sh'
+                    executable.chmod(0o777 & ~mask)
+                    os.link(root / 'source/LICENSE', root / 'source/LICENSE-link')
+                    package_ra.package(root)
+                finally:
+                    os.umask(previous_mask)
+                archive = root / 'MiSTer_RA_Degauss-source.tar.gz'
+                archives.append(archive.read_bytes())
+                with tarfile.open(archive) as tar:
+                    for member in tar:
+                        expected = 0o755 if member.isdir() or member.name.endswith('/build-ra-main.sh') else 0o644
+                        self.assertEqual(member.mode, expected, member.name)
+                    self.assertTrue(tar.getmember('ra-main-source/source/LICENSE-link').islnk())
+                self.assertEqual(executable.stat().st_mode & 0o777, 0o777 & ~mask,
+                                 'Packaging must not change the build tree permissions')
+            self.assertEqual(archives[0], archives[1],
+                             'Equivalent source trees must produce byte-identical release archives')
 
     def test_source_archive_retains_build_inputs_and_excludes_build_products(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test-ra-release.py
+++ b/scripts/test-ra-release.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Local regression checks for RA release source and Downloader delivery."""
+import hashlib
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location('package_ra', ROOT / 'scripts/package-ra-main.py')
+package_ra = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(package_ra)
+
+
+class ReleaseTests(unittest.TestCase):
+    def test_database_preserves_legacy_and_adds_separate_ra_assets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            frontend = root / 'deploy/Scripts/.config/degauss/degauss'
+            frontend.parent.mkdir(parents=True)
+            frontend.write_bytes(b'frontend')
+            normal = root / 'normal'
+            normal.write_bytes(b'normal main')
+            out = root / 'database.json'
+            command = [sys.executable, str(ROOT / 'scripts/make-db.py'), 'v1.2.3', str(root / 'deploy'), str(normal), str(out)]
+            subprocess.run(command, cwd=ROOT, check=True, capture_output=True)
+            legacy = json.loads(out.read_text())
+            self.assertEqual(set(legacy['files']), {'Scripts/.config/degauss/degauss', 'degauss/MiSTer_Degauss'})
+            ra = root / 'ra'
+            ra.mkdir()
+            names = ('MiSTer_RA_Degauss', 'MiSTer_RA_Degauss.cacert.pem', 'MiSTer_RA_Degauss.SOURCE.txt')
+            for name in names:
+                (ra / name).write_bytes(name.encode())
+            subprocess.run(command + ['--ra-dir', str(ra)], cwd=ROOT, check=True, capture_output=True)
+            updated = json.loads(out.read_text())
+            for path, entry in legacy['files'].items():
+                self.assertEqual(updated['files'][path], entry)
+            for name in names:
+                entry = updated['files']['degauss/' + name]
+                self.assertEqual(entry['hash'], hashlib.md5(name.encode()).hexdigest())
+                self.assertEqual(entry['size'], len(name.encode()))
+                self.assertEqual(entry['url'], 'https://github.com/giancarloerra/Degauss/releases/download/v1.2.3/' + name)
+            self.assertNotIn('MiSTer_RA', updated['files'])
+            self.assertFalse(any(path.endswith('.ini') for path in updated['files']))
+            (ra / names[1]).unlink()
+            out.unlink()
+            failed = subprocess.run(command + ['--ra-dir', str(ra)], cwd=ROOT, capture_output=True)
+            self.assertNotEqual(failed.returncode, 0)
+            self.assertFalse(out.exists(), 'Incomplete RA package must not produce a successful database')
+
+    def test_source_archive_retains_build_inputs_and_excludes_build_products(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            required = ('MiSTer_RA_Degauss', 'MiSTer_RA_Degauss.cacert.pem', 'SOURCE-PINS.txt',
+                        'source/LICENSE', 'source/Makefile', 'source/ra_http.cpp',
+                        'rebuild/scripts/build-ra-main.sh', 'rebuild/scripts/package-ra-main.py',
+                        'rebuild/support/ra-main/frontend.patch', 'rebuild/support/ra-main/tls.patch',
+                        'rebuild/support/ra-main/controller.patch',
+                        'rebuild/support/ra-main/Dockerfile', 'source/bin/MiSTer',
+                        'source/lib/example/bin/build-input')
+            for name in required:
+                target = root / name
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(name)
+            package_ra.package(root)
+            archive = root / 'MiSTer_RA_Degauss-source.tar.gz'
+            with tarfile.open(archive) as tar:
+                members = tar.getnames()
+                for member in tar:
+                    self.assertEqual((member.uid, member.gid, member.uname, member.gname, member.mtime), (0, 0, '', '', 0))
+                self.assertIn('ra-main-source/source/ra_http.cpp', members)
+                self.assertIn('ra-main-source/rebuild/scripts/package-ra-main.py', members)
+                self.assertIn('ra-main-source/source/lib/example/bin/build-input', members)
+                self.assertNotIn('ra-main-source/source/bin/MiSTer', members)
+            expected = hashlib.sha256(archive.read_bytes()).hexdigest()
+            self.assertEqual((root / (archive.name + '.sha256')).read_text(), expected + '  ' + archive.name + '\n')
+            self.assertIn(archive.name, (root / 'MiSTer_RA_Degauss.SOURCE.txt').read_text())
+            (root / 'rebuild/scripts/package-ra-main.py').unlink()
+            with self.assertRaises(SystemExit):
+                package_ra.package(root)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,7 +45,7 @@ use crate::options::{speed_badge, speed_label, OptionId, ADVANCED, OPTIONS};
 use crate::render::{FrameWork, PresentMode, Presenter};
 use crate::settings::{CustomViews, SaveOutcome, Settings};
 use crate::surface::Surface;
-use crate::systems::{FoundSystem, SystemDef};
+use crate::systems::{is_favorites, FoundSystem, SystemDef};
 use crate::theme::{Theme, ThemeSet};
 use crate::theme_editor::{
     EditorEffect, EditorMode, ThemeEditor, EDITOR_ROWS, NAME_CANCEL, NAME_CELLS, NAME_COLUMNS,
@@ -393,7 +393,7 @@ fn owner_candidates<'a>(systems: &'a [FoundSystem], path: &Path) -> Vec<&'a Foun
     }
     let candidates: Vec<(&FoundSystem, usize)> = systems
         .iter()
-        .filter(|system| system.category() != "Favorites")
+        .filter(|system| !is_favorites(system.category()))
         .filter_map(|system| {
             let depth = system
                 .paths
@@ -1382,7 +1382,7 @@ fn scraper_scope_only_artwork_pack(
         crate::scraper::Scope::All => {
             let mut candidates = systems
                 .iter()
-                .filter(|system| !system.category().eq_ignore_ascii_case(FAVORITES_ID));
+                .filter(|system| !is_favorites(system.category()));
             let Some(first) = candidates.next() else {
                 return false;
             };
@@ -1500,7 +1500,7 @@ fn favorite_change(
 /// Suppressing an image unconditionally made `Favorites.png` discoverable
 /// by the category code but impossible to see in the Details view.
 fn logo_or_favorite_heart(category: &str, logo: Option<PathBuf>) -> (Option<PathBuf>, bool) {
-    let heart = category == FAVORITES_ID && logo.is_none();
+    let heart = is_favorites(category) && logo.is_none();
     (logo, heart)
 }
 
@@ -4051,7 +4051,7 @@ impl App {
         let id = self
             .all_systems
             .iter()
-            .find(|system| system.category() == "Favorites")?
+            .find(|system| is_favorites(system.category()))?
             .def
             .id
             .clone();
@@ -5524,7 +5524,7 @@ impl App {
             "Utility",
             "Other",
             "Unstable",
-            "Favorites",
+            FAVORITES_ID,
         ];
         let mut categories: Vec<(String, usize)> = Vec::new();
         for name in ORDER {
@@ -5533,11 +5533,11 @@ impl App {
             if name == "Other" && !self.show_other {
                 continue;
             }
-            // Test patterns and measurement cores. Useful, and not what a
-            // list of games is for.
             if name == "Unstable" && !self.show_unstable {
                 continue;
             }
+            // Test patterns and measurement cores. Useful, and not what a
+            // list of games is for.
             if name == "Utility" && !self.show_utility {
                 continue;
             }
@@ -7923,7 +7923,8 @@ impl App {
                         "Artwork Pack cache refresh for {name} cancelled. Games remain browseable, but some artwork matches may be unavailable until it is refreshed."
                     ),
                     (SourceRecoveryPurpose::RefreshSystem, Some(error)) => format!(
-                        "{name} list was not rebuilt: {error}.\nThe previous complete cache remains in use."
+                        "{name} list was not rebuilt.\n{}\nThe previous complete cache remains in use.",
+                        artwork_pack_error_action(&error)
                     ),
                     (SourceRecoveryPurpose::RefreshSystem, None) if cancelled => format!(
                         "{name} list rebuild cancelled. The previous complete cache remains in use."
@@ -8204,10 +8205,10 @@ impl App {
                 Browsing::Systems => self
                     .systems
                     .get(self.system_list.selected())
-                    .is_some_and(|system| !system.category().eq_ignore_ascii_case(FAVORITES_ID)),
+                    .is_some_and(|system| !is_favorites(system.category())),
                 Browsing::Games => self
                     .open_system_ref()
-                    .is_some_and(|system| !system.category().eq_ignore_ascii_case(FAVORITES_ID)),
+                    .is_some_and(|system| !is_favorites(system.category())),
                 Browsing::Categories => false,
             };
         let scrape_game = scrape_scope
@@ -8253,7 +8254,7 @@ impl App {
         match choice {
             SCRAPE_SYSTEM => {
                 let system = self.systems.get(self.system_list.selected())?;
-                if system.category().eq_ignore_ascii_case(FAVORITES_ID) || system.paths.is_empty() {
+                if is_favorites(system.category()) || system.paths.is_empty() {
                     return None;
                 }
                 let place = if system.paths.len() == 1 {
@@ -9775,7 +9776,7 @@ impl App {
         self.open_system.as_ref().is_some_and(|id| {
             self.all_systems
                 .iter()
-                .any(|system| &system.def.id == id && system.category() == "Favorites")
+                .any(|system| &system.def.id == id && is_favorites(system.category()))
         })
     }
 
@@ -10025,7 +10026,7 @@ impl App {
                                 favorite: browse_row_favorite(
                                     self.layout,
                                     false,
-                                    name == FAVORITES_ID,
+                                    is_favorites(name),
                                 ),
                                 cover,
                                 has_cover,
@@ -10048,7 +10049,7 @@ impl App {
                             let favorite = browse_row_favorite(
                                 self.layout,
                                 false,
-                                self.systems[index].category() == FAVORITES_ID,
+                                is_favorites(self.systems[index].category()),
                             );
                             // How many games are in there, where the card
                             // has been read for it.
@@ -10093,7 +10094,7 @@ impl App {
                                 // user made, and the panel marks it with a
                                 // heart rather than a logo: no stand-in here
                                 // either, so the two views agree.
-                                let bare = self.in_favorites() && self.here[index].is_folder();
+                                let bare = inside_favorites && self.here[index].is_folder();
                                 self.here[index].cover.clone().or_else(|| {
                                     if bare {
                                         None
@@ -12482,6 +12483,53 @@ mod tests {
     }
 
     #[test]
+    fn custom_favorites_casing_never_becomes_a_game_owner_or_scraper_target() {
+        let root = picker_temp("favorite-category-casing");
+        std::fs::create_dir_all(&root).unwrap();
+        let game = root.join("MyShelf/Game.mgl");
+        std::fs::create_dir_all(game.parent().unwrap()).unwrap();
+        std::fs::write(&game, b"game").unwrap();
+        for category in ["Favorites", "favorites", "FAVORITES", "FaVoRiTeS"] {
+            let console = found_system_with_extensions("NES", vec![root.join("MyShelf")], &["mgl"]);
+            let table = format!("[[systems]]\nname = \"Shelf\"\nid = \"CustomShelf\"\ncategory = {category:?}\nrbf = \"\"\nfolders = [\"MyShelf\"]\nextensions = [\"rbf\", \"mra\", \"mgl\"]\n");
+            let table =
+                crate::systems::parse_table(&table, Path::new("custom-systems.toml")).unwrap();
+            let table = crate::systems::prepare_table(table, &root).unwrap();
+            let mut discovered = crate::systems::discover_checked(
+                &table,
+                std::slice::from_ref(&root),
+                None,
+                &crate::systems::CoreIndex::read(&root),
+            )
+            .unwrap();
+            let shelf = discovered.remove(0);
+            assert_eq!(
+                shelf.category(),
+                category,
+                "custom category casing survives discovery"
+            );
+            let systems = vec![console, shelf];
+            assert_eq!(
+                owner_of_path(&systems, &game).as_deref(),
+                Some("NES"),
+                "a Favorites shelf must not make the actual owner ambiguous: {category}"
+            );
+            assert!(
+                scraper_scope_only_artwork_pack(
+                    &crate::scraper::Scope::All,
+                    &systems,
+                    &std::collections::BTreeMap::from([("NES".into(), "/art".into())])
+                ),
+                "a Favorites shelf must not become a scrape candidate: {category}"
+            );
+            assert!(is_favorites(systems[1].category()));
+        }
+        assert!(!is_favorites("NES"));
+        assert!(!is_favorites("FavoritesExtra"));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn favorite_owner_requires_a_live_target_and_never_guesses_an_ambiguous_system() {
         let root = picker_temp("favorite-owner");
         let shared = root.join("shared");
@@ -13479,9 +13527,15 @@ mod tests {
         let chosen = PathBuf::from("Favorites.png");
         assert_eq!(
             logo_or_favorite_heart(FAVORITES_ID, Some(chosen.clone())),
-            (Some(chosen), false)
+            (Some(chosen.clone()), false)
         );
-        assert_eq!(logo_or_favorite_heart(FAVORITES_ID, None), (None, true));
+        for category in [FAVORITES_ID, "favorites", "FAVORITES", "FaVoRiTeS"] {
+            assert_eq!(logo_or_favorite_heart(category, None), (None, true));
+            assert_eq!(
+                logo_or_favorite_heart(category, Some(chosen.clone())),
+                (Some(chosen.clone()), false)
+            );
+        }
         assert_eq!(logo_or_favorite_heart("Console", None), (None, false));
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1156,6 +1156,9 @@ fn artwork_pack_health_message(
 fn artwork_pack_error_action(error: &crate::error::DegaussError) -> &'static str {
     match error {
         crate::error::DegaussError::Io { .. } => "Check the selected storage and try again.",
+        crate::error::DegaussError::Malformed { what, .. } if *what == "game descriptor" => {
+            "Repair the game descriptor; see degauss.log."
+        }
         crate::error::DegaussError::Malformed { .. } => "Repair the Artwork Pack and try again.",
         crate::error::DegaussError::Unsupported { .. } => {
             "Check degauss.log for details, then try again."
@@ -11725,6 +11728,17 @@ mod tests {
         let malformed_message = source_change_failure_message(&malformed);
         assert!(malformed_message.contains("Repair the Artwork Pack"));
         assert!(!malformed_message.contains("manifest.tsv"));
+        let descriptor = crate::error::DegaussError::malformed(
+            "game descriptor",
+            "/games/Arcade/Example.mra",
+            "private XML diagnostic",
+        );
+        let descriptor_message = source_change_failure_message(&descriptor);
+        assert!(descriptor_message.contains("Repair the game descriptor"));
+        assert!(descriptor_message.contains("degauss.log"));
+        assert!(!descriptor_message.contains("Artwork Pack"));
+        assert!(!descriptor_message.contains("/games/"));
+        assert!(!descriptor_message.contains("private XML diagnostic"));
         let unsupported_message = source_change_failure_message(&unsupported);
         assert!(unsupported_message.contains("degauss.log"));
         assert!(!unsupported_message.contains("private diagnostic detail"));

--- a/src/app.rs
+++ b/src/app.rs
@@ -2316,6 +2316,16 @@ fn theme_editor_visible_items(mode: EditorMode, total: usize, browse_visible: us
     }
 }
 
+fn initial_present_mode(
+    saved: Option<&str>,
+    default: PresentMode,
+    explicit: Option<PresentMode>,
+) -> PresentMode {
+    explicit
+        .or_else(|| saved.and_then(PresentMode::parse))
+        .unwrap_or(default)
+}
+
 fn resolved_font(setting: Option<&str>, configured: &str) -> Font {
     setting
         .and_then(Font::parse)
@@ -10521,11 +10531,22 @@ impl App {
         )
     }
 
-    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-    /// The drawing path the settings asked for, so the presenter can be put
-    /// into it before the first frame.
+    #[allow(dead_code)]
+    /// The effective drawing path, including any runtime default or override.
     pub fn present_mode(&self) -> PresentMode {
         PresentMode::parse(self.present_label).unwrap_or(PresentMode::Direct)
+    }
+
+    /// Resolve startup presentation without persisting an implicit device default.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub fn initialize_presentation(
+        &mut self,
+        default: PresentMode,
+        explicit: Option<PresentMode>,
+    ) -> PresentMode {
+        let mode = initial_present_mode(self.settings.present.as_deref(), default, explicit);
+        self.present_label = mode.label();
+        mode
     }
 
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
@@ -11601,6 +11622,37 @@ mod tests {
         std::fs::remove_dir_all(&path).ok();
         std::fs::create_dir_all(&path).unwrap();
         path
+    }
+
+    #[test]
+    fn presentation_startup_preserves_explicit_and_saved_choices() {
+        for default in [PresentMode::Direct, PresentMode::Staged] {
+            assert_eq!(initial_present_mode(None, default, None), default);
+            assert_eq!(
+                initial_present_mode(Some("invalid"), default, None),
+                default
+            );
+            for saved in [PresentMode::Direct, PresentMode::Staged] {
+                assert_eq!(
+                    initial_present_mode(Some(saved.label()), default, None),
+                    saved
+                );
+                for explicit in [PresentMode::Direct, PresentMode::Staged] {
+                    assert_eq!(
+                        initial_present_mode(Some(saved.label()), default, Some(explicit)),
+                        explicit
+                    );
+                    assert_eq!(
+                        initial_present_mode(None, default, Some(explicit)),
+                        explicit
+                    );
+                    assert_eq!(
+                        initial_present_mode(Some("invalid"), default, Some(explicit)),
+                        explicit
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -11397,8 +11397,21 @@ pub enum Outcome {
 /// Runs within the renderer's single installed Slint platform.
 #[cfg(test)]
 pub(crate) fn test_library_launch_flow(window: Rc<MinimalSoftwareWindow>) {
-    let root = std::env::temp_dir().join(format!("degauss-app-library-{}", std::process::id()));
-    assert!(!root.exists(), "fixture must be isolated");
+    // Atomically claim a fresh directory; a previous interrupted run may have
+    // left a fixture behind, and its contents are not ours to remove.
+    let root = (0_u64..)
+        .find_map(|attempt| {
+            let candidate = std::env::temp_dir().join(format!(
+                "degauss-app-library-{}-{attempt}",
+                std::process::id()
+            ));
+            match std::fs::create_dir(&candidate) {
+                Ok(()) => Some(candidate),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => None,
+                Err(error) => panic!("creating isolated fixture: {error}"),
+            }
+        })
+        .expect("fixture directory counter exhausted");
     for folder in ["games/NES", "_Console", "_RA_Cores/Cores", "_Unstable"] {
         std::fs::create_dir_all(root.join(folder)).unwrap();
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -250,6 +250,8 @@ fn option_operation(option: OptionId, input: OptionInput) -> OptionOperation {
         | OptionId::ShowEmpty
         | OptionId::ShowOther
         | OptionId::ShowUtility
+        | OptionId::ShowUnstable
+        | OptionId::CorePreference
         | OptionId::ShowBar
         | OptionId::FavoritesFirst
         | OptionId::HoldXFavorite
@@ -383,12 +385,15 @@ fn migrate_legacy_views(settings: &mut Settings, systems: &[FoundSystem]) {
 }
 
 fn owner_candidates<'a>(systems: &'a [FoundSystem], path: &Path) -> Vec<&'a FoundSystem> {
-    if !path.exists() && !crate::favorites::is_amiga_key(path) {
+    if !path.exists()
+        && !crate::favorites::is_amiga_key(path)
+        && crate::zip::split_member_path(path).is_none()
+    {
         return Vec::new();
     }
     let candidates: Vec<(&FoundSystem, usize)> = systems
         .iter()
-        .filter(|system| system.def.id != FAVORITES_ID)
+        .filter(|system| system.category() != "Favorites")
         .filter_map(|system| {
             let depth = system
                 .paths
@@ -439,11 +444,11 @@ fn finish_owner(mut candidates: Vec<&FoundSystem>) -> Option<String> {
     None
 }
 
-fn owner_of_path(systems: &[FoundSystem], path: &Path) -> Option<String> {
+pub(crate) fn owner_of_path(systems: &[FoundSystem], path: &Path) -> Option<String> {
     finish_owner(owner_candidates(systems, path))
 }
 
-fn owner_of_favorite(
+pub(crate) fn owner_of_favorite(
     systems: &[FoundSystem],
     reference: &crate::favorites::FavoriteReference,
 ) -> Option<String> {
@@ -526,7 +531,7 @@ fn enrich_favorite_rows(
         let browse::Kind::Play(browse::Launch::File(path)) = &row.kind else {
             continue;
         };
-        let Some(reference) = crate::favorites::reference_of(path) else {
+        let Some(reference) = crate::favorites::reference_of_with_systems(path, systems) else {
             continue;
         };
         wanted
@@ -1000,6 +1005,8 @@ const SCRAPE_SYSTEM: &str = "Scrape This System";
 const SCRAPE_FOLDER: &str = "Scrape This Folder";
 const SCRAPE_GAME: &str = "Scrape This Game";
 const GAME_DATA_SOURCE: &str = "Game Data Source";
+const CORE_VERSION: &str = "Core Version";
+const USE_DEFAULT_CORE_VERSION: &str = "Use Default Core Version";
 const SOURCE_GAMELIST: &str = "Gamelist";
 const SOURCE_ARTWORK_PACK: &str = "Artwork Pack";
 const CHOOSE_PACK_DIRECTORY: &str = "Choose Another Directory...";
@@ -1375,7 +1382,7 @@ fn scraper_scope_only_artwork_pack(
         crate::scraper::Scope::All => {
             let mut candidates = systems
                 .iter()
-                .filter(|system| !system.def.id.eq_ignore_ascii_case(FAVORITES_ID));
+                .filter(|system| !system.category().eq_ignore_ascii_case(FAVORITES_ID));
             let Some(first) = candidates.next() else {
                 return false;
             };
@@ -1492,8 +1499,8 @@ fn favorite_change(
 /// Favourites keeps its familiar heart only when it has no real image.
 /// Suppressing an image unconditionally made `Favorites.png` discoverable
 /// by the category code but impossible to see in the Details view.
-fn logo_or_favorite_heart(id: &str, logo: Option<PathBuf>) -> (Option<PathBuf>, bool) {
-    let heart = id == FAVORITES_ID && logo.is_none();
+fn logo_or_favorite_heart(category: &str, logo: Option<PathBuf>) -> (Option<PathBuf>, bool) {
+    let heart = category == FAVORITES_ID && logo.is_none();
     (logo, heart)
 }
 
@@ -1509,6 +1516,8 @@ struct ContextActions {
     scrape_game: bool,
     image_override: Option<bool>,
     game_data_source: bool,
+    core_version: bool,
+    core_version_override: bool,
 }
 
 fn category_image_preview(
@@ -1571,6 +1580,13 @@ fn context_entries(
             scrape.push(SCRAPE_GAME.to_string());
         }
         groups.push(scrape);
+    }
+    if actions.core_version {
+        let mut versions = vec![CORE_VERSION.to_string()];
+        if actions.core_version_override {
+            versions.push(USE_DEFAULT_CORE_VERSION.to_string());
+        }
+        groups.push(versions);
     }
     if actions.game_data_source {
         groups.push(vec![GAME_DATA_SOURCE.to_string()]);
@@ -2617,6 +2633,7 @@ pub struct App {
     show_other: bool,
     /// Show the group holding test and measurement cores.
     show_utility: bool,
+    show_unstable: bool,
     /// Show the strip along the bottom.
     show_bar: bool,
     /// Which logo each group is wearing at the moment.
@@ -2686,6 +2703,7 @@ impl App {
         let show_empty = loaded.settings.show_empty.unwrap_or(false);
         let show_other = loaded.settings.show_other.unwrap_or(false);
         let show_utility = loaded.settings.show_utility.unwrap_or(false);
+        let show_unstable = loaded.settings.show_unstable.unwrap_or(true);
         let show_bar = loaded.settings.show_bar.unwrap_or(false);
         let Loaded {
             config,
@@ -2971,6 +2989,7 @@ impl App {
             show_empty,
             show_other,
             show_utility,
+            show_unstable,
             show_bar,
             category_picks: std::collections::BTreeMap::new(),
             category_image_choices: Vec::new(),
@@ -3941,6 +3960,31 @@ impl App {
                     .then_with(|| left.sort_key.cmp(&right.sort_key))
             });
         }
+        if self
+            .opened_config
+            .as_ref()
+            .is_some_and(|config| config.preserve_rbf_stem)
+        {
+            for row in &mut rows {
+                if let browse::Kind::Play(browse::Launch::File(path)) = &row.kind {
+                    if path
+                        .extension()
+                        .is_some_and(|extension| extension.eq_ignore_ascii_case("rbf"))
+                    {
+                        if let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) {
+                            row.name = stem.to_string();
+                            row.sort_key = stem.to_ascii_lowercase();
+                        }
+                    }
+                }
+            }
+            rows.sort_by(|left, right| {
+                right
+                    .is_folder()
+                    .cmp(&left.is_folder())
+                    .then_with(|| left.sort_key.cmp(&right.sort_key))
+            });
+        }
         Ok(rows)
     }
 
@@ -3972,7 +4016,7 @@ impl App {
     /// after anything is favourited, never on a timer.
     fn reread_favorites(&mut self) {
         let root = PathBuf::from(&self.config.menu_root).join(crate::favorites::FAVORITES_DIR);
-        self.favorites = crate::favorites::Favorites::read(&root);
+        self.favorites = crate::favorites::Favorites::read_with_systems(&root, &self.all_systems);
         crate::note(&format!(
             "favourites   {} in {}",
             self.favorites.len(),
@@ -3994,7 +4038,14 @@ impl App {
     /// favourites until a full rebuild is asked for is wrong. The folder is
     /// small, so reading this one system again costs nothing worth noticing.
     fn refresh_favorites_system(&mut self) -> Option<String> {
-        self.refresh_system(FAVORITES_ID)
+        let id = self
+            .all_systems
+            .iter()
+            .find(|system| system.category() == "Favorites")?
+            .def
+            .id
+            .clone();
+        self.refresh_system(&id)
     }
 
     /// Write one system's cache again, from the card as it is now. Only
@@ -4017,7 +4068,10 @@ impl App {
         // are asked again; which menu folder the core sits in is a
         // full-rebuild question.
         let roots: Vec<PathBuf> = self.config.game_roots.iter().map(PathBuf::from).collect();
-        let paths = crate::systems::existing_folders(&system.def, &roots);
+        let paths = match crate::systems::existing_folders_checked(&system.def, &roots) {
+            Ok(paths) => paths,
+            Err(error) => return Some(format!("{name}: {error}")),
+        };
         if paths.is_empty() {
             // Every folder gone. Said out loud, and the cache is left as
             // it was: what to do about a vanished system is the full
@@ -4058,45 +4112,22 @@ impl App {
             // Said out loud rather than quietly keeping the stale listing.
             Err(e) => return Some(format!("{name}: {e}")),
         };
-        let cache = crate::cache::build_system(&library);
-        let saved = crate::cache::save_system(&self.cache_dir, id, &cache);
-        if let Err(e) = saved {
-            // Stop before the index learns the new summary: an index saying
-            // one count while the cache file on disk holds another survives
-            // a restart as a listing that disagrees with itself.
-            crate::note(&format!("cache        {id} not written: {e}"));
-            return Some(format!("{name} not written: {e}"));
-        }
-        let mut error = None;
-        if let Some(index) = self.index.as_mut() {
-            // Only this system's summary is replaced. The index carries
-            // every other system's too, and those are still right.
-            index
-                .systems
-                .insert(id.to_string(), cache.summary(&browse::start_for(&config)));
-            // Written to disk only when no build is running. A forced
-            // build has already emptied the cache folder and is filling a
-            // fresh index one system at a time; writing this one to disk in
-            // the middle of that would leave, after a power cut, an index
-            // whose systems have no cache files, and startup trusts an
-            // index that exists. The running build is told about the change
-            // below and writes the finished index itself.
-            if self.build.is_none() {
-                if let Err(e) = crate::cache::save_index(&self.cache_dir, index) {
-                    // The listing in memory is right either way, so the rest
-                    // of the propagation still runs; only the disk is stale,
-                    // and the user is told rather than left to find out at
-                    // the next start.
-                    crate::note(&format!("cache        index not written: {e}"));
-                    error = Some(format!("{name} index not written: {e}"));
-                }
-            }
-            // A refresh can take a system's count from nothing to
-            // something or back, and a system holding nothing is hidden
-            // at the root. The emptiness answers come from the index, so
-            // they are worked out again.
-            self.apply_index();
-        }
+        let cache = match crate::cache::build_system_checked(&library) {
+            Ok(cache) => cache,
+            Err(error) => return Some(format!("{name}: {error}")),
+        };
+        let mut next_index = self.index.clone().unwrap_or_default();
+        next_index
+            .systems
+            .insert(id.to_string(), cache.summary(&browse::start_for(&config)));
+        let warnings =
+            match crate::cache::save_system_with_index(&self.cache_dir, id, &cache, &next_index) {
+                Ok(warnings) => warnings,
+                Err(error) => return Some(format!("{name}: {error}")),
+            };
+        self.index = Some(next_index);
+        self.apply_index();
+        let error = (!warnings.is_empty()).then(|| warnings.join("\n"));
         if let Some(build) = self.build.as_mut() {
             // A build runs a system per frame with the controls still
             // live, and what it finishes with replaces the index outright.
@@ -4583,7 +4614,7 @@ impl App {
     /// written-down listing is walked once for all of them together: a
     /// pass over one system rather than a lookup per row.
     fn enrich_favorites(&mut self, rows: &mut [browse::Row]) {
-        if self.open_system.as_deref() != Some(FAVORITES_ID) {
+        if !self.in_favorites() {
             return;
         }
         // Clone only the small ownership/settings inputs so provider reuse can
@@ -4596,7 +4627,8 @@ impl App {
             let browse::Kind::Play(browse::Launch::File(path)) = &row.kind else {
                 continue;
             };
-            let Some(reference) = crate::favorites::reference_of(path) else {
+            let Some(reference) = crate::favorites::reference_of_with_systems(path, &systems)
+            else {
                 continue;
             };
             let Some(id) = owner_of_favorite(&systems, &reference) else {
@@ -4750,7 +4782,7 @@ impl App {
     }
 
     fn mark_favorites(&self, rows: &mut [browse::Row]) {
-        if self.open_system.as_deref() == Some(FAVORITES_ID) {
+        if self.in_favorites() {
             // Everything playable on this shelf is a favourite by
             // definition, but the lookup below is keyed by what a
             // favourite points AT, and these rows are the favourite files
@@ -5004,7 +5036,31 @@ impl App {
             self.dirty = true;
             return None;
         };
-        let config = self.opened_config.clone()?;
+        let mut config = self.opened_config.clone()?;
+        if self.in_favorites() {
+            if let browse::Launch::File(path) = &game {
+                if let Some(reference) =
+                    crate::favorites::reference_of_with_systems(path, &self.all_systems)
+                {
+                    if let Some(id) = owner_of_favorite(&self.all_systems, &reference) {
+                        if let Some(owner) =
+                            self.all_systems.iter().find(|system| system.def.id == id)
+                        {
+                            config = owner.to_config();
+                        }
+                    }
+                    if crate::zip::split_member_path(&reference.owner_target).is_some() {
+                        if let Err(error) =
+                            crate::zip::validate_member_for_launch(&reference.owner_target)
+                        {
+                            self.message = Some(error.to_string());
+                            self.dirty = true;
+                            return None;
+                        }
+                    }
+                }
+            }
+        }
         // A self-describing file names its own core, so a favourite or a
         // core file must not be blocked on the system's. Everything else
         // ends up in an MGL naming `config.rbf`, and handing MiSTer a core
@@ -5019,20 +5075,38 @@ impl App {
         // favourite's dangling link would answer for a core whose real
         // file is gone, and the launch would still end in MiSTer's own
         // "No rbf found!" with Degauss already gone.
-        if !self_describing
-            && !crate::systems::core_file_exists(Path::new(&self.config.menu_root), &config.rbf)
-        {
-            self.message = Some(format!(
-                "{}: core {} is not on the card",
-                config.name, config.rbf
-            ));
-            self.dirty = true;
-            return None;
+        let core_system = self.core_system_id().or_else(|| self.open_system.clone());
+        let selected_core = core_system
+            .as_ref()
+            .and_then(|id| self.settings.core_choices.get(id))
+            .map(String::as_str);
+        let ra_first = self.settings.core_preference.unwrap_or_default()
+            == crate::settings::CorePreference::RetroAchievementsFirst;
+        if !self_describing {
+            if let Err(error) = crate::core_choices::resolve(
+                &config,
+                Path::new(&self.config.menu_root),
+                selected_core,
+                ra_first,
+            ) {
+                self.message = Some(error.to_string());
+                self.dirty = true;
+                return None;
+            }
         }
         // A gamelist can name a file that was deleted or renamed since it
         // was written. The plan would build anyway and MiSTer would fail
         // after this process had already handed over, so the absence has to
         // become a line on screen here or never.
+        if let browse::Launch::File(path) = &game {
+            if crate::zip::split_member_path(path).is_some() {
+                if let Err(error) = crate::zip::validate_member_for_launch(path) {
+                    self.message = Some(error.to_string());
+                    self.dirty = true;
+                    return None;
+                }
+            }
+        }
         let missing = match &game {
             // A favourite that is really an AmigaVision title points at an
             // installation, not at itself; the file that has to exist is
@@ -5042,7 +5116,7 @@ impl App {
             // existence check and fail after the hand-over.
             browse::Launch::File(path) => match crate::launch::amiga_marker(path) {
                 Some((install, _)) => !install.is_dir(),
-                None => !path.exists(),
+                None => crate::zip::split_member_path(path).is_none() && !path.exists(),
             },
             browse::Launch::AmigaVision { install, .. } => !install.is_dir(),
         };
@@ -5056,7 +5130,14 @@ impl App {
         // cannot be built becomes a message here rather than an exit later.
         let mgl = Path::new("/tmp/degauss.mgl");
         let plan = match &game {
-            browse::Launch::File(path) => crate::launch::plan(&config, path, mgl),
+            browse::Launch::File(path) => crate::launch::plan_with_choice(
+                &config,
+                path,
+                mgl,
+                Path::new(&self.config.menu_root),
+                ra_first,
+                selected_core,
+            ),
             browse::Launch::AmigaVision { install, title } => {
                 crate::launch::plan_amiga_vision(&config, install, title, mgl)
             }
@@ -5168,7 +5249,7 @@ impl App {
     /// back, and part of what can change is which systems there are at
     /// all, so it walks the same ground startup walked: the menu folders
     /// for cores, then the game folders against the table.
-    fn rediscover_systems(&mut self) {
+    fn rediscover_systems(&mut self) -> Result<()> {
         let roots: Vec<PathBuf> = self.config.game_roots.iter().map(PathBuf::from).collect();
         let cores = crate::systems::CoreIndex::read(Path::new(&self.config.menu_root));
         let open = self.open_system.clone();
@@ -5178,8 +5259,12 @@ impl App {
                 .find(|s| s.def.id == id)
                 .map(|s| s.name().to_string())
         });
-        self.all_systems =
-            crate::systems::discover(&self.table, &roots, self.logo_dir.as_deref(), &cores);
+        self.all_systems = crate::systems::discover_checked(
+            &self.table,
+            &roots,
+            self.logo_dir.as_deref(),
+            &cores,
+        )?;
         // The screensaver's shortlist holds positions into the list that
         // was just replaced, so it is built again on next use.
         self.saver_candidates = None;
@@ -5192,6 +5277,7 @@ impl App {
             }
         }
         self.rebuild_system_list();
+        Ok(())
     }
 
     /// Leave the system that just stopped existing, the way walking out
@@ -5219,14 +5305,11 @@ impl App {
 
     /// Begin reading the card into the cache.
     ///
-    /// `forced` throws away what is already written down. Without it a
-    /// system whose file is already there is left alone, which is what
-    /// makes a second run cheap.
+    /// `forced` replaces each system only after a complete successful read.
+    /// Without it an existing cache is reused, keeping a second run cheap.
     fn start_build(&mut self, forced: bool) {
-        // One at a time. Replacing a build in flight would lose the
-        // progress made and, when forced, clear the folder a second
-        // time; the progress message already on screen says what is
-        // happening, so the press needs no other answer.
+        // One at a time. Replacing a build in flight would lose its progress;
+        // the existing progress message already explains the active work.
         if self.build.is_some() || self.source_job.is_some() || self.refreshing.is_some() {
             return;
         }
@@ -5235,9 +5318,7 @@ impl App {
             self.dirty = true;
             return;
         }
-        if forced {
-            crate::cache::clear_for_rebuild(&self.cache_dir);
-        }
+        // Keep the last complete caches until their replacement is committed.
         let total = self.all_systems.len();
         self.source_recovery_queue.clear();
         self.source_recovery_warnings.clear();
@@ -5261,11 +5342,15 @@ impl App {
         // Popped from the end, so reverse to read them in the order they
         // are listed: the name on screen should march forwards.
         left.reverse();
+        let mut index = self.index.clone().unwrap_or_default();
+        index
+            .systems
+            .retain(|id, _| self.all_systems.iter().any(|s| &s.def.id == id));
         self.build = Some(Building {
             left,
             done: 0,
             total,
-            index: crate::cache::Index::new(),
+            index,
             forced,
         });
         // Not shown yet: it goes up when the reading starts, which is
@@ -5283,7 +5368,12 @@ impl App {
             let finished = self.build.take().expect("just checked");
             let index = finished.index;
             if let Err(e) = crate::cache::save_index(&self.cache_dir, &index) {
-                crate::note(&format!("cache        index not written: {e}"));
+                let message = format!("cache index not written: {e}");
+                crate::note(&message);
+                self.message_after_build = Some(match self.message_after_build.take() {
+                    Some(previous) => format!("{previous}\n{message}"),
+                    None => message,
+                });
             }
             self.index = Some(index);
             self.apply_index();
@@ -5347,42 +5437,52 @@ impl App {
         } else {
             None
         };
-        let summary = summary.or_else(|| {
-            if pack {
-                // The queued Pack worker will produce the complete cache and
-                // fold its summary into the index. Walking it here would put
-                // the same potentially large job back on the UI thread.
-                return None;
-            }
-            let library = match Library::open_with_names(&config, self.names.clone()) {
-                Ok(library) => library,
-                Err(e) => {
-                    crate::note(&format!("cache        {id} not read: {e}"));
-                    return None;
+        let summary = match summary {
+            Some(summary) => Some(summary),
+            None if pack => None,
+            None => {
+                let built = (|| -> Result<(crate::cache::Summary, Vec<String>)> {
+                    let library = Library::open_with_names(&config, self.names.clone())?;
+                    let cache = crate::cache::build_system_checked(&library)?;
+                    let summary = cache.summary(&start);
+                    let mut next_index = self.build.as_ref().expect("active build").index.clone();
+                    next_index.systems.insert(id.clone(), summary);
+                    let warnings = crate::cache::save_system_with_index(
+                        &self.cache_dir,
+                        &id,
+                        &cache,
+                        &next_index,
+                    )?;
+                    Ok((summary, warnings))
+                })();
+                match built {
+                    Ok((summary, warnings)) => {
+                        if !warnings.is_empty() {
+                            let message = warnings.join("\n");
+                            self.message_after_build =
+                                Some(match self.message_after_build.take() {
+                                    Some(previous) => format!("{previous}\n{message}"),
+                                    None => message,
+                                });
+                        }
+                        Some(summary)
+                    }
+                    Err(error) => {
+                        let message = format!("{name}: {error}");
+                        crate::note(&message);
+                        self.message_after_build = Some(match self.message_after_build.take() {
+                            Some(previous) => format!("{previous}\n{message}"),
+                            None => message,
+                        });
+                        None
+                    }
                 }
-            };
-            let cache = match crate::cache::build_system_controlled(
-                &library,
-                &std::sync::atomic::AtomicBool::new(false),
-                &mut |_, _| {},
-            ) {
-                Ok(Some(cache)) => cache,
-                Ok(None) => return None,
-                Err(error) => {
-                    crate::note(&format!("cache        {id} not built: {error}"));
-                    return None;
-                }
-            };
-            let summary = cache.summary(&start);
-            if let Err(e) = crate::cache::save_system(&self.cache_dir, &id, &cache) {
-                crate::note(&format!("cache        {id} not written: {e}"));
             }
-            Some(summary)
-        });
-
+        };
         if let (Some(build), Some(summary)) = (self.build.as_mut(), summary) {
             build.index.systems.insert(id, summary);
         }
+
         self.dirty = true;
     }
 
@@ -5407,12 +5507,13 @@ impl App {
         // MiSTer's own menu uses, and only when something is in them.
         // Favourites last: it is not a machine, it is a shelf of things
         // picked off the others.
-        const ORDER: [&str; 6] = [
+        const ORDER: [&str; 7] = [
             "Arcade",
             "Console",
             "Computer",
             "Utility",
             "Other",
+            "Unstable",
             "Favorites",
         ];
         let mut categories: Vec<(String, usize)> = Vec::new();
@@ -5424,6 +5525,9 @@ impl App {
             }
             // Test patterns and measurement cores. Useful, and not what a
             // list of games is for.
+            if name == "Unstable" && !self.show_unstable {
+                continue;
+            }
             if name == "Utility" && !self.show_utility {
                 continue;
             }
@@ -6096,6 +6200,15 @@ impl App {
                 self.settings.show_other = Some(self.show_other);
                 self.rebuild_system_list();
             }
+            OptionId::ShowUnstable => {
+                self.show_unstable = !self.show_unstable;
+                self.settings.show_unstable = Some(self.show_unstable);
+                self.rebuild_system_list();
+            }
+            OptionId::CorePreference => {
+                self.settings.core_preference =
+                    Some(self.settings.core_preference.unwrap_or_default().next());
+            }
             OptionId::ShowUtility => {
                 self.show_utility = !self.show_utility;
                 self.settings.show_utility = Some(self.show_utility);
@@ -6202,6 +6315,13 @@ impl App {
             OptionId::ShowEmpty => on_off(self.show_empty),
             OptionId::ShowOther => on_off(self.show_other),
             OptionId::ShowUtility => on_off(self.show_utility),
+            OptionId::ShowUnstable => on_off(self.show_unstable),
+            OptionId::CorePreference => self
+                .settings
+                .core_preference
+                .unwrap_or_default()
+                .label()
+                .to_string(),
             OptionId::ShowBar => on_off(self.show_bar),
             OptionId::FavoritesFirst => on_off(self.favorites_first),
             OptionId::HoldXFavorite => on_off(self.hold_x_favorite),
@@ -6294,7 +6414,11 @@ impl App {
         }
         // Discovery normally happens only at startup. Repeat it first so a
         // newly added or removed core or folder is included in the rebuild.
-        self.rediscover_systems();
+        if let Err(error) = self.rediscover_systems() {
+            self.message = Some(error.to_string());
+            self.dirty = true;
+            return;
+        }
         self.start_build(true);
         self.dirty = true;
     }
@@ -6459,6 +6583,15 @@ impl App {
     /// rather than an action.
     fn context_value(&self, index: usize) -> String {
         match self.menu.get(index).map(String::as_str) {
+            Some(CORE_VERSION) => self
+                .core_system_id()
+                .and_then(|id| self.settings.core_choices.get(&id))
+                .map(|key| match key.as_str() {
+                    "standard" => "Standard".to_string(),
+                    "ra" => "RetroAchievements".to_string(),
+                    _ => key.clone(),
+                })
+                .unwrap_or_else(|| "Default".to_string()),
             Some(CHANGE_VIEW) => self.layout.shown().to_string(),
             Some(GAME_DATA_SOURCE) => self
                 .context_system_id()
@@ -6480,6 +6613,10 @@ impl App {
     /// rather than hiding it behind a press.
     fn adjust_context(&mut self, delta: isize) {
         let selected = self.menu_list.selected();
+        if self.menu.get(selected).map(String::as_str) == Some(CORE_VERSION) {
+            self.adjust_core_version(delta);
+            return;
+        }
         if self.menu.get(selected).map(String::as_str) != Some(CHANGE_VIEW) {
             return;
         }
@@ -6491,6 +6628,108 @@ impl App {
         self.remember_view();
         self.apply_geometry();
         self.touch_selection();
+        self.dirty = true;
+    }
+
+    fn core_system_id(&self) -> Option<String> {
+        let id = if self.in_favorites() && self.browsing == Browsing::Games {
+            let path = self.selected_game()?;
+            let reference = crate::favorites::reference_of_with_systems(&path, &self.all_systems)?;
+            owner_of_favorite(&self.all_systems, &reference)?
+        } else {
+            self.context_system_id()?.to_string()
+        };
+        self.all_systems
+            .iter()
+            .find(|system| system.def.id == id && !system.def.rbf.is_empty())
+            .map(|_| id)
+    }
+
+    fn adjust_core_version(&mut self, delta: isize) {
+        let Some(id) = self.core_system_id() else {
+            return;
+        };
+        let Some(system) = self.all_systems.iter().find(|system| system.def.id == id) else {
+            return;
+        };
+        let available = match crate::core_choices::available(
+            &system.to_config(),
+            Path::new(&self.config.menu_root),
+        ) {
+            Ok(choices) => choices,
+            Err(error) => {
+                self.message = Some(error.to_string());
+                self.dirty = true;
+                return;
+            }
+        };
+        let mut choices = vec![(String::new(), "Default".to_string())];
+        choices.extend(
+            available
+                .into_iter()
+                .map(|choice| (choice.key, choice.label)),
+        );
+        let current = self
+            .settings
+            .core_choices
+            .get(&id)
+            .map(String::as_str)
+            .unwrap_or("");
+        let at = choices
+            .iter()
+            .position(|(key, _)| key == current)
+            .unwrap_or(0);
+        let next = (at as isize + delta.signum()).rem_euclid(choices.len() as isize) as usize;
+        let (key, label) = &choices[next];
+        let mut settings = self.settings.clone();
+        if key.is_empty() {
+            settings.core_choices.remove(&id);
+        } else {
+            settings.core_choices.insert(id, key.clone());
+        }
+        match settings.save(&self.settings_path) {
+            Ok(outcome) => {
+                self.settings = settings;
+                self.open_context();
+                if let Some(index) = self.menu.iter().position(|entry| entry == CORE_VERSION) {
+                    self.menu_list.select(index);
+                }
+                self.message = match outcome {
+                    crate::settings::SaveOutcome::Durable => None,
+                    crate::settings::SaveOutcome::InstalledWithWarning(warning) => {
+                        Some(format!("Core Version: {label}\n{warning}"))
+                    }
+                };
+            }
+            Err(error) => self.message = Some(error.to_string()),
+        }
+        self.dirty = true;
+    }
+
+    /// Clear the saved override without consulting any mounted core folder.
+    /// This remains usable when enumeration failed or a selected file vanished.
+    fn use_default_core_version(&mut self) {
+        let Some(id) = self.core_system_id() else {
+            return;
+        };
+        let mut settings = self.settings.clone();
+        if settings.core_choices.remove(&id).is_none() {
+            return;
+        }
+        match settings.save(&self.settings_path) {
+            Ok(outcome) => {
+                self.settings = settings;
+                self.screen = Screen::Browse;
+                self.apply_geometry();
+                self.message = Some(match outcome {
+                    crate::settings::SaveOutcome::Durable => "Core Version: Default".to_string(),
+                    crate::settings::SaveOutcome::InstalledWithWarning(warning) => {
+                        format!("Core Version: Default\n{warning}")
+                    }
+                });
+            }
+            Err(error) => self.message = Some(error.to_string()),
+        }
         self.dirty = true;
     }
 
@@ -6768,7 +7007,17 @@ impl App {
             return;
         }
 
-        let outcome = match crate::launch::favorite_mgl(&config, &game) {
+        let outcome = match crate::launch::favorite_mgl_with_choice(
+            &config,
+            &game,
+            Path::new(&self.config.menu_root),
+            self.settings.core_preference.unwrap_or_default()
+                == crate::settings::CorePreference::RetroAchievementsFirst,
+            self.open_system
+                .as_ref()
+                .and_then(|id| self.settings.core_choices.get(id))
+                .map(String::as_str),
+        ) {
             Ok(Some(mgl)) => {
                 // The favourite is filed under the name the browser showed,
                 // which the gamelist may have set, not under the file's own
@@ -6825,7 +7074,7 @@ impl App {
         let Some(game) = self.selected_game() else {
             return;
         };
-        let file = if self.open_system.as_deref() == Some(FAVORITES_ID) {
+        let file = if self.in_favorites() {
             Some(game.clone())
         } else {
             self.favorites.file_for(&game).map(Path::to_path_buf)
@@ -7506,9 +7755,7 @@ impl App {
                             self.apply_geometry();
                             self.dirty = true;
                         }
-                    } else if self.browsing == Browsing::Games
-                        && self.open_system.as_deref() == Some(FAVORITES_ID)
-                    {
+                    } else if self.browsing == Browsing::Games && self.in_favorites() {
                         self.relist_here();
                     }
                     self.start_provider_job_if_ready();
@@ -7665,8 +7912,8 @@ impl App {
                     (SourceRecoveryPurpose::OpenSystem, None) if cancelled => format!(
                         "Artwork Pack cache refresh for {name} cancelled. Games remain browseable, but some artwork matches may be unavailable until it is refreshed."
                     ),
-                    (SourceRecoveryPurpose::RefreshSystem, Some(_)) => format!(
-                        "{name} list was not rebuilt.\nThe previous complete cache remains in use."
+                    (SourceRecoveryPurpose::RefreshSystem, Some(error)) => format!(
+                        "{name} list was not rebuilt: {error}.\nThe previous complete cache remains in use."
                     ),
                     (SourceRecoveryPurpose::RefreshSystem, None) if cancelled => format!(
                         "{name} list rebuild cancelled. The previous complete cache remains in use."
@@ -7712,7 +7959,12 @@ impl App {
             );
             return;
         };
-        let (caches, install_warnings) = match prepared.install() {
+        let mut next_index = self.index.clone().unwrap_or_default();
+        update_index_summaries(&mut next_index, &self.all_systems, prepared.caches());
+        let (_caches, install_warnings) = match prepared
+            .with_index(&self.cache_dir, &next_index)
+            .and_then(|prepared| prepared.install())
+        {
             Ok(installed) => installed,
             Err(error) => {
                 crate::note(&format!(
@@ -7740,14 +7992,7 @@ impl App {
             self.source_recovery_suppressed.remove(group);
         }
         self.store_source_providers(providers);
-        if let Some(index) = self.index.as_mut() {
-            update_index_summaries(index, &self.all_systems, &caches);
-            if let Err(error) = crate::cache::save_index(&self.cache_dir, index) {
-                crate::note(&format!("cache        recovery index not written: {error}"));
-                self.source_recovery_warnings
-                    .push(format!("the system index was not saved: {error}"));
-            }
-        }
+        self.index = Some(next_index);
         self.correct_system_counts();
         self.rebuild_system_list();
         self.screen = Screen::Browse;
@@ -7935,7 +8180,7 @@ impl App {
         // the target-keyed lookup below answers false for every one of
         // them and the menu offered to Add what is already there. On the
         // shelf the answer is known without asking.
-        let favorite = if self.open_system.as_deref() == Some(FAVORITES_ID) {
+        let favorite = if self.in_favorites() {
             self.selected_game().map(|_| true)
         } else {
             self.selected_game().map(|path| self.favorites.holds(&path))
@@ -7949,11 +8194,10 @@ impl App {
                 Browsing::Systems => self
                     .systems
                     .get(self.system_list.selected())
-                    .is_some_and(|system| !system.def.id.eq_ignore_ascii_case(FAVORITES_ID)),
+                    .is_some_and(|system| !system.category().eq_ignore_ascii_case(FAVORITES_ID)),
                 Browsing::Games => self
-                    .open_system
-                    .as_deref()
-                    .is_some_and(|system| !system.eq_ignore_ascii_case(FAVORITES_ID)),
+                    .open_system_ref()
+                    .is_some_and(|system| !system.category().eq_ignore_ascii_case(FAVORITES_ID)),
                 Browsing::Categories => false,
             };
         let scrape_game = scrape_scope
@@ -7981,6 +8225,10 @@ impl App {
                 scrape_game,
                 image_override,
                 game_data_source,
+                core_version: self.core_system_id().is_some(),
+                core_version_override: self
+                    .core_system_id()
+                    .is_some_and(|id| self.settings.core_choices.contains_key(&id)),
             },
         );
         if self.menu.is_empty() {
@@ -7995,7 +8243,7 @@ impl App {
         match choice {
             SCRAPE_SYSTEM => {
                 let system = self.systems.get(self.system_list.selected())?;
-                if system.def.id.eq_ignore_ascii_case(FAVORITES_ID) || system.paths.is_empty() {
+                if system.category().eq_ignore_ascii_case(FAVORITES_ID) || system.paths.is_empty() {
                     return None;
                 }
                 let place = if system.paths.len() == 1 {
@@ -8011,7 +8259,7 @@ impl App {
             }
             SCRAPE_FOLDER => {
                 let system_id = self.open_system.clone()?;
-                if system_id.eq_ignore_ascii_case(FAVORITES_ID) {
+                if self.in_favorites() {
                     return None;
                 }
                 let (place, display_name) = match self.here.get(self.game_list.selected()) {
@@ -8031,7 +8279,7 @@ impl App {
             }
             SCRAPE_GAME => {
                 let system_id = self.open_system.clone()?;
-                if system_id.eq_ignore_ascii_case(FAVORITES_ID) {
+                if self.in_favorites() {
                     return None;
                 }
                 let row = self.here.get(self.game_list.selected())?;
@@ -9383,13 +9631,19 @@ impl App {
                     // Any action other than continuing to adjust the view
                     // closes or replaces Context. Persist a view already
                     // chosen there before that path can launch or fail.
-                    if was_context && choice != CHANGE_VIEW && choice != USE_GLOBAL_VIEW {
+                    if was_context
+                        && choice != CHANGE_VIEW
+                        && choice != USE_GLOBAL_VIEW
+                        && choice != USE_DEFAULT_CORE_VERSION
+                    {
                         self.save_settings();
                     }
-                    if choice == CHANGE_VIEW {
+                    if choice == CHANGE_VIEW || choice == CORE_VERSION {
                         // Stays open, like a setting: the point is to see
                         // the view while choosing it.
                         self.adjust_context(1);
+                    } else if choice == USE_DEFAULT_CORE_VERSION {
+                        self.use_default_core_version();
                     } else if choice == USE_GLOBAL_VIEW {
                         self.use_global_view();
                     } else if choice == CHANGE_CATEGORY_IMAGE {
@@ -9508,7 +9762,11 @@ impl App {
     /// Whether the favourites folder is what is being looked at, so the
     /// mark can stand in for a picture nothing here will ever have.
     fn in_favorites(&self) -> bool {
-        self.open_system.as_deref() == Some(FAVORITES_ID)
+        self.open_system.as_ref().is_some_and(|id| {
+            self.all_systems
+                .iter()
+                .any(|system| &system.def.id == id && system.category() == "Favorites")
+        })
     }
 
     /// The picture, the words under it, whether the heart should stand in
@@ -9550,7 +9808,7 @@ impl App {
                 match self.systems.get(self.system_list.selected()) {
                     Some(system) => {
                         let (logo, heart) =
-                            logo_or_favorite_heart(&system.def.id, self.system_logo(system));
+                            logo_or_favorite_heart(system.category(), self.system_logo(system));
                         (logo, system.name().to_string(), heart, false)
                     }
                     None => (None, String::new(), false, false),
@@ -9780,7 +10038,7 @@ impl App {
                             let favorite = browse_row_favorite(
                                 self.layout,
                                 false,
-                                self.systems[index].def.id == FAVORITES_ID,
+                                self.systems[index].category() == FAVORITES_ID,
                             );
                             // How many games are in there, where the card
                             // has been read for it.
@@ -9894,7 +10152,12 @@ impl App {
             Screen::Context => {
                 for index in range {
                     let value = self.context_value(index);
-                    rows.push(plain_row(&self.menu[index], &value));
+                    if self.menu[index] == CORE_VERSION {
+                        // Full nightly paths use the existing title marquee on small screens.
+                        rows.push(plain_row(&format!("{CORE_VERSION}: {value}"), ""));
+                    } else {
+                        rows.push(plain_row(&self.menu[index], &value));
+                    }
                 }
             }
             Screen::Options | Screen::Advanced => {
@@ -10623,14 +10886,16 @@ impl App {
             .iter()
             .map(|crumb| (crumb.place.clone(), crumb.selected))
             .collect();
-        crate::state::State::record(
+        let mut saved = crate::state::State::record(
             &system,
             self.open_category.as_deref().unwrap_or_default(),
             &trail,
             self.game_list.selected(),
             &self.left_at,
             &self.category_system,
-        )
+        );
+        saved.selected_row = self.here.get(self.game_list.selected()).map(row_key);
+        saved
     }
 
     /// Put the user back where they were before the game.
@@ -10708,7 +10973,11 @@ impl App {
         // the truthful one, so it goes back in whole.
         self.left_at = saved.left_at.clone();
         if walked_everything {
-            self.game_list.select(saved.selected);
+            self.game_list.select(reselect(
+                &self.here,
+                saved.selected_row.as_deref(),
+                saved.selected,
+            ));
         } else {
             // The walk stopped short of the folder the cursor position
             // belongs to; that number means a row in a folder that was
@@ -11125,6 +11394,190 @@ pub enum Outcome {
     },
 }
 
+/// Runs within the renderer's single installed Slint platform.
+#[cfg(test)]
+pub(crate) fn test_library_launch_flow(window: Rc<MinimalSoftwareWindow>) {
+    let root = std::env::temp_dir().join(format!("degauss-app-library-{}", std::process::id()));
+    assert!(!root.exists(), "fixture must be isolated");
+    for folder in ["games/NES", "_Console", "_RA_Cores/Cores", "_Unstable"] {
+        std::fs::create_dir_all(root.join(folder)).unwrap();
+    }
+    std::fs::write(root.join("_Console/NES_20260101.rbf"), b"standard").unwrap();
+    std::fs::write(root.join("_RA_Cores/Cores/NES.rbf"), b"ra").unwrap();
+    std::fs::write(root.join("_RA_Cores/NES.mgl"), b"<mistergamedescription><rbf>_RA_Cores/Cores/NES</rbf><setname same_dir=\"1\">RA_NES</setname></mistergamedescription>").unwrap();
+    let nightly = "_Unstable/NES_unstable_20260101_123456.rbf";
+    std::fs::write(root.join(nightly), b"nightly").unwrap();
+    let archive = root.join("games/NES/small.zip");
+    std::fs::write(
+        &archive,
+        crate::zip::tests_archive(&["A/one.nes", "B/two.nes"], false),
+    )
+    .unwrap();
+    let mut config = Config::parse("[app]", &root.join("degauss.toml")).unwrap();
+    config.menu_root = root.to_string_lossy().into_owned();
+    config.game_roots = vec![root.join("games").to_string_lossy().into_owned()];
+    let table = crate::systems::parse_table(
+        include_str!("../assets/systems.toml"),
+        Path::new("systems.toml"),
+    )
+    .unwrap();
+    let def = table.iter().find(|s| s.id == "NES").unwrap().clone();
+    let found = FoundSystem {
+        def: def.clone(),
+        paths: vec![root.join("games/NES")],
+        logo_dir: None,
+        menu_folder: None,
+    };
+    let loaded = Loaded {
+        config,
+        settings: Settings::default(),
+        settings_path: root.join("settings.toml"),
+        systems: vec![found],
+        table: vec![def],
+        names: Default::default(),
+        logo_dir: None,
+        themes_dir: root.join("themes"),
+        themes: Default::default(),
+    };
+    let ui = DegaussWindow::new().unwrap();
+    let mut app = App::new(loaded, window, ui, StartupTimings::default(), 352, 240);
+    app.open_system_by_index(0);
+    let rules = std::mem::take(&mut app.all_systems[0].def.launch);
+    assert_eq!(
+        app.core_system_id().as_deref(),
+        Some("NES"),
+        "an explicitly bound core remains selectable without file launch rules"
+    );
+    assert!(
+        !crate::core_choices::available(&app.all_systems[0].to_config(), &root,)
+            .unwrap()
+            .is_empty()
+    );
+    app.all_systems[0].def.launch = rules;
+    let rbf = std::mem::take(&mut app.all_systems[0].def.rbf);
+    assert!(
+        app.core_system_id().is_none(),
+        "file rules alone do not bind a system core"
+    );
+    app.all_systems[0].def.rbf = rbf;
+    app.enter(Place::Archive(archive.clone()));
+    assert_eq!(app.here.len(), 2, "archive keeps two immediate folders");
+    app.enter(Place::ArchiveDirectory {
+        archive: archive.clone(),
+        prefix: "A".into(),
+    });
+    assert_eq!(app.here.len(), 1);
+    app.game_list.select(0);
+    let mgl = |app: &mut App| match app
+        .confirm_launch()
+        .expect("UI must allow a valid ZIP member")
+    {
+        Outcome::Launch { plan, .. } => plan.mgl,
+        _ => panic!("expected launch outcome"),
+    };
+    assert!(mgl(&mut app).contains("<rbf>_Console/NES</rbf>"));
+    app.open_context();
+    assert!(app.menu.iter().any(|row| row == CORE_VERSION));
+    app.menu_list
+        .select(app.menu.iter().position(|row| row == CORE_VERSION).unwrap());
+    app.handle(Action::Faster);
+    assert!(
+        app.message.is_none(),
+        "successful cycling must not intercept the next input"
+    );
+    assert_eq!(
+        app.settings.core_choices.get("NES").map(String::as_str),
+        Some("standard")
+    );
+    assert_eq!(
+        Settings::load(&app.settings_path).unwrap().core_choices,
+        app.settings.core_choices
+    );
+    app.handle(Action::Faster);
+    assert_eq!(
+        app.settings.core_choices.get("NES").map(String::as_str),
+        Some("ra"),
+        "consecutive inputs must cycle without dismissing a modal"
+    );
+    assert!(app.message.is_none());
+    assert_eq!(
+        Settings::load(&app.settings_path).unwrap().core_choices,
+        app.settings.core_choices
+    );
+    assert!(mgl(&mut app).contains("same_dir=\"1\""));
+    std::fs::remove_file(root.join("_Console/NES_20260101.rbf")).unwrap();
+    assert!(
+        mgl(&mut app).contains("_RA_Cores/Cores/NES"),
+        "RA works without standard"
+    );
+    app.settings
+        .core_choices
+        .insert("NES".into(), nightly.into());
+    assert!(
+        mgl(&mut app).contains(nightly.trim_end_matches(".rbf")),
+        "explicit nightly works without standard"
+    );
+    std::fs::remove_file(root.join(nightly)).unwrap();
+    assert!(
+        app.confirm_launch().is_none(),
+        "missing explicit core must stay in UI"
+    );
+    assert!(app
+        .message
+        .as_ref()
+        .is_some_and(|message| !message.is_empty()));
+    app.settings.core_choices.insert("NES".into(), "ra".into());
+    std::fs::write(
+        &archive,
+        crate::zip::tests_archive(&["A/First.nes", "A/Target.nes", "B/Target.nes"], false),
+    )
+    .unwrap();
+    assert!(app.refresh_system("NES").is_none());
+    app.show_here();
+    app.filter = "TARGET".into();
+    app.apply_filter();
+    assert_eq!(app.here.len(), 1);
+    assert_eq!(
+        app.game_list.selected(),
+        0,
+        "search has its own row indexes"
+    );
+    assert!(mgl(&mut app).contains("small.zip/A/Target.nes"));
+    let state_path = root.join("return-state.toml");
+    app.position().save(&state_path).unwrap();
+    let saved = crate::state::State::load(&state_path);
+    app.restore_position(&saved);
+    assert!(
+        app.filter.is_empty(),
+        "resume preserves existing search-reset behavior"
+    );
+    assert_eq!(
+        app.game_list.selected(),
+        1,
+        "the launched member moved in the full list"
+    );
+    assert_eq!(
+        row_key(&app.here[app.game_list.selected()]),
+        format!("f:{}", archive.join("A/Target.nes").display()),
+        "return must select the exact member, not another folder's same basename"
+    );
+    let mut old_saved = saved.clone();
+    old_saved.selected_row = None;
+    app.restore_position(&old_saved);
+    assert_eq!(
+        app.game_list.selected(),
+        0,
+        "old state files retain numeric selection"
+    );
+    std::fs::write(&archive, b"broken").unwrap();
+    assert!(
+        app.confirm_launch().is_none(),
+        "changed archive must be revalidated at confirmation"
+    );
+    drop(app);
+    std::fs::remove_dir_all(root).unwrap();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -11412,6 +11865,7 @@ mod tests {
         std::fs::create_dir_all(&games).unwrap();
         std::fs::write(games.join("Game.rom"), b"rom").unwrap();
         let config = SystemConfig {
+            preserve_rbf_stem: false,
             name: "Test".to_string(),
             path: games.to_string_lossy().into_owned(),
             extensions: vec!["rom".to_string()],
@@ -12104,6 +12558,7 @@ mod tests {
         .unwrap();
 
         let config = SystemConfig {
+            preserve_rbf_stem: false,
             name: "SuperGrafx".to_string(),
             path: games.to_string_lossy().into_owned(),
             extensions: vec!["sgx".to_string()],
@@ -12787,6 +13242,31 @@ mod tests {
             },
         );
         assert!(!groups.iter().any(|entry| entry == REBUILD_SYSTEM));
+    }
+
+    #[test]
+    fn default_core_reset_is_available_from_saved_state_without_enumerating_files() {
+        for override_exists in [false, true] {
+            let entries = context_entries(
+                Browsing::Systems,
+                false,
+                None,
+                None,
+                false,
+                ContextActions {
+                    core_version: true,
+                    core_version_override: override_exists,
+                    ..ContextActions::default()
+                },
+            );
+            assert!(entries.iter().any(|entry| entry == CORE_VERSION));
+            assert_eq!(
+                entries
+                    .iter()
+                    .any(|entry| entry == USE_DEFAULT_CORE_VERSION),
+                override_exists
+            );
+        }
     }
 
     #[test]

--- a/src/artwork_pack.rs
+++ b/src/artwork_pack.rs
@@ -24,7 +24,8 @@ const MAX_ROWS: usize = 250_000;
 const MAX_LINE_BYTES: usize = 64 * 1024;
 const MAX_VALUE_BYTES: usize = 1_024;
 const MAX_JPEGS: usize = 100_000;
-const MAX_IDENTITY_XML_BYTES: u64 = 1024 * 1024;
+// XML metadata stays bounded; embedded ROM bytes do not belong to that budget.
+const MAX_IDENTITY_XML_BYTES: usize = 1024 * 1024;
 const MAX_MGL_REDIRECTS: usize = 8;
 const MAX_HASH_BYTES: u64 = 64 * 1024 * 1024;
 const HASH_BUFFER_BYTES: usize = 128 * 1024;
@@ -267,9 +268,21 @@ pub struct Provider {
     /// prepared by a background worker so browse projection performs no game
     /// descriptor, archive, ROM, or Pack filesystem I/O.
     prepared: Option<Arc<HashMap<String, PackPresentation>>>,
+    archive_cache: Arc<std::sync::Mutex<crate::zip::ArchiveCache>>,
 }
 
 impl Provider {
+    fn identity_for_launch(
+        &self,
+        launch: &Launch,
+        cancelled: &AtomicBool,
+    ) -> Result<Option<GameIdentity>> {
+        let mut archives = self.archive_cache.lock().map_err(|_| {
+            DegaussError::unsupported("archive lookup", "archive cache lock was poisoned")
+        })?;
+        identity_for_launch_controlled(launch, cancelled, &mut archives)
+    }
+
     pub fn load(system_id: &str, docs_root: &Path, language: Option<&str>) -> Self {
         let cancelled = AtomicBool::new(false);
         Self::load_controlled(system_id, docs_root, language, &cancelled)
@@ -319,6 +332,7 @@ impl Provider {
                 snapshot: None,
                 synopsis_language: normalized_language(language),
                 prepared: None,
+                archive_cache: Arc::new(std::sync::Mutex::new(crate::zip::ArchiveCache::default())),
             });
         };
 
@@ -376,6 +390,7 @@ impl Provider {
                     snapshot: None,
                     synopsis_language: normalized_language(language),
                     prepared: None,
+            archive_cache: Arc::new(std::sync::Mutex::new(crate::zip::ArchiveCache::default())),
                 });
             }
         }
@@ -438,6 +453,7 @@ impl Provider {
             snapshot: None,
             synopsis_language: normalized_language(language),
             prepared: None,
+            archive_cache: Arc::new(std::sync::Mutex::new(crate::zip::ArchiveCache::default())),
         })
     }
 
@@ -471,6 +487,7 @@ impl Provider {
     /// an older source-neutral cache across a new worker validation pass.
     pub fn clear_prepared(&mut self) {
         self.prepared = None;
+        self.archive_cache = Arc::new(std::sync::Mutex::new(crate::zip::ArchiveCache::default()));
     }
 
     #[cfg(test)]
@@ -492,6 +509,7 @@ impl Provider {
     /// rebuilt cache.
     pub(crate) fn discard_catalogue(&mut self) {
         self.directories = Arc::new(Vec::new());
+        self.archive_cache = Arc::new(std::sync::Mutex::new(crate::zip::ArchiveCache::default()));
     }
 
     #[cfg(test)]
@@ -516,7 +534,7 @@ impl Provider {
         if !self.health.usable() {
             return Ok(None);
         }
-        let Some(mut identity) = identity_for_launch_controlled(launch, cancelled)? else {
+        let Some(mut identity) = self.identity_for_launch(launch, cancelled)? else {
             return Ok(None);
         };
         let cheap = self.resolve(&identity);
@@ -648,7 +666,7 @@ impl Provider {
         if !self.health.usable() || cancelled.load(Ordering::Relaxed) {
             return Ok(None);
         }
-        let Some(identity) = identity_for_launch_controlled(launch, cancelled)? else {
+        let Some(identity) = self.identity_for_launch(launch, cancelled)? else {
             return Ok(None);
         };
         if self
@@ -758,7 +776,7 @@ impl Provider {
                 if !inspected.insert(launch_cache_key(launch)) {
                     continue;
                 }
-                let identity = identity_for_launch_controlled(launch, cancelled)?;
+                let identity = self.identity_for_launch(launch, cancelled)?;
                 if cancelled.load(Ordering::Relaxed) {
                     return Ok(None);
                 }
@@ -2108,6 +2126,7 @@ fn first_line(value: &str) -> String {
 fn identity_for_launch_controlled(
     launch: &Launch,
     cancelled: &AtomicBool,
+    archives: &mut crate::zip::ArchiveCache,
 ) -> Result<Option<GameIdentity>> {
     if cancelled.load(Ordering::Relaxed) {
         return Ok(None);
@@ -2121,7 +2140,9 @@ fn identity_for_launch_controlled(
             extension: None,
             hash_path: None,
         })),
-        Launch::File(path) => identity_for_path_controlled(path, cancelled),
+        Launch::File(path) => {
+            identity_for_path_redirected(path, cancelled, 0, &mut HashSet::new(), archives)
+        }
     }
 }
 
@@ -2130,11 +2151,18 @@ fn identity_for_path(path: &Path) -> Result<Option<GameIdentity>> {
     identity_for_path_controlled(path, &AtomicBool::new(false))
 }
 
+#[cfg(test)]
 fn identity_for_path_controlled(
     path: &Path,
     cancelled: &AtomicBool,
 ) -> Result<Option<GameIdentity>> {
-    identity_for_path_redirected(path, cancelled, 0, &mut HashSet::new())
+    identity_for_path_redirected(
+        path,
+        cancelled,
+        0,
+        &mut HashSet::new(),
+        &mut crate::zip::ArchiveCache::default(),
+    )
 }
 
 fn identity_for_path_redirected(
@@ -2142,16 +2170,18 @@ fn identity_for_path_redirected(
     cancelled: &AtomicBool,
     redirects: usize,
     visited_mgls: &mut HashSet<PathBuf>,
+    archives: &mut crate::zip::ArchiveCache,
 ) -> Result<Option<GameIdentity>> {
     if cancelled.load(Ordering::Relaxed) {
         return Ok(None);
     }
     if let Some((archive, member)) = archive_member(path) {
-        let Some(entries) = crate::zip::entries_controlled(&archive, cancelled)? else {
+        let Some(entries) = archives.read_controlled(&archive, cancelled)? else {
             return Ok(None);
         };
         let Some(entry) = entries
-            .into_iter()
+            .entries
+            .iter()
             .find(|entry| Path::new(&entry.name) == member)
         else {
             return Ok(None);
@@ -2179,7 +2209,7 @@ fn identity_for_path_redirected(
         .unwrap_or("")
         .to_ascii_lowercase();
     if extension == "mra" {
-        let Some(setname) = xml_text(path, "setname")? else {
+        let Some(setname) = xml_text(path, "setname", cancelled)? else {
             return Ok(None);
         };
         if cancelled.load(Ordering::Relaxed) {
@@ -2216,7 +2246,13 @@ fn identity_for_path_redirected(
         if cancelled.load(Ordering::Relaxed) {
             return Ok(None);
         }
-        return identity_for_path_redirected(&target, cancelled, redirects + 1, visited_mgls);
+        return identity_for_path_redirected(
+            &target,
+            cancelled,
+            redirects + 1,
+            visited_mgls,
+            archives,
+        );
     }
     let name = path
         .file_stem()
@@ -2327,27 +2363,97 @@ fn fingerprint_key(path: &Path) -> String {
     path.to_string_lossy().into_owned()
 }
 
-fn xml_text(path: &Path, wanted: &str) -> Result<Option<String>> {
-    let size = std::fs::metadata(path)
-        .map_err(|error| DegaussError::io("reading game descriptor", path, error))?
-        .len();
-    if size > MAX_IDENTITY_XML_BYTES {
-        return Err(DegaussError::unsupported(
-            "game descriptor",
-            format!(
-                "{} is larger than {MAX_IDENTITY_XML_BYTES} bytes",
-                path.display()
-            ),
-        ));
+/// Bound retained XML metadata without rejecting large embedded ROM payloads.
+struct IdentityXmlInput<'a, R> {
+    inner: R,
+    cancelled: &'a AtomicBool,
+    metadata_bytes: usize,
+}
+
+impl<R: BufRead> Read for IdentityXmlInput<'_, R> {
+    fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+        let available = self.fill_buf()?;
+        let count = output.len().min(available.len());
+        output[..count].copy_from_slice(&available[..count]);
+        self.consume(count);
+        Ok(count)
     }
+}
+
+impl<R: BufRead> BufRead for IdentityXmlInput<'_, R> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        if self.cancelled.load(Ordering::Relaxed) {
+            return Err(std::io::Error::other("game descriptor reading cancelled"));
+        }
+        let available = self.inner.fill_buf()?;
+        let remaining = MAX_IDENTITY_XML_BYTES.saturating_sub(self.metadata_bytes);
+        if remaining == 0 && !available.is_empty() {
+            return Err(std::io::Error::other(format!(
+                "XML metadata exceeds {MAX_IDENTITY_XML_BYTES} bytes"
+            )));
+        }
+        Ok(&available[..available.len().min(remaining)])
+    }
+
+    fn consume(&mut self, count: usize) {
+        self.metadata_bytes += count;
+        self.inner.consume(count);
+    }
+}
+
+fn xml_text(path: &Path, wanted: &str, cancelled: &AtomicBool) -> Result<Option<String>> {
     let file = File::open(path)
         .map_err(|error| DegaussError::io("opening game descriptor", path, error))?;
-    let mut reader = Reader::from_reader(BufReader::new(file));
+    xml_text_from_reader(BufReader::new(file), path, wanted, cancelled)
+}
+
+fn xml_text_from_reader<R: BufRead>(
+    input: R,
+    path: &Path,
+    wanted: &str,
+    cancelled: &AtomicBool,
+) -> Result<Option<String>> {
+    let mut reader = Reader::from_reader(IdentityXmlInput {
+        inner: input,
+        cancelled,
+        metadata_bytes: 0,
+    });
     let mut buffer = Vec::new();
     let mut active = false;
     let mut value = String::new();
+    let mut embedded_payload = false;
     loop {
+        if cancelled.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        if embedded_payload {
+            // Native MRA parts, patches and cheats carry hexadecimal data. Consume
+            // those bytes through quick-xml's stream API, retaining neither a
+            // text event nor a copy. Leave markup and other content to the XML
+            // parser, including its existing malformed-document diagnostics.
+            loop {
+                let available = match reader.stream().fill_buf() {
+                    Ok(bytes) => bytes
+                        .iter()
+                        .take_while(|byte| {
+                            byte.is_ascii_hexdigit() || byte.is_ascii_whitespace() || **byte == b','
+                        })
+                        .count(),
+                    Err(_) if cancelled.load(Ordering::Relaxed) => return Ok(None),
+                    Err(error) => {
+                        return Err(DegaussError::io("reading game descriptor", path, error))
+                    }
+                };
+                if available == 0 {
+                    break;
+                }
+                reader.stream().consume(available);
+                reader.get_mut().metadata_bytes -= available;
+            }
+            embedded_payload = false;
+        }
         match reader.read_event_into(&mut buffer) {
+            Err(_) if cancelled.load(Ordering::Relaxed) => return Ok(None),
             Err(error) => {
                 return Err(DegaussError::malformed(
                     "game descriptor",
@@ -2358,6 +2464,10 @@ fn xml_text(path: &Path, wanted: &str) -> Result<Option<String>> {
             Ok(Event::Eof) => break,
             Ok(Event::Start(event)) => {
                 active = event.name().as_ref().eq_ignore_ascii_case(wanted);
+                embedded_payload = !active
+                    && ["part", "patch", "cheat"]
+                        .iter()
+                        .any(|tag| event.name().as_ref().eq_ignore_ascii_case(tag));
                 if active {
                     value.clear();
                 }
@@ -2524,6 +2634,7 @@ mod tests {
         )
         .unwrap();
         let config = crate::config::SystemConfig {
+            preserve_rbf_stem: false,
             name: "SuperGrafx".to_string(),
             path: games.to_string_lossy().into_owned(),
             extensions: vec!["sgx".to_string()],
@@ -3156,6 +3267,166 @@ mod tests {
         std::fs::remove_dir_all(dir).ok();
     }
 
+    fn embedded_mra(size: usize, setname_first: bool) -> Vec<u8> {
+        let identity = "<setname>embedded</setname>";
+        let mut bytes = b"<misterromdescription>".to_vec();
+        if setname_first {
+            bytes.extend_from_slice(identity.as_bytes());
+        }
+        bytes.extend_from_slice(b"<rom index=\"0\"><part>");
+        bytes.resize(bytes.len() + size, b'A');
+        bytes.extend_from_slice(b"</part></rom>");
+        if !setname_first {
+            bytes.extend_from_slice(identity.as_bytes());
+        }
+        bytes.extend_from_slice(b"</misterromdescription>");
+        bytes
+    }
+
+    #[test]
+    fn large_embedded_mra_matches_before_or_after_rom_data_and_through_mgl() {
+        let dir = temp("large-embedded-mra");
+        let mra = dir.join("Game.mra");
+        for first in [true, false] {
+            for payload in [
+                MAX_IDENTITY_XML_BYTES - 1,
+                MAX_IDENTITY_XML_BYTES + 1,
+                3 * MAX_IDENTITY_XML_BYTES,
+            ] {
+                std::fs::write(&mra, embedded_mra(payload, first)).unwrap();
+                let identity = identity_for_path(&mra).unwrap().unwrap();
+                assert_eq!(identity.name, "embedded");
+                assert_eq!(identity.setname.as_deref(), Some("embedded"));
+            }
+        }
+        let mgl = dir.join("Favorite.mgl");
+        std::fs::write(
+            &mgl,
+            "<mistergamedescription><file path=\"Game.mra\"/></mistergamedescription>",
+        )
+        .unwrap();
+        assert_eq!(identity_for_path(&mgl).unwrap().unwrap().name, "embedded");
+        // The background preparation path must also complete, even when there
+        // is no matching image and it considers a fingerprint for this MRA.
+        let docs = dir.join("docs");
+        ready_directory(&docs, "Arcade", "other", "Other", "Other");
+        let provider = Provider::load("Arcade", &docs, None);
+        assert!(provider.health.usable(), "{:?}", provider.diagnostics);
+        assert!(provider
+            .fingerprint_for_launch(&Launch::File(mra), &AtomicBool::new(false), &mut |_| {})
+            .unwrap()
+            .is_none());
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn mra_native_payload_tags_accept_large_comma_separated_hex() {
+        let cancelled = AtomicBool::new(false);
+        for tag in ["part", "patch", "cheat"] {
+            let document = format!(
+                "<misterromdescription><{tag}>{}</{tag}><setname>kept</setname></misterromdescription>",
+                "AA, BB\n".repeat(MAX_IDENTITY_XML_BYTES / 4)
+            );
+            // Small chunks force tag, payload, and comma boundaries through
+            // the real buffered reader rather than a single borrowed slice.
+            let reader = BufReader::with_capacity(13, std::io::Cursor::new(document));
+            assert_eq!(
+                xml_text_from_reader(reader, Path::new("payload.mra"), "setname", &cancelled)
+                    .unwrap()
+                    .as_deref(),
+                Some("kept"),
+                "native {tag} payload must not consume the XML metadata budget"
+            );
+        }
+    }
+
+    #[test]
+    fn mra_identity_keeps_metadata_limits_and_existing_xml_errors() {
+        let path = Path::new("descriptor.mra");
+        let cancelled = AtomicBool::new(false);
+        let oversized = format!(
+            "<misterromdescription><setname>{}</setname></misterromdescription>",
+            "x".repeat(MAX_IDENTITY_XML_BYTES + 1)
+        );
+        let error =
+            xml_text_from_reader(std::io::Cursor::new(oversized), path, "setname", &cancelled)
+                .unwrap_err();
+        assert!(
+            error.to_string().contains("XML metadata exceeds"),
+            "{error}"
+        );
+        let malformed = b"<misterromdescription><rom></wrong><setname>bad</setname>";
+        assert!(
+            xml_text_from_reader(std::io::Cursor::new(malformed), path, "setname", &cancelled)
+                .is_err()
+        );
+        assert_eq!(
+            xml_text_from_reader(
+                std::io::Cursor::new(b"<misterromdescription/>"),
+                path,
+                "setname",
+                &cancelled
+            )
+            .unwrap(),
+            None
+        );
+        // Matching never validated bytes after the first complete setname.
+        assert_eq!(
+            xml_text_from_reader(
+                std::io::Cursor::new(b"<root><setname>  kept  </setname><broken"),
+                path,
+                "setname",
+                &cancelled
+            )
+            .unwrap()
+            .as_deref(),
+            Some("kept")
+        );
+    }
+
+    #[test]
+    fn embedded_mra_stream_checks_cancellation_and_propagates_read_errors() {
+        struct ControlledInput<'a> {
+            bytes: std::io::Cursor<Vec<u8>>,
+            cancelled: &'a AtomicBool,
+            fail: bool,
+        }
+        impl Read for ControlledInput<'_> {
+            fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+                if self.bytes.position() >= 4096 {
+                    if self.fail {
+                        return Err(std::io::Error::other("injected descriptor read failure"));
+                    }
+                    self.cancelled.store(true, Ordering::Relaxed);
+                }
+                self.bytes.read(output)
+            }
+        }
+        for fail in [false, true] {
+            let cancelled = AtomicBool::new(false);
+            let input = ControlledInput {
+                bytes: std::io::Cursor::new(embedded_mra(3 * MAX_IDENTITY_XML_BYTES, false)),
+                cancelled: &cancelled,
+                fail,
+            };
+            let result = xml_text_from_reader(
+                BufReader::with_capacity(128, input),
+                Path::new("embedded.mra"),
+                "setname",
+                &cancelled,
+            );
+            if fail {
+                assert!(result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("injected descriptor read failure"));
+            } else {
+                assert_eq!(result.unwrap(), None);
+                assert!(cancelled.load(Ordering::Relaxed));
+            }
+        }
+    }
+
     #[test]
     fn loose_crc_is_cancellable_and_resolves_only_with_matching_size() {
         let (root, art) = pack("loose-crc");
@@ -3233,6 +3504,47 @@ mod tests {
             .unwrap();
         assert_eq!(result, None);
         std::fs::remove_dir_all(root.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn completed_provider_clones_release_operation_archive_listings() {
+        let root = temp("provider-archive-lifecycle");
+        let archive = root.join("empty.zip");
+        let mut bytes = vec![0; 22];
+        bytes[..4].copy_from_slice(b"PK\x05\x06");
+        std::fs::write(&archive, bytes).unwrap();
+        let mut provider = Provider::load("NES", &root, None);
+        let contents = provider
+            .archive_cache
+            .lock()
+            .unwrap()
+            .read(&archive)
+            .unwrap();
+        let listing = Arc::downgrade(&contents);
+        drop(contents);
+        let mut worker = provider.clone();
+
+        provider.discard_catalogue();
+        assert!(
+            listing.upgrade().is_some(),
+            "an active worker keeps its own listing"
+        );
+        assert!(!Arc::ptr_eq(&provider.archive_cache, &worker.archive_cache));
+        worker.clear_prepared();
+        assert!(
+            listing.upgrade().is_none(),
+            "completed clones release the previous listing"
+        );
+
+        let contents = worker.archive_cache.lock().unwrap().read(&archive).unwrap();
+        let listing = Arc::downgrade(&contents);
+        drop(contents);
+        worker.discard_catalogue();
+        assert!(
+            listing.upgrade().is_none(),
+            "a UI snapshot retains no archive listing"
+        );
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/browse.rs
+++ b/src/browse.rs
@@ -58,6 +58,8 @@ pub enum Place {
     /// all of them, live in `_DOS Games`. Opening only the first folder
     /// hides the entire library.
     Roots,
+    /// An internal ZIP directory. Appended to preserve postcard enum tags.
+    ArchiveDirectory { archive: PathBuf, prefix: String },
 }
 
 impl Place {
@@ -66,6 +68,7 @@ impl Place {
             Place::Dir(path) | Place::Archive(path) => path,
             Place::Listing { file, .. } => file,
             Place::Roots => Path::new(""),
+            Place::ArchiveDirectory { archive, .. } => archive,
         }
     }
 
@@ -82,6 +85,9 @@ impl Place {
                 format!("l:{}|{}", install.display(), file.display())
             }
             Place::Roots => "r:".to_string(),
+            Place::ArchiveDirectory { archive, prefix } => {
+                format!("a:{}/{}", archive.display(), prefix)
+            }
         }
     }
 }
@@ -323,6 +329,7 @@ pub struct Library {
     /// but it must remain visible to the diagnostic paths rather than being
     /// reduced to a log line that `--audit` cannot report.
     structural_problems: Vec<(PathBuf, String)>,
+    archive_cache: std::cell::RefCell<crate::zip::ArchiveCache>,
     /// What reading this system's metadata cost, so the answer to "why did
     /// that take a moment" is measured rather than guessed.
     pub cost: OpenCost,
@@ -342,6 +349,23 @@ pub struct OpenCost {
 /// reached through one reads as an ordinary file and its games disappear.
 /// Collections built out of linked trees are common enough on a card that
 /// the extra call is worth making, and it is only made for links.
+fn entry_is_dir_checked(item: &std::fs::DirEntry) -> Result<bool> {
+    let kind = item
+        .file_type()
+        .map_err(|error| DegaussError::io("reading entry type", item.path(), error))?;
+    if kind.is_symlink() {
+        // Dangling links have no launchable target; preserve that established
+        // case, but permission/device failures must not hide a subtree.
+        match std::fs::metadata(item.path()) {
+            Ok(metadata) => Ok(metadata.is_dir()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(DegaussError::io("reading link target", item.path(), error)),
+        }
+    } else {
+        Ok(kind.is_dir())
+    }
+}
+
 fn entry_is_dir(item: &std::fs::DirEntry) -> bool {
     match item.file_type() {
         Ok(kind) if kind.is_symlink() => item.path().is_dir(),
@@ -429,6 +453,7 @@ impl Library {
             roots,
             names,
             structural_problems,
+            archive_cache: std::cell::RefCell::new(crate::zip::ArchiveCache::default()),
             cost,
         })
     }
@@ -446,9 +471,12 @@ impl Library {
     /// a person reads them.
     pub fn list(&self, place: &Place, show_empty: bool) -> Result<(Vec<Row>, ListStats)> {
         let (mut rows, stats) = match place {
-            Place::Roots => self.list_roots(show_empty),
+            Place::Roots => self.list_roots(show_empty)?,
             Place::Dir(dir) => self.list_dir(dir, show_empty)?,
-            Place::Archive(archive) => self.list_archive(archive)?,
+            Place::Archive(archive) => self.list_archive(archive, "", show_empty)?,
+            Place::ArchiveDirectory { archive, prefix } => {
+                self.list_archive(archive, prefix, show_empty)?
+            }
             Place::Listing { install, file } => self.list_listing(install, file)?,
         };
         // Folders first, exactly as the stock menu orders them, then by
@@ -462,11 +490,11 @@ impl Library {
     }
 
     /// The system's folders, one row each, named as they are on the card.
-    fn list_roots(&self, show_empty: bool) -> (Vec<Row>, ListStats) {
+    fn list_roots(&self, show_empty: bool) -> Result<(Vec<Row>, ListStats)> {
         let mut rows = Vec::new();
         let mut stats = ListStats::default();
         for (index, root) in self.roots.iter().enumerate() {
-            if !show_empty && self.shows_nothing(&root.path, Some(index), 0) {
+            if !show_empty && self.shows_nothing(&root.path, Some(index), 0)? {
                 stats.empty_folders_hidden += 1;
                 continue;
             }
@@ -478,7 +506,7 @@ impl Library {
             stats.folders += 1;
             rows.push(folder_row(name, Place::Dir(root.path.clone())));
         }
-        (rows, stats)
+        Ok((rows, stats))
     }
 
     fn list_dir(&self, dir: &Path, show_empty: bool) -> Result<(Vec<Row>, ListStats)> {
@@ -498,26 +526,9 @@ impl Library {
         let mut rows = Vec::new();
         let mut stats = ListStats::default();
 
-        // An entry the filesystem refuses is a game that silently is not
-        // there. Dropping it is still the only answer, because one bad entry
-        // must not cost the whole folder, but it is counted and said out
-        // loud: a folder that is quietly short is the harder fault to find.
-        let mut unreadable = 0usize;
-        let entries: Vec<std::fs::DirEntry> = listing
-            .filter_map(|item| match item {
-                Ok(entry) => Some(entry),
-                Err(_) => {
-                    unreadable += 1;
-                    None
-                }
-            })
-            .collect();
-        if unreadable > 0 {
-            crate::note(&format!(
-                "folder       {}: {unreadable} entries could not be read and are missing",
-                dir.display()
-            ));
-        }
+        let entries = listing
+            .collect::<std::io::Result<Vec<_>>>()
+            .map_err(|error| DegaussError::io("reading folder entry", dir, error))?;
         for item in entries {
             let name = item.file_name().to_string_lossy().into_owned();
             // Dotfiles are not content, and a card that has met a Mac is
@@ -525,13 +536,9 @@ impl Library {
             if name.starts_with('.') {
                 continue;
             }
-            // Unreadable entries are skipped rather than guessed at.
-            if item.file_type().is_err() {
-                continue;
-            }
             let path = item.path();
 
-            if entry_is_dir(&item) {
+            if entry_is_dir_checked(&item)? {
                 // Windows leaves this on every card it touches, and the
                 // stock menu does not show it either.
                 if name == "System Volume Information" {
@@ -542,14 +549,14 @@ impl Library {
                     continue;
                 }
                 if self.is_art_directory(&path, root)
-                    || self.is_structural_art_subtree(&path, root)
+                    || self.is_structural_art_subtree(&path, root)?
                     || self.is_skipped(&name)
                 {
                     continue;
                 }
                 // A folder with nothing to reach inside it is a dead end,
                 // and a card accumulates them.
-                if !show_empty && self.shows_nothing(&path, root, 0) {
+                if !show_empty && self.shows_nothing(&path, root, 0)? {
                     stats.empty_folders_hidden += 1;
                     continue;
                 }
@@ -610,19 +617,89 @@ impl Library {
 
     /// The launchable files inside an archive. Only names are read; nothing
     /// is unpacked, because unpacking is the loader's job at launch time.
-    fn list_archive(&self, archive: &Path) -> Result<(Vec<Row>, ListStats)> {
-        let names = crate::zip::list(archive)?;
+    fn list_archive(
+        &self,
+        archive: &Path,
+        prefix: &str,
+        show_empty: bool,
+    ) -> Result<(Vec<Row>, ListStats)> {
+        let contents = self.archive_cache.borrow_mut().read(archive)?;
+        let entries = &contents.entries;
+        let supported: Vec<_> = entries
+            .iter()
+            .filter(|entry| self.config.accepts(Path::new(&entry.name)))
+            .collect();
+        let legacy_metadata = supported.len() == 1;
         let root = self.root_for(archive);
         let mut rows = Vec::new();
         let mut stats = ListStats::default();
-
-        for name in names {
-            let inner = archive.join(&name);
-            if !self.config.accepts(&inner) {
+        let mut folders = HashSet::new();
+        let directory = if prefix.is_empty() {
+            String::new()
+        } else {
+            format!("{prefix}/")
+        };
+        if !prefix.is_empty()
+            && !entries
+                .iter()
+                .any(|entry| entry.name.starts_with(&directory))
+            && !contents
+                .directories
+                .iter()
+                .any(|entry| entry == prefix || entry.starts_with(&directory))
+        {
+            return Err(DegaussError::malformed(
+                "zip archive",
+                archive,
+                format!("virtual directory {prefix:?} is missing or was renamed"),
+            ));
+        }
+        if show_empty {
+            for entry in
+                contents
+                    .directories
+                    .iter()
+                    .map(String::as_str)
+                    .chain(entries.iter().filter_map(|entry| {
+                        entry.name.rsplit_once('/').map(|(directory, _)| directory)
+                    }))
+            {
+                let Some(relative) = entry.strip_prefix(&directory) else {
+                    continue;
+                };
+                let folder = relative.split('/').next().unwrap_or_default();
+                if !folder.is_empty() && folders.insert(folder.to_string()) {
+                    stats.folders += 1;
+                    rows.push(folder_row(
+                        folder.to_string(),
+                        Place::ArchiveDirectory {
+                            archive: archive.to_path_buf(),
+                            prefix: format!("{directory}{folder}"),
+                        },
+                    ));
+                }
+            }
+        }
+        for entry in supported {
+            let Some(relative) = entry.name.strip_prefix(&directory) else {
+                continue;
+            };
+            if let Some((folder, _)) = relative.split_once('/') {
+                if folders.insert(folder.to_string()) {
+                    stats.folders += 1;
+                    rows.push(folder_row(
+                        folder.to_string(),
+                        Place::ArchiveDirectory {
+                            archive: archive.to_path_buf(),
+                            prefix: format!("{directory}{folder}"),
+                        },
+                    ));
+                }
                 continue;
             }
             stats.games += 1;
-            let row = self.game_row(&inner, root);
+            let row =
+                self.game_row_with_metadata(&archive.join(&entry.name), root, legacy_metadata);
             if row.cover.is_some() {
                 stats.with_art += 1;
             }
@@ -674,6 +751,10 @@ impl Library {
     }
 
     fn game_row(&self, path: &Path, root: Option<usize>) -> Row {
+        self.game_row_with_metadata(path, root, true)
+    }
+
+    fn game_row_with_metadata(&self, path: &Path, root: Option<usize>, legacy: bool) -> Row {
         let name = self.display_name(path);
         let mut row = Row {
             sort_key: name.to_lowercase(),
@@ -690,7 +771,7 @@ impl Library {
             .unwrap_or(path)
             .to_string_lossy()
             .into_owned();
-        self.bind(&mut row, &rel, root);
+        self.bind_with_metadata(&mut row, &rel, root, legacy);
         row
     }
 
@@ -713,6 +794,7 @@ impl Library {
             .unwrap_or_else(|| file_name.clone());
 
         match extension_of(path).as_str() {
+            "rbf" if self.config.preserve_rbf_stem => stem,
             "rbf" => {
                 // A core carries the date it was built: NeoGeo_20260603.rbf.
                 // Main cuts it at "_20" when what follows is long enough to
@@ -732,9 +814,19 @@ impl Library {
 
     /// Attach whatever the metadata overlay knows about a row.
     fn bind(&self, row: &mut Row, key: &str, root: Option<usize>) {
+        self.bind_with_metadata(row, key, root, true);
+    }
+
+    fn bind_with_metadata(&self, row: &mut Row, key: &str, root: Option<usize>, legacy: bool) {
         let Some(meta) = root
             .and_then(|index| self.roots[index].gamelist.as_ref())
-            .and_then(|list| list.lookup(key))
+            .and_then(|list| {
+                if legacy {
+                    list.lookup(key)
+                } else {
+                    list.lookup_exact(key)
+                }
+            })
             .map(|(meta, _)| meta.clone())
         else {
             return;
@@ -836,58 +928,58 @@ impl Library {
     /// would show, so a folder of games answers on its first entry; only a
     /// tree that really is empty is walked to the bottom, and an empty tree
     /// is cheap to walk.
-    fn shows_nothing(&self, dir: &Path, root: Option<usize>, depth: usize) -> bool {
+    fn shows_nothing(&self, dir: &Path, root: Option<usize>, depth: usize) -> Result<bool> {
         if depth > MAX_DEPTH {
             // Too deep to keep asking. Say it shows something, so the worst
             // a symlink loop can do is leave one folder visible.
-            return false;
+            return Ok(false);
         }
         // Asked once for the folder, not once per file in it: it is a
         // property of the folder, and answering it rescans the parent.
         let amiga_install = amiga_install_of(dir).is_some();
-        let Ok(listing) = std::fs::read_dir(dir) else {
-            // A folder that cannot be read is not known to be empty, and
-            // hiding it would hide the problem with it.
-            return false;
-        };
-        for item in listing.flatten() {
+        let listing = std::fs::read_dir(dir)
+            .map_err(|error| DegaussError::io("reading folder", dir, error))?;
+        for item in listing {
+            let item =
+                item.map_err(|error| DegaussError::io("reading folder entry", dir, error))?;
             let name = item.file_name().to_string_lossy().into_owned();
             if name.starts_with('.') || name == "System Volume Information" {
                 continue;
             }
             let path = item.path();
-            if entry_is_dir(&item) {
+            if entry_is_dir_checked(&item)? {
                 if self.is_art_directory(&path, root)
                     || self.is_skipped(&name)
-                    || self.shows_nothing(&path, root, depth + 1)
+                    || self.shows_nothing(&path, root, depth + 1)?
                 {
                     continue;
                 }
-                return false;
+                return Ok(false);
             }
             // A file only counts if it is one this system can open, an
             // archive that opens like a folder, or a listing naming titles
             // held inside a disk image.
             let extension = extension_of(&path);
             if extension == "zip" || (self.config.accepts(&path) && !is_not_a_game(&name)) {
-                return false;
+                return Ok(false);
             }
             if extension == "txt" && amiga_install {
-                return false;
+                return Ok(false);
             }
         }
-        true
+        Ok(true)
     }
 
     fn is_art_directory(&self, path: &Path, root: Option<usize>) -> bool {
         root.is_some_and(|index| self.roots[index].art.is_art_directory(path))
     }
 
-    fn is_structural_art_subtree(&self, path: &Path, root: Option<usize>) -> bool {
-        root.is_some_and(|index| {
-            self.roots[index].art.has_structural_art_below(path)
-                && self.shows_nothing(path, root, 0)
-        })
+    fn is_structural_art_subtree(&self, path: &Path, root: Option<usize>) -> Result<bool> {
+        if root.is_some_and(|index| self.roots[index].art.has_structural_art_below(path)) {
+            self.shows_nothing(path, root, 0)
+        } else {
+            Ok(false)
+        }
     }
 
     fn is_skipped(&self, name: &str) -> bool {
@@ -1101,7 +1193,7 @@ impl Library {
             .iter()
             .map(|root| (Place::Dir(root.path.clone()), 0))
             .collect();
-        let mut seen: HashSet<String> = HashSet::new();
+        let mut seen: HashSet<(String, Option<String>)> = HashSet::new();
 
         while let Some((place, depth)) = stack.pop() {
             if audit.places_read >= AUDIT_LIMIT {
@@ -1113,7 +1205,11 @@ impl Library {
             }
             // The same folder reached twice is counted once. Organised
             // collections are built out of links back into the same tree.
-            if !seen.insert(key(place.path())) {
+            let prefix = match &place {
+                Place::ArchiveDirectory { prefix, .. } => Some(prefix.clone()),
+                _ => None,
+            };
+            if !seen.insert((key(place.path()), prefix)) {
                 continue;
             }
             audit.places_read += 1;
@@ -1189,6 +1285,7 @@ mod tests {
 
     fn system(path: &Path) -> SystemConfig {
         SystemConfig {
+            preserve_rbf_stem: false,
             name: "Commodore 64".to_string(),
             path: path.to_string_lossy().into_owned(),
             extensions: vec!["d64".to_string(), "prg".to_string()],
@@ -1576,8 +1673,13 @@ mod tests {
             panic!("an archive must open like a folder");
         };
         let (inside, stats) = library.list(place, false).unwrap();
-        assert_eq!(names_of(&inside), vec!["Another Game", "Metal Slug"]);
-        assert_eq!(stats.games, 2);
+        assert_eq!(names_of(&inside), vec!["sub", "Metal Slug"]);
+        assert_eq!(stats.games, 1);
+        let Kind::Enter(nested) = &inside[0].kind else {
+            panic!("implied directory");
+        };
+        let (nested, _) = library.list(nested, false).unwrap();
+        assert_eq!(names_of(&nested), ["Another Game"]);
         // readme.txt is in the archive but no core loads it.
         assert!(!inside.iter().any(|row| row.name.contains("readme")));
 
@@ -1586,6 +1688,28 @@ mod tests {
         };
         assert_eq!(path, &archive.join("Metal Slug.neo"));
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn audit_visits_nested_archive_directories_with_exact_member_casing() {
+        let dir = temp("audit-nested-zip");
+        // ASCII case aliases are rejected by Main-compatible archive validation.
+        // These UTF-8 prefixes remain distinct and must not be lowercased by audit.
+        std::fs::write(
+            dir.join("library.zip"),
+            crate::zip::tests_archive(&["Ä/One.d64", "ä/Two.d64"], false),
+        )
+        .unwrap();
+        let library = Library::open(&system(&dir)).unwrap();
+        let audit = library.audit(false);
+        assert_eq!(audit.games, 2);
+        assert!(audit.unreadable.is_empty());
+        assert!(audit.first_game.is_some());
+        assert_eq!(
+            audit.places_read, 4,
+            "root, archive and both member directories"
+        );
+        std::fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]
@@ -1881,5 +2005,149 @@ mod tests {
             "CLI report and dry-run must choose the first game shown by the effective source"
         );
         std::fs::remove_dir_all(&dir).ok();
+    }
+    #[test]
+    fn multigame_zip_metadata_is_exact_and_same_basenames_remain_distinct() {
+        let dir = temp("zip-metadata");
+        let archive = dir.join("library.zip");
+        std::fs::write(
+            &archive,
+            crate::zip::tests_archive(&["one/Game.d64", "two/Game.d64", "empty/"], true),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("gamelist.xml"),
+            r#"<gameList>
+            <game><path>library.zip</path><name>Archive title</name></game>
+            <game><path>Game.d64</path><name>Wrong sibling</name></game>
+            <game><path>./library.zip/one/Game.d64</path><name>Correct one</name></game>
+            </gameList>"#,
+        )
+        .unwrap();
+        let library = Library::open(&system(&dir)).unwrap();
+        let (rows, _) = library
+            .list(&Place::Archive(archive.clone()), true)
+            .unwrap();
+        assert_eq!(names_of(&rows), ["empty", "one", "two"]);
+        let (hidden_empty, _) = library
+            .list(&Place::Archive(archive.clone()), false)
+            .unwrap();
+        assert_eq!(names_of(&hidden_empty), ["one", "two"]);
+        for (prefix, expected) in [("one", "Correct one"), ("two", "Game.d64")] {
+            let place = Place::ArchiveDirectory {
+                archive: archive.clone(),
+                prefix: prefix.into(),
+            };
+            let (rows, _) = library.list(&place, false).unwrap();
+            assert_eq!(names_of(&rows), [expected]);
+            assert_eq!(
+                rows[0].kind,
+                Kind::Play(Launch::File(archive.join(format!("{prefix}/Game.d64"))))
+            );
+        }
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn one_supported_zip_member_preserves_legacy_archive_metadata() {
+        let dir = temp("zip-single-metadata");
+        let archive = dir.join("Only.zip");
+        std::fs::write(
+            &archive,
+            crate::zip::tests_archive(&["folder/Game.d64", "readme.txt"], false),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("gamelist.xml"),
+            r#"<gameList><game><path>Only.zip</path><name>Legacy name</name></game></gameList>"#,
+        )
+        .unwrap();
+        let library = Library::open(&system(&dir)).unwrap();
+        let (rows, _) = library
+            .list(
+                &Place::ArchiveDirectory {
+                    archive,
+                    prefix: "folder".into(),
+                },
+                false,
+            )
+            .unwrap();
+        assert_eq!(names_of(&rows), ["Legacy name"]);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn existing_place_serialization_tags_do_not_move() {
+        for (place, tag) in [
+            (Place::Dir("x".into()), 0),
+            (Place::Archive("x.zip".into()), 1),
+            (
+                Place::Listing {
+                    install: "i".into(),
+                    file: "f".into(),
+                },
+                2,
+            ),
+            (Place::Roots, 3),
+        ] {
+            let bytes = postcard::to_allocvec(&place).unwrap();
+            assert_eq!(bytes[0], tag);
+            assert_eq!(postcard::from_bytes::<Place>(&bytes).unwrap(), place);
+        }
+        let place = Place::ArchiveDirectory {
+            archive: "x.zip".into(),
+            prefix: "folder".into(),
+        };
+        assert_eq!(postcard::to_allocvec(&place).unwrap()[0], 4);
+    }
+
+    #[test]
+    fn unstable_core_names_keep_build_suffixes_while_stable_names_stay_short() {
+        let dir = temp("nightly-names");
+        let mut config = system(&dir);
+        config.preserve_rbf_stem = true;
+        let library = Library::open(&config).unwrap();
+        assert_eq!(
+            library.display_name(Path::new("Core_20260907_build123.rbf")),
+            "Core_20260907_build123"
+        );
+        config.preserve_rbf_stem = false;
+        let library = Library::open(&config).unwrap();
+        assert_eq!(
+            library.display_name(Path::new("Core_20260907_build123.rbf")),
+            "Core"
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+    #[test]
+    fn long_multiline_description_with_double_escaped_quotes_survives_browse_and_cache() {
+        let dir = temp("description-regression");
+        std::fs::write(dir.join("Race.d64"), b"synthetic test content").unwrap();
+        let opening = "A visiting pilot arrives at an island circuit and joins a friendly race across beaches and hills. The competitors unlock new routes, explore hidden tracks and collect useful items along the way.";
+        let xml = format!("<gameList><game><path>./Race.d64</path><name>Island Race</name><genre>Racing</genre><desc>{opening}\n\nThe second paragraph describes the &amp;quot;Token Challenge&amp;quot;.\n\nAnother paragraph describes multiplayer races.</desc><favorite>true</favorite></game></gameList>");
+        std::fs::write(dir.join("gamelist.xml"), xml).unwrap();
+        let expected = format!(
+            "{}...",
+            opening.chars().take(160).collect::<String>().trim_end()
+        );
+        let library = Library::open(&system(&dir)).unwrap();
+        let (rows, _) = library.list(&library.start(), false).unwrap();
+        assert_eq!(rows[0].details.desc, expected);
+        assert_eq!(rows[0].genre.as_deref(), Some("Racing"));
+        assert!(rows[0].favorite);
+        let cache = crate::cache::build_system_controlled(
+            &library,
+            &std::sync::atomic::AtomicBool::new(false),
+            &mut |_, _| {},
+        )
+        .unwrap()
+        .unwrap();
+        let encoded = postcard::to_allocvec(&cache).unwrap();
+        let decoded: crate::cache::SystemCache = postcard::from_bytes(&encoded).unwrap();
+        assert_eq!(
+            decoded.get(&library.start()).unwrap().rows[0].details.desc,
+            expected
+        );
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -31,7 +31,7 @@ const FORMAT: u32 = 1;
 const ARTWORK_PACK_FORMAT: u32 = 3;
 
 /// What is known about every system, small enough to read at startup.
-#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Index {
     pub format: u32,
     /// Keyed by the system's id from the table.
@@ -122,6 +122,12 @@ pub struct Folder {
     pub rows: Vec<Row>,
     /// Playable things below this folder, at any depth.
     pub games: usize,
+}
+
+impl Default for Index {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Index {
@@ -234,6 +240,7 @@ pub fn save_index(dir: &Path, index: &Index) -> Result<()> {
     write(&index_path(dir), &bytes)
 }
 
+#[cfg(test)]
 pub fn save_system(dir: &Path, id: &str, cache: &SystemCache) -> Result<()> {
     let bytes = postcard::to_stdvec(cache)
         .map_err(|e| DegaussError::unsupported("cache", format!("writing {id}: {e}")))?;
@@ -247,22 +254,14 @@ pub fn save_system(dir: &Path, id: &str, cache: &SystemCache) -> Result<()> {
 /// playable things under each folder is worked out on the way back up, so
 /// the answer to "is there anything in here" costs a lookup rather than a
 /// walk.
+pub fn build_system_checked(library: &Library) -> Result<SystemCache> {
+    build_system_controlled(library, &AtomicBool::new(false), &mut |_, _| {})?
+        .ok_or_else(|| DegaussError::unsupported("cache build", "cancelled"))
+}
+
+#[cfg(test)]
 pub fn build_system(library: &Library) -> SystemCache {
-    let cancelled = AtomicBool::new(false);
-    match build_system_controlled(library, &cancelled, &mut |_, _| {}) {
-        Ok(Some(cache)) => cache,
-        Ok(None) => SystemCache {
-            format: FORMAT,
-            folders: BTreeMap::new(),
-        },
-        Err(error) => {
-            crate::note(&format!("cache        build failed: {error}"));
-            SystemCache {
-                format: FORMAT,
-                folders: BTreeMap::new(),
-            }
-        }
-    }
+    build_system_checked(library).expect("fixture cache must build")
 }
 
 /// Build with cooperative cancellation and progress between filesystem
@@ -309,19 +308,20 @@ fn walk_controlled(
         return Ok(None);
     }
     let key = place.key();
-    if depth > MAX_DEPTH || seen.contains(&key) {
+    if depth > MAX_DEPTH {
+        return Err(DegaussError::unsupported(
+            "cache traversal",
+            format!(
+                "{} exceeds the maximum folder depth of {MAX_DEPTH}",
+                place.path().display()
+            ),
+        ));
+    }
+    if seen.contains(&key) {
         return Ok(Some(0));
     }
     seen.push(key.clone());
-    let (mut rows, _) = match library.list(place, true) {
-        Ok(listing) => listing,
-        // Released Degauss treats an unreadable nested branch as holding no
-        // games and continues indexing the rest of the system. Preserve that
-        // behaviour, but let an unreadable system root fail a transactional
-        // source build instead of installing an empty replacement cache.
-        Err(_) if depth > 0 => return Ok(Some(0)),
-        Err(error) => return Err(error),
-    };
+    let (mut rows, _) = library.list(place, true)?;
 
     let mut games = 0;
     for row in &mut rows {
@@ -363,6 +363,9 @@ fn walk_controlled(
     );
     *folders_done += 1;
     progress(*folders_done, *games_done);
+    if cancelled.load(Ordering::Relaxed) {
+        return Ok(None);
+    }
     Ok(Some(games))
 }
 
@@ -435,8 +438,75 @@ impl Drop for PreparedCacheGroup {
 }
 
 impl PreparedCacheGroup {
+    /// Completed rows available for computing the matching index before any
+    /// live file is replaced.
+    pub fn caches(&self) -> &[StagedSystemCache] {
+        &self.caches
+    }
+
+    /// Stage the matching index in the same rollback transaction as its rows.
+    pub fn with_index(mut self, dir: &Path, index: &Index) -> Result<Self> {
+        let final_path = dir.join("index.bin");
+        if self
+            .files
+            .iter()
+            .any(|entry| entry.final_path == final_path)
+        {
+            return Err(DegaussError::unsupported(
+                "cache transaction",
+                "index already staged",
+            ));
+        }
+        // Inspect the previous index before creating a file, so a failed
+        // metadata check cannot leave an untracked staging file behind.
+        let had_old = path_exists(&final_path)?;
+        let (new_path, backup_path) = loop {
+            let serial = NEXT_CACHE_TRANSACTION.fetch_add(1, Ordering::Relaxed);
+            let tag = format!("degauss-index-{}-{serial}", std::process::id());
+            let new_path = final_path.with_extension(format!("{tag}.new"));
+            let backup_path = final_path.with_extension(format!("{tag}.bak"));
+            if !path_exists(&new_path)? && !path_exists(&backup_path)? {
+                break (new_path, backup_path);
+            }
+        };
+        let bytes = postcard::to_stdvec(index)
+            .map_err(|e| DegaussError::unsupported("cache index", e.to_string()))?;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&new_path)
+            .map_err(|e| DegaussError::io("creating staged index", &new_path, e))?;
+        self.files.push(StagedCacheFile {
+            had_old,
+            final_path,
+            new_path: new_path.clone(),
+            backup_path,
+            backup_moved: false,
+            installed: false,
+        });
+        use std::io::Write as _;
+        file.write_all(&bytes)
+            .and_then(|_| file.sync_all())
+            .map_err(|e| DegaussError::io("writing staged index", &new_path, e))?;
+        let written = std::fs::read(&new_path)
+            .map_err(|e| DegaussError::io("validating staged index", &new_path, e))?;
+        let decoded: Index = postcard::from_bytes(&written)
+            .map_err(|e| DegaussError::malformed("staged index", &new_path, e.to_string()))?;
+        if decoded.format != FORMAT {
+            return Err(DegaussError::malformed(
+                "staged index",
+                &new_path,
+                "incompatible format",
+            ));
+        }
+        Ok(self)
+    }
+
     /// Replace every member of the group as one transaction. If any member
     /// fails, every earlier member is restored before the error is returned.
+    /// This handles observed I/O failures, not process termination or power
+    /// loss between renames: no filesystem provides one atomic rename for
+    /// this group, and no restart-recovery journal is written here.
     pub fn install(mut self) -> Result<(Vec<StagedSystemCache>, Vec<String>)> {
         let install = (|| -> Result<()> {
             for entry in &mut self.files {
@@ -445,7 +515,7 @@ impl PreparedCacheGroup {
                         DegaussError::io("backing up the previous cache", &entry.final_path, error)
                     })?;
                     entry.backup_moved = true;
-                } else if entry.final_path.exists() {
+                } else if path_exists(&entry.final_path)? {
                     return Err(DegaussError::unsupported(
                         "cache transaction",
                         format!(
@@ -491,6 +561,18 @@ impl PreparedCacheGroup {
         }
         self.finished = true;
         Ok((std::mem::take(&mut self.caches), warnings))
+    }
+}
+
+fn path_exists(path: &Path) -> Result<bool> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(DegaussError::io(
+            "checking cache transaction path",
+            path,
+            error,
+        )),
     }
 }
 
@@ -614,13 +696,14 @@ fn stage_transactional_with_tag(
         let new_path = final_path.with_extension(format!("{tag}-{position}.new"));
         let backup_path = final_path.with_extension(format!("{tag}-{position}.bak"));
         let bytes = encode_for(kind, cache)?;
+        let had_old = path_exists(&final_path)?;
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
             .open(&new_path)
             .map_err(|error| DegaussError::io("creating staged cache", &new_path, error))?;
         prepared.files.push(StagedCacheFile {
-            had_old: final_path.exists(),
+            had_old,
             final_path,
             new_path: new_path.clone(),
             backup_path,
@@ -667,6 +750,31 @@ pub fn install_transactional(
     prepared.install().map(|(_, warnings)| warnings)
 }
 
+/// Commit a complete system scan and its summary together.
+pub fn save_system_with_index(
+    dir: &Path,
+    id: &str,
+    cache: &SystemCache,
+    index: &Index,
+) -> Result<Vec<String>> {
+    let staged = StagedSystemCache {
+        id: id.to_string(),
+        cache: cache.clone(),
+        fingerprints: ContentFingerprints::new(),
+        fingerprints_complete: false,
+    };
+    stage_transactional(
+        dir,
+        CacheKind::Gamelist,
+        vec![staged],
+        &AtomicBool::new(false),
+    )?
+    .ok_or_else(|| DegaussError::unsupported("cache transaction", "cancelled"))?
+    .with_index(dir, index)?
+    .install()
+    .map(|(_, warnings)| warnings)
+}
+
 /// When a folder itself last changed, seconds since the epoch, or 0.
 ///
 /// A directory's own mtime moves when an entry is added or removed from it,
@@ -686,29 +794,18 @@ pub fn mtime_of(path: &Path) -> i64 {
         .unwrap_or(0)
 }
 
-/// Clear the released index and gamelist system files while retaining the
-/// independent Artwork Pack cache. A forced global rebuild can then refresh
-/// source-neutral rows without discarding valid CRC fingerprints before the
-/// replacement for that system has been produced.
-pub fn clear_for_rebuild(dir: &Path) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if entry.file_name() == "artwork-pack" {
-            continue;
-        }
-        if path.is_dir() {
-            let _ = std::fs::remove_dir_all(path);
-        } else {
-            let _ = std::fs::remove_file(path);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn a_default_index_round_trips_as_the_existing_cache_format() {
+        let index = super::Index::default();
+        assert_eq!(index.format, super::FORMAT);
+        let bytes = postcard::to_stdvec(&index).unwrap();
+        let restored: super::Index = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(restored.format, super::FORMAT);
+        assert!(restored.systems.is_empty());
+    }
+
     use super::*;
     use crate::config::SystemConfig;
 
@@ -720,6 +817,7 @@ mod tests {
 
     fn system(dir: &Path) -> SystemConfig {
         SystemConfig {
+            preserve_rbf_stem: false,
             name: "Test".into(),
             path: dir.to_string_lossy().into_owned(),
             extensions: vec!["d64".into()],
@@ -953,38 +1051,6 @@ mod tests {
         std::fs::remove_dir_all(store).ok();
     }
 
-    #[test]
-    fn forced_rebuild_clear_retains_only_the_independent_pack_cache() {
-        let store = temp("pack-preserved-on-rebuild");
-        std::fs::write(index_path(&store), b"old-index").unwrap();
-        std::fs::write(system_path(&store, "Test"), b"old-system").unwrap();
-        std::fs::create_dir_all(store.join("other-dir")).unwrap();
-        std::fs::write(store.join("other-dir/file"), b"old").unwrap();
-        let cache = SystemCache {
-            format: FORMAT,
-            folders: BTreeMap::new(),
-        };
-        install_transactional(
-            &store,
-            CacheKind::ArtworkPack,
-            &[StagedSystemCache {
-                id: "Test".into(),
-                cache,
-                fingerprints: ContentFingerprints::new(),
-                fingerprints_complete: true,
-            }],
-        )
-        .unwrap();
-
-        clear_for_rebuild(&store);
-
-        assert!(!index_path(&store).exists());
-        assert!(!system_path(&store, "Test").exists());
-        assert!(!store.join("other-dir").exists());
-        assert!(load_artwork_pack_data(&store, "Test").is_some());
-        std::fs::remove_dir_all(store).ok();
-    }
-
     fn staged(id: &str) -> StagedSystemCache {
         StagedSystemCache {
             id: id.to_string(),
@@ -1174,7 +1240,7 @@ mod tests {
     }
 
     #[test]
-    fn an_unreadable_nested_branch_keeps_the_released_zero_subtree_behaviour() {
+    fn an_unreadable_nested_branch_fails_instead_of_becoming_an_empty_cache() {
         let games = temp("nested-read-failure");
         let not_a_directory = games.join("not-a-directory");
         std::fs::write(&not_a_directory, b"file").unwrap();
@@ -1188,7 +1254,7 @@ mod tests {
         let mut folders = 0;
         let mut games_done = 0;
 
-        let below = walk_controlled(
+        let error = walk_controlled(
             &library,
             &Place::Dir(not_a_directory),
             1,
@@ -1199,10 +1265,217 @@ mod tests {
             &mut games_done,
             &mut |_, _| {},
         )
-        .unwrap();
+        .unwrap_err();
 
-        assert_eq!(below, Some(0));
+        assert!(error.to_string().contains("reading folder"));
         assert!(cache.folders.is_empty());
         std::fs::remove_dir_all(games).ok();
+    }
+
+    #[test]
+    fn successful_rebuild_removes_deleted_files_and_zip_members_without_touching_other_systems() {
+        let games = temp("rebuild-removal-games");
+        let store = temp("rebuild-removal-store");
+        std::fs::write(games.join("Keep.d64"), b"rom").unwrap();
+        std::fs::write(games.join("Remove.d64"), b"rom").unwrap();
+        std::fs::write(
+            games.join("Set.zip"),
+            crate::zip::tests_archive(&["One.d64", "Two.d64"], false),
+        )
+        .unwrap();
+        let library = Library::open(&system(&games)).unwrap();
+        let initial = build_system_checked(&library).unwrap();
+        let mut index = Index::new();
+        index
+            .systems
+            .insert("Test".into(), initial.summary(&library.start()));
+        index.systems.insert(
+            "Untouched".into(),
+            Summary {
+                games: 7,
+                folders: 2,
+            },
+        );
+        save_system_with_index(&store, "Test", &initial, &index).unwrap();
+        std::fs::write(system_path(&store, "Untouched"), b"other-cache-bytes").unwrap();
+        let independent = artwork_pack_system_path(&store, "Test");
+        std::fs::create_dir_all(independent.parent().unwrap()).unwrap();
+        std::fs::write(&independent, b"independent-pack").unwrap();
+        assert_eq!(index.systems["Test"].games, 4);
+
+        std::fs::remove_file(games.join("Remove.d64")).unwrap();
+        std::fs::write(
+            games.join("Set.zip"),
+            crate::zip::tests_archive(&["One.d64"], false),
+        )
+        .unwrap();
+        let rebuilt = build_system_checked(&Library::open(&system(&games)).unwrap()).unwrap();
+        index
+            .systems
+            .insert("Test".into(), rebuilt.summary(&library.start()));
+        assert!(save_system_with_index(&store, "Test", &rebuilt, &index)
+            .unwrap()
+            .is_empty());
+        let reloaded = load_system(&store, "Test").unwrap();
+        assert_eq!(reloaded.summary(&library.start()).games, 2);
+        assert_eq!(load_index(&store).unwrap().systems["Test"].games, 2);
+        assert_eq!(load_index(&store).unwrap().systems["Untouched"].games, 7);
+        assert_eq!(
+            std::fs::read(system_path(&store, "Untouched")).unwrap(),
+            b"other-cache-bytes"
+        );
+        assert_eq!(std::fs::read(independent).unwrap(), b"independent-pack");
+        std::fs::remove_dir_all(games).unwrap();
+        std::fs::remove_dir_all(store).unwrap();
+    }
+
+    #[test]
+    fn malformed_nested_archive_cannot_replace_a_previous_cache_or_index() {
+        let games = temp("failed-rebuild-games");
+        let store = temp("failed-rebuild-store");
+        std::fs::create_dir_all(games.join("Nested")).unwrap();
+        let archive = games.join("Nested/Set.zip");
+        std::fs::write(&archive, crate::zip::tests_archive(&["Game.d64"], false)).unwrap();
+        let library = Library::open(&system(&games)).unwrap();
+        let old = build_system_checked(&library).unwrap();
+        let mut index = Index::new();
+        index
+            .systems
+            .insert("Test".into(), old.summary(&library.start()));
+        save_system_with_index(&store, "Test", &old, &index).unwrap();
+        let old_cache_bytes = std::fs::read(system_path(&store, "Test")).unwrap();
+        let old_index_bytes = std::fs::read(index_path(&store)).unwrap();
+        std::fs::write(&archive, b"broken archive").unwrap();
+        let error = build_system_checked(&Library::open(&system(&games)).unwrap()).unwrap_err();
+        assert!(error.to_string().contains("Set.zip"));
+        assert_eq!(
+            std::fs::read(system_path(&store, "Test")).unwrap(),
+            old_cache_bytes
+        );
+        assert_eq!(std::fs::read(index_path(&store)).unwrap(), old_index_bytes);
+        assert_eq!(load_index(&store).unwrap().systems["Test"].games, 1);
+        std::fs::remove_dir_all(games).unwrap();
+        std::fs::remove_dir_all(store).unwrap();
+    }
+
+    #[test]
+    fn failed_index_install_rolls_back_the_new_rows_and_preserves_the_old_pair() {
+        let store = temp("index-install-rollback");
+        let old = staged("Test");
+        let old_index = Index::new();
+        save_system_with_index(&store, "Test", &old.cache, &old_index).unwrap();
+        let old_cache_bytes = std::fs::read(system_path(&store, "Test")).unwrap();
+        let old_index_bytes = std::fs::read(index_path(&store)).unwrap();
+        let mut next = Index::new();
+        next.systems.insert(
+            "Test".into(),
+            Summary {
+                games: 8,
+                folders: 1,
+            },
+        );
+        let mut changed = staged("Test");
+        changed.cache.folders.insert(
+            "changed".into(),
+            Folder {
+                mtime: 0,
+                rows: Vec::new(),
+                games: 8,
+            },
+        );
+        let prepared = stage_transactional(
+            &store,
+            CacheKind::Gamelist,
+            vec![changed],
+            &AtomicBool::new(false),
+        )
+        .unwrap()
+        .unwrap()
+        .with_index(&store, &next)
+        .unwrap();
+        assert_eq!(prepared.caches().len(), 1);
+        // Fail the real rename after the rows have already been installed.
+        let index_staging = prepared.files.last().unwrap().new_path.clone();
+        std::fs::remove_file(index_staging).unwrap();
+        let error = prepared.install().unwrap_err();
+        assert!(error.to_string().contains("installing the staged cache"));
+        assert_eq!(
+            std::fs::read(system_path(&store, "Test")).unwrap(),
+            old_cache_bytes
+        );
+        assert_eq!(std::fs::read(index_path(&store)).unwrap(), old_index_bytes);
+        assert_eq!(
+            std::fs::read_dir(&store).unwrap().count(),
+            2,
+            "only original live files remain"
+        );
+        std::fs::remove_dir_all(store).unwrap();
+    }
+
+    #[test]
+    fn dropping_a_complete_staged_pair_preserves_live_files() {
+        let store = temp("cancel-staged-pair");
+        let cache = staged("Test");
+        let index = Index::new();
+        save_system_with_index(&store, "Test", &cache.cache, &index).unwrap();
+        let old_cache_bytes = std::fs::read(system_path(&store, "Test")).unwrap();
+        let old_index_bytes = std::fs::read(index_path(&store)).unwrap();
+        let prepared = stage_transactional(
+            &store,
+            CacheKind::Gamelist,
+            vec![cache],
+            &AtomicBool::new(false),
+        )
+        .unwrap()
+        .unwrap()
+        .with_index(&store, &index)
+        .unwrap();
+        drop(prepared);
+        assert_eq!(
+            std::fs::read(system_path(&store, "Test")).unwrap(),
+            old_cache_bytes
+        );
+        assert_eq!(std::fs::read(index_path(&store)).unwrap(), old_index_bytes);
+        assert_eq!(std::fs::read_dir(&store).unwrap().count(), 2);
+        std::fs::remove_dir_all(store).unwrap();
+    }
+
+    #[test]
+    fn cancellation_at_the_final_progress_callback_still_discards_the_cache() {
+        let games = temp("cancel-final-progress");
+        std::fs::write(games.join("Game.d64"), b"rom").unwrap();
+        let library = Library::open(&system(&games)).unwrap();
+        let cancelled = AtomicBool::new(false);
+        let cache = build_system_controlled(&library, &cancelled, &mut |_, _| {
+            cancelled.store(true, Ordering::Relaxed)
+        })
+        .unwrap();
+        assert!(cache.is_none());
+        std::fs::remove_dir_all(games).unwrap();
+    }
+
+    #[test]
+    fn excessive_depth_is_an_error_instead_of_an_empty_subtree() {
+        let games = temp("excessive-depth");
+        let library = Library::open(&system(&games)).unwrap();
+        let mut cache = SystemCache {
+            format: FORMAT,
+            folders: BTreeMap::new(),
+        };
+        let error = walk_controlled(
+            &library,
+            &library.start(),
+            MAX_DEPTH + 1,
+            &mut cache,
+            &mut Vec::new(),
+            &AtomicBool::new(false),
+            &mut 0,
+            &mut 0,
+            &mut |_, _| {},
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("maximum folder depth"));
+        assert!(cache.folders.is_empty());
+        std::fs::remove_dir_all(games).unwrap();
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -446,7 +446,7 @@ impl PreparedCacheGroup {
 
     /// Stage the matching index in the same rollback transaction as its rows.
     pub fn with_index(mut self, dir: &Path, index: &Index) -> Result<Self> {
-        let final_path = dir.join("index.bin");
+        let final_path = index_path(dir);
         if self
             .files
             .iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,6 +151,9 @@ pub struct LaunchRule {
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct SystemConfig {
+    /// Runtime collection presentation; never part of user configuration.
+    #[serde(skip)]
+    pub preserve_rbf_stem: bool,
     pub name: String,
     /// Absolute path to the folder holding the games.
     pub path: String,
@@ -437,6 +440,7 @@ favorite = "#fe2e1d"
     #[test]
     fn extension_matching_is_case_insensitive_both_ways() {
         let system = SystemConfig {
+            preserve_rbf_stem: false,
             name: "C64".into(),
             path: "/games/C64".into(),
             extensions: vec!["d64".into(), "prg".into()],
@@ -455,6 +459,7 @@ favorite = "#fe2e1d"
     #[test]
     fn the_launch_rule_for_a_file_comes_from_its_extension() {
         let system = SystemConfig {
+            preserve_rbf_stem: false,
             name: "C64".into(),
             path: "/games/C64".into(),
             extensions: vec!["d64".into(), "prg".into()],

--- a/src/core_choices.rs
+++ b/src/core_choices.rs
@@ -1,0 +1,481 @@
+//! Explicit per-system core versions. Choices are resolved from current files
+//! at launch time; catalog rows and systems tables retain their old identity.
+use std::path::{Component, Path, PathBuf};
+
+use crate::config::SystemConfig;
+use crate::core_variants::{self, EffectiveCore};
+use crate::error::{DegaussError, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreChoice {
+    pub key: String,
+    pub label: String,
+}
+
+fn core_stem(reference: &str) -> &str {
+    let name = reference.rsplit('/').next().unwrap_or(reference);
+    if name
+        .get(name.len().saturating_sub(4)..)
+        .is_some_and(|suffix| suffix.eq_ignore_ascii_case(".rbf"))
+    {
+        &name[..name.len() - 4]
+    } else {
+        name
+    }
+}
+
+fn nightly_matches(stem: &str, reference: &str) -> bool {
+    let wanted = crate::systems::core_name(core_stem(reference));
+    if wanted.is_empty() {
+        return false;
+    }
+    if crate::systems::core_name(stem) == wanted {
+        return true;
+    }
+    // The official nightly suffix is bounded, not a loose core-name prefix.
+    let lower = stem.to_ascii_lowercase();
+    let Some(at) = lower.rfind("_unstable_") else {
+        return false;
+    };
+    let suffix = &stem[at + "_unstable_".len()..];
+    let Some((date, hash)) = suffix.split_once('_') else {
+        return false;
+    };
+    date.len() == 8
+        && date.bytes().all(|byte| byte.is_ascii_digit())
+        && !hash.is_empty()
+        && hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+        && crate::systems::core_name(&stem[..at]) == wanted
+}
+
+/// Recognize a nightly reference even after removal, so a saved favourite
+/// can retain its owning system and report its missing selected version.
+pub fn is_unstable_reference(system: &SystemConfig, reference: &str) -> bool {
+    let path = Path::new(reference);
+    path.components()
+        .all(|component| matches!(component, Component::Normal(_)))
+        && path.components().next() == Some(Component::Normal("_Unstable".as_ref()))
+        && path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| nightly_matches(core_stem(name), &system.rbf))
+}
+
+fn nightlies(system: &SystemConfig, root: &Path) -> Result<Vec<CoreChoice>> {
+    let folder = root.join("_Unstable");
+    match std::fs::metadata(&folder) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(DegaussError::io("Unstable directory", &folder, error)),
+        Ok(_) => {}
+    }
+    let mut result = Vec::new();
+    walk_nightlies(system, root, &folder, &mut Vec::new(), &mut result)?;
+    result.sort_by(|a, b| {
+        a.key
+            .to_ascii_lowercase()
+            .as_bytes()
+            .cmp(b.key.to_ascii_lowercase().as_bytes())
+            .then_with(|| a.key.as_bytes().cmp(b.key.as_bytes()))
+    });
+    Ok(result)
+}
+
+fn walk_nightlies(
+    system: &SystemConfig,
+    root: &Path,
+    folder: &Path,
+    ancestors: &mut Vec<PathBuf>,
+    result: &mut Vec<CoreChoice>,
+) -> Result<()> {
+    if ancestors.len() > crate::browse::MAX_DEPTH {
+        return Err(DegaussError::unsupported(
+            "Unstable directory",
+            "maximum folder depth exceeded",
+        ));
+    }
+    let identity = std::fs::canonicalize(folder)
+        .map_err(|error| DegaussError::io("Unstable directory", folder, error))?;
+    if ancestors.contains(&identity) {
+        return Err(DegaussError::unsupported(
+            "Unstable directory",
+            format!("directory cycle at {}", folder.display()),
+        ));
+    }
+    ancestors.push(identity);
+    let listing = std::fs::read_dir(folder)
+        .map_err(|error| DegaussError::io("Unstable directory", folder, error))?;
+    for entry in listing {
+        let entry =
+            entry.map_err(|error| DegaussError::io("Unstable directory entry", folder, error))?;
+        if entry.file_name().to_string_lossy().starts_with('.') {
+            continue;
+        }
+        let path = entry.path();
+        let metadata = std::fs::metadata(&path)
+            .map_err(|error| DegaussError::io("Unstable core entry", &path, error))?;
+        if metadata.is_dir() {
+            walk_nightlies(system, root, &path, ancestors, result)?;
+        } else if metadata.is_file()
+            && path
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("rbf"))
+        {
+            let stem = path
+                .file_stem()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| {
+                    DegaussError::unsupported("Unstable core", "filename is not valid UTF-8")
+                })?;
+            if nightly_matches(stem, &system.rbf) {
+                let relative = path.strip_prefix(root).expect("scan remains beneath root");
+                let key = relative.to_str().ok_or_else(|| {
+                    DegaussError::unsupported("Unstable core", "path is not valid UTF-8")
+                })?;
+                result.push(CoreChoice {
+                    key: key.into(),
+                    label: key.into(),
+                });
+            }
+        }
+    }
+    ancestors.pop();
+    Ok(())
+}
+
+/// Main's MGL loader chooses the greatest original filename among
+/// case-insensitive stem-prefix matches followed by '.' or '_'. Validate
+/// that its native lookup will select the exact saved choice.
+fn validate_native_choice(actual: &Path) -> Result<()> {
+    let directory = actual.parent().expect("Unstable file has a parent");
+    let selected = actual
+        .file_name()
+        .expect("Unstable file has a name")
+        .as_encoded_bytes();
+    let prefix = &selected[..selected.len() - 4];
+    let mut winner: Option<Vec<u8>> = None;
+    let entries = std::fs::read_dir(directory)
+        .map_err(|error| DegaussError::io("selected core directory", directory, error))?;
+    for entry in entries {
+        let entry = entry
+            .map_err(|error| DegaussError::io("selected core directory entry", directory, error))?;
+        let name = entry.file_name();
+        let bytes = name.as_encoded_bytes();
+        if bytes.len() <= prefix.len()
+            || bytes.len() <= 4
+            || !bytes[bytes.len() - 4..].eq_ignore_ascii_case(b".rbf")
+            || !bytes[..prefix.len()].eq_ignore_ascii_case(prefix)
+            || !matches!(bytes[prefix.len()], b'.' | b'_')
+        {
+            continue;
+        }
+        let kind = entry
+            .file_type()
+            .map_err(|error| DegaussError::io("selected core entry", entry.path(), error))?;
+        if kind.is_dir() {
+            continue;
+        }
+        if winner
+            .as_ref()
+            .is_none_or(|current| current.as_slice() < bytes)
+        {
+            winner = Some(bytes.to_vec());
+        }
+    }
+    if winner.as_deref() != Some(selected) {
+        return Err(DegaussError::unsupported("selected core version", format!(
+            "MiSTer's filename lookup would not select {}; another matching filename shadows this build",
+            actual.display())));
+    }
+    Ok(())
+}
+
+/// Installed versions plus a labelled RA error when that installation is
+/// invalid. The UI adds Default; no default is persisted.
+pub fn available(system: &SystemConfig, root: &Path) -> Result<Vec<CoreChoice>> {
+    if system.rbf.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut choices = Vec::new();
+    if core_variants::core_present(root, &system.rbf)? {
+        choices.push(CoreChoice {
+            key: "standard".into(),
+            label: "Standard".into(),
+        });
+    }
+    match core_variants::installed_ra(system, root) {
+        Ok(Some(_)) => choices.push(CoreChoice {
+            key: "ra".into(),
+            label: "RetroAchievements".into(),
+        }),
+        Ok(None) => {}
+        Err(error) => choices.push(CoreChoice {
+            key: "ra".into(),
+            label: format!("RetroAchievements unavailable: {error}"),
+        }),
+    }
+    choices.extend(nightlies(system, root)?);
+    Ok(choices)
+}
+
+/// Explicit choices fail if missing. Default preserves the Standard/RA rule
+/// and never silently selects an Unstable core, even if only one exists.
+pub fn resolve(
+    system: &SystemConfig,
+    root: &Path,
+    selected: Option<&str>,
+    ra_first: bool,
+) -> Result<EffectiveCore> {
+    let Some(selected) = selected else {
+        return core_variants::resolve(system, root, ra_first);
+    };
+    let missing = || {
+        DegaussError::unsupported(
+            "selected core version",
+            format!("{selected} is not installed for {}", system.name),
+        )
+    };
+    match selected {
+        "standard" => {
+            if !core_variants::core_present(root, &system.rbf)? {
+                return Err(missing());
+            }
+            Ok(core_variants::standard(system))
+        }
+        "ra" => core_variants::installed_ra(system, root)?.ok_or_else(missing),
+        _ => {
+            let path = Path::new(selected);
+            if !path
+                .extension()
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("rbf"))
+                || !is_unstable_reference(system, selected)
+            {
+                return Err(DegaussError::unsupported(
+                    "selected core version",
+                    format!("invalid Unstable choice {selected}"),
+                ));
+            }
+            let actual = root.join(path);
+            match std::fs::metadata(&actual) {
+                Ok(metadata) if metadata.is_file() => {}
+                Ok(_) => return Err(missing()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Err(missing()),
+                Err(error) => {
+                    return Err(DegaussError::io("selected Unstable core", &actual, error))
+                }
+            }
+            validate_native_choice(&actual)?;
+            let mut core = core_variants::standard(system);
+            // Main appends/matches the extension itself. Keep the complete
+            // dated/hash stem so the native lookup retains this exact build.
+            core.rbf = selected[..selected.len() - 4].into();
+            Ok(core)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn directory(tag: &str) -> PathBuf {
+        let root =
+            std::env::temp_dir().join(format!("degauss-core-choices-{tag}-{}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn system() -> SystemConfig {
+        SystemConfig {
+            preserve_rbf_stem: false,
+            name: "NES".into(),
+            path: "/games/NES".into(),
+            extensions: vec!["nes".into()],
+            rbf: "_Console/NES".into(),
+            launch: Vec::new(),
+            setname: Some("NES".into()),
+            skip_folders: Vec::new(),
+            extra_paths: Vec::new(),
+        }
+    }
+
+    fn write(root: &Path, path: &str, bytes: &[u8]) {
+        let path = root.join(path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, bytes).unwrap();
+    }
+
+    #[test]
+    fn choices_list_installed_standard_ra_and_distinct_matching_nightlies() {
+        let root = directory("all");
+        write(&root, "_Console/NES_20260901.rbf", b"fixture");
+        write(&root, "_RA_Cores/Cores/NES.rbf", b"fixture");
+        write(&root, "_RA_Cores/NES.mgl", br#"<mistergamedescription><rbf>_RA_Cores/Cores/NES</rbf><setname same_dir="1">RA_NES</setname></mistergamedescription>"#);
+        for filename in [
+            "NES_unstable_20260901_a1.rbf",
+            "NES_unstable_20260902_b2.RBF",
+            "NES_20260903.rbf",
+            "NES_RF_20260901.rbf",
+            "SNES_unstable_20260901_a1.rbf",
+        ] {
+            write(&root, &format!("_Unstable/{filename}"), b"fixture");
+        }
+        let choices = available(&system(), &root).unwrap();
+        assert_eq!(choices.len(), 5);
+        assert_eq!(choices[0].key, "standard");
+        assert_eq!(choices[1].key, "ra");
+        assert!(choices
+            .iter()
+            .all(|choice| !choice.key.contains("NES_RF") && !choice.key.contains("SNES")));
+        let ra = resolve(&system(), &root, Some("ra"), false).unwrap();
+        assert_eq!(ra.rbf, "_RA_Cores/Cores/NES");
+        assert_eq!(
+            ra.setname_xml.as_deref(),
+            Some("<setname same_dir=\"1\">RA_NES</setname>")
+        );
+        for key in [
+            "_Unstable/NES_unstable_20260901_a1.rbf",
+            "_Unstable/NES_unstable_20260902_b2.RBF",
+        ] {
+            let chosen = resolve(&system(), &root, Some(key), false).unwrap();
+            assert_eq!(chosen.rbf, &key[..key.len() - 4]);
+            assert_eq!(
+                chosen.setname_xml.as_deref(),
+                Some("<setname>NES</setname>")
+            );
+        }
+        assert_eq!(
+            resolve(&system(), &root, None, false).unwrap().rbf,
+            "_Console/NES"
+        );
+        assert_eq!(
+            resolve(&system(), &root, None, true).unwrap().rbf,
+            "_RA_Cores/Cores/NES"
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn nightly_only_system_requires_an_explicit_exact_choice() {
+        let root = directory("nightly-only");
+        let key = "_Unstable/nested/NES_unstable_20260901_ab12.rbf";
+        write(&root, key, b"fixture");
+        let choices = available(&system(), &root).unwrap();
+        assert_eq!(choices.len(), 1);
+        assert_eq!(choices[0].key, key);
+        assert!(resolve(&system(), &root, None, false).is_err());
+        assert_eq!(
+            resolve(&system(), &root, Some(key), false).unwrap().rbf,
+            &key[..key.len() - 4]
+        );
+        assert!(resolve(&system(), &root, Some("standard"), false).is_err());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn removed_explicit_nightly_is_an_error_even_with_standard_installed() {
+        let root = directory("missing-selected");
+        let key = "_Unstable/NES_unstable_20260901_aa.rbf";
+        write(&root, "_Console/NES.rbf", b"fixture");
+        write(&root, key, b"fixture");
+        assert!(resolve(&system(), &root, Some(key), false).is_ok());
+        std::fs::remove_file(root.join(key)).unwrap();
+        let error = resolve(&system(), &root, Some(key), false).unwrap_err();
+        assert!(error.to_string().contains(key));
+        assert!(
+            is_unstable_reference(&system(), key),
+            "removed favourite retains system identity"
+        );
+        assert!(resolve(&system(), &root, Some("ra"), false).is_err());
+        assert_eq!(
+            resolve(&system(), &root, Some("standard"), true)
+                .unwrap()
+                .rbf,
+            "_Console/NES"
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn arbitrary_prefixes_and_escaping_paths_are_not_core_versions() {
+        let system = system();
+        for reference in [
+            "_Unstable/NES_RF.rbf",
+            "_Unstable/NES_unstable_20260901_NOTHASH.rbf",
+            "_Unstable/NES_unstable_2026_abc.rbf",
+            "_Unstable/../NES.rbf",
+            "/_Unstable/NES.rbf",
+            "_Console/NES.rbf",
+            "_Unstable/NES.mgl",
+        ] {
+            assert!(!is_unstable_reference(&system, reference), "{reference}");
+        }
+        assert!(is_unstable_reference(&system, "_Unstable/NES.rbf"));
+        assert!(is_unstable_reference(&system, "_Unstable/NES"));
+        assert!(is_unstable_reference(
+            &system,
+            "_Unstable/NES_unstable_20260901_ab12"
+        ));
+        assert!(is_unstable_reference(&system, "_Unstable/NES_20260901.rbf"));
+        assert!(!nightly_matches("日本語", "_Console/NES"));
+        assert_eq!(core_stem("日本語"), "日本語");
+    }
+
+    #[test]
+    fn malformed_ra_choice_does_not_remove_a_valid_standard_alternative() {
+        let root = directory("malformed-ra");
+        write(&root, "_Console/NES.rbf", b"fixture");
+        write(&root, "_RA_Cores/NES.mgl", b"malformed XML");
+        let choices = available(&system(), &root).unwrap();
+        assert_eq!(choices[0].key, "standard");
+        assert_eq!(choices[1].key, "ra");
+        assert!(choices[1].label.contains("unavailable"));
+        assert!(resolve(&system(), &root, Some("standard"), true).is_ok());
+        assert!(resolve(&system(), &root, Some("ra"), false).is_err());
+        assert!(resolve(&system(), &root, None, false).is_ok());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn ra_only_system_remains_available_without_a_standard_binary() {
+        let root = directory("ra-only");
+        write(&root, "_RA_Cores/Cores/NES.rbf", b"fixture");
+        write(&root, "_RA_Cores/NES.mgl", br#"<mistergamedescription><rbf>_RA_Cores/Cores/NES</rbf><setname same_dir="1">RA_NES</setname></mistergamedescription>"#);
+        assert_eq!(available(&system(), &root).unwrap()[0].key, "ra");
+        assert_eq!(
+            resolve(&system(), &root, None, false).unwrap().rbf,
+            "_RA_Cores/Cores/NES"
+        );
+        assert!(resolve(&system(), &root, Some("standard"), false).is_err());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn native_main_prefix_shadowing_is_reported_instead_of_loading_another_build() {
+        let root = directory("native-shadow");
+        let key = "_Unstable/NES_unstable_20260901_aa.rbf";
+        write(&root, key, b"fixture");
+        write(
+            &root,
+            "_Unstable/NES_unstable_20260901_aa_extra.rbf",
+            b"fixture",
+        );
+        let error = resolve(&system(), &root, Some(key), false).unwrap_err();
+        assert!(error.to_string().contains("shadows this build"));
+        std::fs::remove_file(root.join("_Unstable/NES_unstable_20260901_aa_extra.rbf")).unwrap();
+        assert_eq!(
+            resolve(&system(), &root, Some(key), false).unwrap().rbf,
+            "_Unstable/NES_unstable_20260901_aa"
+        );
+        assert!(
+            resolve(
+                &system(),
+                &root,
+                Some("_Unstable/NES_unstable_20260901_aa"),
+                false
+            )
+            .is_err(),
+            "saved choices require their exact .rbf filename"
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/core_choices.rs
+++ b/src/core_choices.rs
@@ -145,6 +145,8 @@ fn walk_nightlies(
 /// Main's MGL loader chooses the greatest original filename among
 /// case-insensitive stem-prefix matches followed by '.' or '_'. Validate
 /// that its native lookup will select the exact saved choice.
+/// Contract: Degauss-Main f8dc68e3dcf4694f5593e6552aea56cd852982af,
+/// support/arcade/mra_loader.cpp::get_rbf (case-insensitive match, strcmp winner).
 fn validate_native_choice(actual: &Path) -> Result<()> {
     let directory = actual.parent().expect("Unstable file has a parent");
     let selected = actual

--- a/src/core_variants.rs
+++ b/src/core_variants.rs
@@ -1,0 +1,676 @@
+//! Runtime core selection. Installed launchers supply RA's set name and attributes;
+//! no variant information is persisted in systems tables or catalog caches.
+use crate::{
+    config::SystemConfig,
+    error::{DegaussError, Result},
+};
+use quick_xml::{events::Event, Reader};
+use std::ops::Range;
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+pub struct EffectiveCore {
+    pub rbf: String,
+    /// Complete XML element, including the installer's same_dir attribute.
+    pub setname_xml: Option<String>,
+}
+
+#[derive(Debug)]
+struct Element {
+    range: Range<usize>,
+    inner: Range<usize>,
+    value: String,
+}
+
+fn elements(text: &str, path: &Path) -> Result<(Element, Option<Element>)> {
+    let mut reader = Reader::from_str(text);
+    let mut depth = 0usize;
+    let mut root_seen = false;
+    let mut active: Option<(bool, usize, usize)> = None;
+    let mut rbf = None;
+    let mut setname = None;
+    let bad = |message: &str| DegaussError::malformed("core launcher", path, message.to_string());
+    loop {
+        let start = reader.buffer_position() as usize;
+        match reader.read_event().map_err(|e| bad(&e.to_string()))? {
+            Event::Start(e) => {
+                if depth == 0 {
+                    if root_seen
+                        || !e
+                            .name()
+                            .as_ref()
+                            .eq_ignore_ascii_case("mistergamedescription")
+                    {
+                        return Err(bad("expected a single mistergamedescription root"));
+                    }
+                    root_seen = true;
+                }
+                if active.is_some() {
+                    return Err(bad("nested core or setname element"));
+                }
+                if e.name().as_ref().eq_ignore_ascii_case("rbf")
+                    || e.name().as_ref().eq_ignore_ascii_case("setname")
+                {
+                    if depth != 1 {
+                        return Err(bad("core and setname must be root children"));
+                    }
+                    for a in e.attributes() {
+                        a.map_err(|e| bad(&e.to_string()))?;
+                    }
+                    active = Some((
+                        e.name().as_ref().eq_ignore_ascii_case("rbf"),
+                        start,
+                        reader.buffer_position() as usize,
+                    ));
+                }
+                depth += 1;
+            }
+            Event::End(_) => {
+                depth = depth
+                    .checked_sub(1)
+                    .ok_or_else(|| bad("unexpected closing element"))?;
+                if let Some((is_rbf, begin, inner)) = active.take() {
+                    let value = quick_xml::escape::unescape(text[inner..start].trim())
+                        .map_err(|e| bad(&e.to_string()))?
+                        .into_owned();
+                    if value.is_empty() {
+                        return Err(bad("empty core or setname"));
+                    }
+                    let slot = if is_rbf { &mut rbf } else { &mut setname };
+                    if slot.is_some() {
+                        return Err(bad("duplicate core or setname"));
+                    }
+                    *slot = Some(Element {
+                        range: begin..reader.buffer_position() as usize,
+                        inner: inner..start,
+                        value,
+                    });
+                }
+            }
+            Event::Empty(e)
+                if e.name().as_ref().eq_ignore_ascii_case("rbf")
+                    || e.name().as_ref().eq_ignore_ascii_case("setname") =>
+            {
+                return Err(bad("empty core or setname"))
+            }
+            Event::Empty(_) if active.is_some() => {
+                return Err(bad("nested core or setname element"))
+            }
+            // Main accepts and ignores a DOCTYPE declaration. quick_xml does
+            // not fetch external declarations; retaining it preserves native
+            // custom MGLs without adding entity expansion or network access.
+            Event::DocType(_) => {}
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    if depth != 0 {
+        return Err(bad("unclosed XML element"));
+    }
+    Ok((rbf.ok_or_else(|| bad("missing rbf element"))?, setname))
+}
+
+fn read_launcher(path: &Path) -> Result<String> {
+    crate::favorites::read_mgl_text(path, "core launcher")
+}
+
+fn undated_name(stem: &str) -> &str {
+    match stem.rsplit_once('_') {
+        Some((before, date))
+            if date.len() >= 8 && date.as_bytes()[..8].iter().all(u8::is_ascii_digit) =>
+        {
+            before
+        }
+        _ => stem,
+    }
+}
+
+/// Preserve the released core-presence comparison, including dated references
+/// and punctuation aliases. The original configured reference is still emitted.
+pub(crate) fn same_core_identity(left: &str, right: &str) -> bool {
+    let normalize = |value: &str| {
+        undated_name(value)
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric())
+            .map(|c| c.to_ascii_lowercase())
+            .collect::<String>()
+    };
+    normalize(left) == normalize(right)
+}
+
+pub(crate) fn core_present(root: &Path, rbf: &str) -> Result<bool> {
+    let reference = Path::new(rbf);
+    if reference
+        .extension()
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("rbf"))
+    {
+        return Err(DegaussError::unsupported("MGL core reference", "MiSTer Main requires an extensionless RBF reference; remove the trailing .rbf from the configured core"));
+    }
+    let folder = root.join(reference.parent().unwrap_or(Path::new("")));
+    let wanted = reference.file_name().and_then(|s| s.to_str()).unwrap_or("");
+    let listing = match std::fs::read_dir(&folder) {
+        Ok(listing) => listing,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(DegaussError::io("core directory", &folder, e)),
+    };
+    for entry in listing {
+        let entry = entry.map_err(|e| DegaussError::io("core directory", &folder, e))?;
+        let path = entry.path();
+        if !path
+            .extension()
+            .is_some_and(|s| s.eq_ignore_ascii_case("rbf"))
+        {
+            continue;
+        }
+        let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+        if same_core_identity(stem, wanted) {
+            let metadata =
+                std::fs::metadata(&path).map_err(|e| DegaussError::io("core file", &path, e))?;
+            if metadata.is_file() {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+pub(crate) fn standard(system: &SystemConfig) -> EffectiveCore {
+    EffectiveCore {
+        rbf: system.rbf.clone(),
+        setname_xml: system
+            .setname
+            .as_ref()
+            .filter(|s| !s.is_empty())
+            .map(|s| format!("<setname>{}</setname>", quick_xml::escape::escape(s))),
+    }
+}
+
+/// Resolve the installer launcher for the configured RBF. Shared systems keep
+/// their existing file index and extension rules, which select the hardware
+/// mode. RA's attributed setname selects the Main profile and retains the
+/// original core's game directory; it must not be synthesized from a system ID.
+pub fn resolve(system: &SystemConfig, root: &Path, ra_first: bool) -> Result<EffectiveCore> {
+    if !ra_first && core_present(root, &system.rbf)? {
+        return Ok(standard(system));
+    }
+    if let Some(core) = installed_ra(system, root)? {
+        return Ok(core);
+    }
+    if ra_first && core_present(root, &system.rbf)? {
+        return Ok(standard(system));
+    }
+    Err(DegaussError::unsupported(
+        "core",
+        format!(
+            "neither standard nor RetroAchievements core is installed for {}",
+            system.name
+        ),
+    ))
+}
+
+pub(crate) fn installed_ra(system: &SystemConfig, root: &Path) -> Result<Option<EffectiveCore>> {
+    let basename = Path::new(&system.rbf)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    let basename = undated_name(basename);
+    let identity = basename;
+    let folder = root.join("_RA_Cores");
+    let mut matches = Vec::new();
+    match std::fs::read_dir(&folder) {
+        Ok(listing) => {
+            for entry in listing {
+                let entry =
+                    entry.map_err(|e| DegaussError::io("RA launcher directory", &folder, e))?;
+                let path = entry.path();
+                if path
+                    .extension()
+                    .is_some_and(|s| s.eq_ignore_ascii_case("mgl"))
+                    && path.file_stem().and_then(|s| s.to_str()).is_some_and(|s| {
+                        s.eq_ignore_ascii_case(identity)
+                            || s.eq_ignore_ascii_case(&format!("RA_{identity}"))
+                    })
+                {
+                    matches.push(path);
+                }
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(DegaussError::io("RA launcher directory", &folder, e)),
+    }
+    if matches.len() > 1 {
+        return Err(DegaussError::unsupported(
+            "RA core",
+            format!("multiple launchers match {identity}"),
+        ));
+    }
+    if let Some(path) = matches.first() {
+        let text = read_launcher(path)?;
+        let (rbf, setname) = elements(&text, path)?;
+        let expected_rbf = format!("_RA_Cores/Cores/{basename}");
+        let set = setname
+            .ok_or_else(|| DegaussError::malformed("RA launcher", path, "missing setname"))?;
+        if !rbf.value.eq_ignore_ascii_case(&expected_rbf)
+            || !set.value.eq_ignore_ascii_case(&format!("RA_{identity}"))
+        {
+            return Err(DegaussError::malformed(
+                "RA launcher",
+                path,
+                format!("expected core {expected_rbf} and setname RA_{identity}"),
+            ));
+        }
+        if !core_present(root, &rbf.value)? {
+            return Err(DegaussError::unsupported(
+                "RA core",
+                format!(
+                    "launcher {} names missing core {}",
+                    path.display(),
+                    rbf.value
+                ),
+            ));
+        }
+        return Ok(Some(EffectiveCore {
+            rbf: rbf.value,
+            setname_xml: Some(text[set.range].to_owned()),
+        }));
+    }
+    if core_present(root, &format!("_RA_Cores/Cores/{basename}"))? {
+        return Err(DegaussError::unsupported(
+            "RA launcher",
+            format!(
+                "RA core {basename} is installed but its launcher is missing from {}",
+                folder.display()
+            ),
+        ));
+    }
+    Ok(None)
+}
+
+fn preserve_setname_attributes(old: &str, new: &str, path: &Path) -> Result<String> {
+    let bad = |e: String| DegaussError::malformed("core launcher", path, e);
+    let mut new_reader = Reader::from_str(new);
+    let Event::Start(new_tag) = new_reader.read_event().map_err(|e| bad(e.to_string()))? else {
+        return Err(bad("invalid replacement setname".into()));
+    };
+    let keys: Vec<_> = new_tag
+        .attributes()
+        .map(|a| a.map(|a| a.key.as_ref().to_ascii_lowercase()))
+        .collect::<std::result::Result<_, _>>()
+        .map_err(|e| bad(e.to_string()))?;
+    let mut old_reader = Reader::from_str(old);
+    let Event::Start(old_tag) = old_reader.read_event().map_err(|e| bad(e.to_string()))? else {
+        return Err(bad("invalid original setname".into()));
+    };
+    let mut additional = String::new();
+    for attribute in old_tag.attributes() {
+        let attribute = attribute.map_err(|e| bad(e.to_string()))?;
+        let key = attribute.key.as_ref();
+        if key.eq_ignore_ascii_case("same_dir") || keys.iter().any(|k| k.eq_ignore_ascii_case(key))
+        {
+            continue;
+        }
+        let start = key.as_ptr() as usize - old.as_ptr() as usize;
+        let end =
+            attribute.value.as_ptr() as usize - old.as_ptr() as usize + attribute.value.len() + 1;
+        additional.push(' ');
+        additional.push_str(&old[start..end]);
+    }
+    let mut result = new.to_owned();
+    result.insert_str(1 + new_tag.name().as_ref().len(), &additional);
+    Ok(result)
+}
+
+/// Replace only core/setname elements; all unrelated XML remains byte-for-byte.
+pub fn apply(text: &str, path: &Path, core: &EffectiveCore) -> Result<String> {
+    let (rbf, setname) = elements(text, path)?;
+    let mut patches = vec![(
+        rbf.inner.clone(),
+        quick_xml::escape::escape(&core.rbf).into_owned(),
+    )];
+    match (setname, &core.setname_xml) {
+        (Some(old), replacement) => {
+            let replacement = match replacement {
+                Some(new) => preserve_setname_attributes(&text[old.range.clone()], new, path)?,
+                None => String::new(),
+            };
+            patches.push((old.range, replacement));
+        }
+        (None, Some(new)) => patches.push((rbf.range.end..rbf.range.end, format!("\n\t{new}"))),
+        _ => {}
+    }
+    patches.sort_by_key(|(range, _)| std::cmp::Reverse(range.start));
+    let mut result = text.to_owned();
+    for (range, replacement) in patches {
+        result.replace_range(range, &replacement);
+    }
+    Ok(result)
+}
+
+/// Only known standard/RA references are eligible for conversion. Custom MGLs
+/// remain direct launches, including launchers for unrelated cores or sets.
+pub fn recognized_favorite(path: &Path, system: &SystemConfig) -> Result<bool> {
+    let text = read_launcher(path)?;
+    let (rbf, setname) = elements(&text, path)?;
+    let base = Path::new(&system.rbf)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    let base = undated_name(base);
+    let identity = base;
+    let standard_match = (rbf.value.eq_ignore_ascii_case(&system.rbf)
+        || crate::core_choices::is_unstable_reference(system, &rbf.value))
+        && match (
+            &setname,
+            system.setname.as_deref().filter(|s| !s.is_empty()),
+        ) {
+            (None, None) => true,
+            (Some(actual), Some(expected)) => actual.value.eq_ignore_ascii_case(expected),
+            _ => false,
+        };
+    let ra_match = rbf
+        .value
+        .eq_ignore_ascii_case(&format!("_RA_Cores/Cores/{base}"))
+        && setname.is_some_and(|s| s.value.eq_ignore_ascii_case(&format!("RA_{identity}")));
+    Ok(standard_match || ra_match)
+}
+
+/// Avoid generating a temporary shortcut when its effective core is unchanged.
+pub fn needs_conversion(path: &Path, core: &EffectiveCore) -> Result<bool> {
+    let text = read_launcher(path)?;
+    let (rbf, setname) = elements(&text, path)?;
+    if !rbf.value.eq_ignore_ascii_case(&core.rbf) {
+        return Ok(true);
+    }
+    Ok(match (setname, &core.setname_xml) {
+        (None, None) => false,
+        (Some(old), Some(new)) => text[old.range] != *new,
+        _ => true,
+    })
+}
+
+pub fn convert_favorite(path: &Path, core: &EffectiveCore) -> Result<String> {
+    apply(&read_launcher(path)?, path, core)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    fn setup(name: &str) -> (PathBuf, SystemConfig) {
+        let root = std::env::temp_dir().join(format!("degauss-ra-{name}-{}", std::process::id()));
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+        std::fs::create_dir_all(root.join("_Console")).unwrap();
+        std::fs::create_dir_all(root.join("_RA_Cores/Cores")).unwrap();
+        std::fs::create_dir_all(root.join("games/NES")).unwrap();
+        let system = SystemConfig {
+            preserve_rbf_stem: false,
+            name: "NES".into(),
+            path: root.join("games/NES").to_string_lossy().into_owned(),
+            extra_paths: vec![],
+            extensions: vec!["nes".into()],
+            rbf: "_Console/NES".into(),
+            setname: None,
+            skip_folders: vec![],
+            launch: vec![crate::config::LaunchRule {
+                extensions: vec!["nes".into()],
+                delay: 1,
+                kind: "f".into(),
+                index: 0,
+                companion_extensions: vec![],
+                companion_index: None,
+                reset_delay: None,
+                reset_hold: None,
+            }],
+        };
+        (root, system)
+    }
+    fn install_ra(root: &Path) {
+        std::fs::write(root.join("_RA_Cores/Cores/NES.rbf"), b"test discovery only").unwrap();
+        std::fs::write(root.join("_RA_Cores/NES.mgl"), "<mistergamedescription><rbf>_RA_Cores/Cores/NES</rbf><setname same_dir=\"1\">RA_NES</setname></mistergamedescription>").unwrap();
+    }
+    #[test]
+    fn preference_and_missing_variant_matrix() {
+        let (root, system) = setup("matrix");
+        for ra_first in [false, true] {
+            assert!(resolve(&system, &root, ra_first).is_err());
+        }
+        std::fs::write(
+            root.join("_Console/NES_20260907.rbf"),
+            b"test discovery only",
+        )
+        .unwrap();
+        for ra_first in [false, true] {
+            assert_eq!(resolve(&system, &root, ra_first).unwrap().rbf, system.rbf);
+        }
+        install_ra(&root);
+        let favorite = crate::launch::favorite_mgl_with_preference(
+            &system,
+            &root.join("games/NES/Game.nes"),
+            &root,
+            true,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(favorite.contains("<setname same_dir=\"1\">RA_NES</setname>"));
+        assert_eq!(resolve(&system, &root, false).unwrap().rbf, system.rbf);
+        assert_eq!(
+            resolve(&system, &root, true)
+                .unwrap()
+                .setname_xml
+                .as_deref(),
+            Some("<setname same_dir=\"1\">RA_NES</setname>")
+        );
+        std::fs::remove_file(root.join("_Console/NES_20260907.rbf")).unwrap();
+        for ra_first in [false, true] {
+            assert_eq!(
+                resolve(&system, &root, ra_first).unwrap().rbf,
+                "_RA_Cores/Cores/NES"
+            );
+        }
+        std::fs::remove_dir_all(root).unwrap();
+    }
+    #[test]
+    fn malformed_preferred_launcher_is_not_silently_replaced_with_standard() {
+        let (root, system) = setup("malformed");
+        install_ra(&root);
+        std::fs::write(root.join("_Console/NES.rbf"), b"test discovery only").unwrap();
+        std::fs::write(
+            root.join("_RA_Cores/NES.mgl"),
+            "<mistergamedescription><rbf>wrong</rbf></mistergamedescription>",
+        )
+        .unwrap();
+        assert!(resolve(&system, &root, true).is_err());
+        assert_eq!(resolve(&system, &root, false).unwrap().rbf, system.rbf);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+    #[test]
+    fn temporary_conversion_preserves_actions_and_original_favorite() {
+        let (root, system) = setup("favorite");
+        install_ra(&root);
+        std::fs::write(root.join("games/NES/Game.nes"), b"test path only").unwrap();
+        let original = "<mistergamedescription custom='yes'><rbf>_Console/NES</rbf><!-- keep --><file delay='2' type='f' index='1' path='Game.nes' custom='unchanged'/><reset delay='3' hold='4'/><unknown x='y'/></mistergamedescription>";
+        let path = root.join("Favorite.mgl");
+        std::fs::write(&path, original).unwrap();
+        let plan = crate::launch::plan_with_preference(
+            &system,
+            &path,
+            &root.join("temp.mgl"),
+            &root,
+            true,
+        )
+        .unwrap();
+        assert!(plan
+            .mgl
+            .contains("<setname same_dir=\"1\">RA_NES</setname>"));
+        assert!(plan.mgl.contains("<!-- keep -->"));
+        assert!(plan
+            .mgl
+            .contains("custom='unchanged'/><reset delay='3' hold='4'/><unknown x='y'/>"));
+        assert!(plan.mgl.contains(&format!(
+            "path='{}'",
+            root.join("games/NES/Game.nes").display()
+        )));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), original);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+    #[test]
+    fn shared_core_uses_installer_identity_and_preserves_system_file_rules() {
+        let (root, mut system) = setup("shared");
+        install_ra(&root);
+        system.setname = Some("FDS".into());
+        assert_eq!(
+            resolve(&system, &root, true)
+                .unwrap()
+                .setname_xml
+                .as_deref(),
+            Some("<setname same_dir=\"1\">RA_NES</setname>")
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+    #[test]
+    fn a_nightly_favorite_can_switch_back_without_rewriting_the_saved_file() {
+        let (root, system) = setup("nightly-favorite");
+        std::fs::write(root.join("_Console/NES.rbf"), b"discovery fixture").unwrap();
+        std::fs::create_dir_all(root.join("_Unstable")).unwrap();
+        let chosen = "_Unstable/NES_unstable_20260810_137d52.rbf";
+        std::fs::write(root.join(chosen), b"discovery fixture").unwrap();
+        let game = root.join("games/NES/Game.nes");
+        std::fs::write(&game, b"path fixture").unwrap();
+        let original =
+            crate::launch::favorite_mgl_with_choice(&system, &game, &root, false, Some(chosen))
+                .unwrap()
+                .unwrap();
+        let expected_rbf = "<rbf>_Unstable/NES_unstable_20260810_137d52</rbf>";
+        assert!(original.contains(expected_rbf));
+        assert!(!original.contains("137d52.rbf</rbf>"));
+        let ordinary = crate::launch::plan_with_choice(
+            &system,
+            &game,
+            &root.join("ordinary.mgl"),
+            &root,
+            false,
+            Some(chosen),
+        )
+        .unwrap();
+        assert!(ordinary.mgl.contains(expected_rbf));
+        let definitions = crate::systems::parse_table(
+            r#"
+[[systems]]
+name = "NES"
+id = "NES"
+folders = ["NES"]
+rbf = "_Console/NES"
+extensions = ["nes", "mgl"]
+"#,
+            Path::new("nightly Favorite fixture"),
+        )
+        .unwrap();
+        let owners: Vec<_> = definitions
+            .into_iter()
+            .map(|def| crate::systems::FoundSystem {
+                def,
+                paths: vec![root.join("games/NES")],
+                logo_dir: None,
+                menu_folder: None,
+            })
+            .collect();
+        let favorite = root.join("Nightly.mgl");
+        std::fs::write(&favorite, &original).unwrap();
+        let owner = || {
+            let reference =
+                crate::favorites::reference_of_with_systems(&favorite, &owners).unwrap();
+            crate::app::owner_of_favorite(&owners, &reference)
+        };
+        assert!(recognized_favorite(&favorite, &system).unwrap());
+        assert_eq!(owner().as_deref(), Some("NES"));
+        std::fs::remove_file(root.join(chosen)).unwrap();
+        assert!(recognized_favorite(&favorite, &system).unwrap());
+        assert_eq!(owner().as_deref(), Some("NES"));
+        let plan = crate::launch::plan_with_choice(
+            &system,
+            &favorite,
+            &root.join("temp.mgl"),
+            &root,
+            false,
+            Some("standard"),
+        )
+        .unwrap();
+        assert!(plan.mgl.contains("<rbf>_Console/NES</rbf>"));
+        assert_eq!(std::fs::read_to_string(favorite).unwrap(), original);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn configured_dated_stems_and_released_punctuation_aliases_remain_present() {
+        let (root, mut system) = setup("dated-config");
+        std::fs::write(root.join("_Console/NES_20260823.rbf"), b"discovery fixture").unwrap();
+        system.rbf = "_Console/NES_20260823".into();
+        assert!(core_present(&root, &system.rbf).unwrap());
+        assert_eq!(resolve(&system, &root, false).unwrap().rbf, system.rbf);
+        install_ra(&root);
+        assert_eq!(
+            resolve(&system, &root, true).unwrap().rbf,
+            "_RA_Cores/Cores/NES"
+        );
+        std::fs::write(
+            root.join("_Console/NeoGeoPocket-Color.rbf"),
+            b"discovery fixture",
+        )
+        .unwrap();
+        assert!(core_present(&root, "_Console/NeoGeoPocketColor").unwrap());
+        let invalid = core_present(&root, "_Console/NES_20260823.rbf")
+            .unwrap_err()
+            .to_string();
+        assert!(invalid.contains("extensionless RBF reference"));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn native_doctype_mgl_keeps_direct_launch_and_declaration_during_conversion() {
+        let (root, system) = setup("doctype");
+        std::fs::write(root.join("_Console/NES.rbf"), b"discovery fixture").unwrap();
+        let game = root.join("games/NES/Game.nes");
+        std::fs::write(&game, b"path fixture").unwrap();
+        let original = format!("<!DOCTYPE mistergamedescription>\n<mistergamedescription><rbf>_Console/NES</rbf><file delay=\"1\" type=\"f\" index=\"1\" path=\"{}\"/></mistergamedescription>", game.display());
+        let favorite = root.join("Custom.mgl");
+        std::fs::write(&favorite, &original).unwrap();
+        let output = root.join("temp.mgl");
+        let direct = crate::launch::plan_with_choice(
+            &system,
+            &favorite,
+            &output,
+            &root,
+            false,
+            Some("standard"),
+        )
+        .unwrap();
+        assert!(direct.mgl.is_empty());
+        assert_eq!(
+            direct.command,
+            format!("load_core {}\n", favorite.display())
+        );
+        install_ra(&root);
+        let converted =
+            crate::launch::plan_with_choice(&system, &favorite, &output, &root, false, Some("ra"))
+                .unwrap();
+        assert!(converted
+            .mgl
+            .starts_with("<!DOCTYPE mistergamedescription>\n"));
+        assert!(converted.mgl.contains("<rbf>_RA_Cores/Cores/NES</rbf>"));
+        assert_eq!(std::fs::read_to_string(favorite).unwrap(), original);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn duplicate_or_unclosed_descriptors_are_rejected() {
+        let path = Path::new("test.mgl");
+        for text in [
+            "<mistergamedescription><rbf>x</rbf><rbf>x</rbf></mistergamedescription>",
+            "<mistergamedescription><rbf>x</rbf>",
+        ] {
+            assert!(elements(text, path).is_err());
+        }
+    }
+}

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::BufReader;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use quick_xml::events::Event;
@@ -63,13 +63,20 @@ pub struct Favorites {
 impl Favorites {
     /// Read the folder. A card without one has no favourites, which is not
     /// an error.
+    #[cfg(test)]
     pub fn read(root: &Path) -> Favorites {
         let mut found = Favorites::default();
-        found.walk(root, 0);
+        found.walk(root, 0, &[]);
         found
     }
 
-    fn walk(&mut self, dir: &Path, depth: usize) {
+    pub fn read_with_systems(root: &Path, systems: &[crate::systems::FoundSystem]) -> Favorites {
+        let mut found = Favorites::default();
+        found.walk(root, 0, systems);
+        found
+    }
+
+    fn walk(&mut self, dir: &Path, depth: usize, systems: &[crate::systems::FoundSystem]) {
         if depth > 6 {
             return;
         }
@@ -96,7 +103,7 @@ impl Favorites {
                 continue;
             }
             if meta.is_dir() {
-                self.walk(&path, depth + 1);
+                self.walk(&path, depth + 1, systems);
                 continue;
             }
             if path
@@ -110,8 +117,8 @@ impl Favorites {
                     self.by_target.insert(amiga_key(&install, &title), path);
                     continue;
                 }
-                if let Ok(Some(target)) = mgl_target(&path) {
-                    self.by_target.insert(target, path);
+                if let Some(reference) = reference_of_with_systems(&path, systems) {
+                    self.by_target.insert(reference.cache_target, path);
                 }
             }
         }
@@ -209,6 +216,201 @@ pub fn reference_of(path: &Path) -> Option<FavoriteReference> {
     None
 }
 
+/// Resolve bare file names using the owning system's discovered game folders.
+/// Absolute paths and existing parent-relative conventions retain their meaning.
+/// Ambiguous owners are left unresolved rather than assigned to another system.
+pub fn reference_of_with_systems(
+    path: &Path,
+    systems: &[crate::systems::FoundSystem],
+) -> Option<FavoriteReference> {
+    let mut reference = reference_of(path)?;
+    if !reference.mgl || is_amiga_key(&reference.owner_target) {
+        return Some(reference);
+    }
+    let descriptor_path = std::fs::read_link(path)
+        .map(|target| resolve_link_target(path, target))
+        .unwrap_or_else(|_| path.to_path_buf());
+    let text = read_mgl_text(&descriptor_path, "favourite MGL").ok()?;
+    let mut reader = Reader::from_str(&text);
+    let mut raw = None;
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(e) | Event::Empty(e))
+                if e.name().as_ref().eq_ignore_ascii_case("file") =>
+            {
+                for a in e.attributes() {
+                    let a = a.ok()?;
+                    if a.key.as_ref().eq_ignore_ascii_case("path") {
+                        raw = Some(
+                            a.normalized_value(XmlVersion::Implicit1_0)
+                                .ok()?
+                                .into_owned(),
+                        );
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => return None,
+            _ => {}
+        }
+    }
+    let raw = raw?;
+    if raw.starts_with('/') || raw.starts_with("../") || raw.starts_with("./") {
+        return Some(reference);
+    }
+    let rbf = reference.rbf.as_deref()?;
+    let core = Path::new(rbf).file_name()?.to_str()?;
+    let set = reference
+        .setname
+        .as_deref()
+        .map(|s| s.strip_prefix("RA_").unwrap_or(s));
+    let owners: Vec<_> = systems
+        .iter()
+        .filter(|system| {
+            let configured_core = Path::new(&system.def.rbf)
+                .file_name()
+                .and_then(|s| s.to_str());
+            (configured_core.is_some_and(|s| crate::core_variants::same_core_identity(s, core))
+                || crate::core_choices::is_unstable_reference(&system.to_config(), rbf))
+                && system.to_config().accepts(Path::new(&raw))
+                && (rbf.starts_with("_RA_Cores/Cores/")
+                    && set.is_some_and(|s| s.eq_ignore_ascii_case(core))
+                    || match (system.to_config().setname.as_deref(), set) {
+                        (Some(expected), Some(actual)) => expected.eq_ignore_ascii_case(actual),
+                        (None, None) => true,
+                        (None, Some(actual)) => actual.eq_ignore_ascii_case(core),
+                        _ => false,
+                    })
+        })
+        .collect();
+    let [owner] = owners.as_slice() else {
+        return Some(reference);
+    };
+    let candidates: Vec<_> = owner
+        .paths
+        .iter()
+        .map(|root| normalize_path(root.join(&raw)))
+        .filter(|p| p.is_file() || crate::zip::validate_member(p).is_ok())
+        .collect();
+    if let Some(target) = candidates.first() {
+        if reference.cache_target == reference.owner_target {
+            reference.cache_target = target.clone();
+        }
+        reference.owner_target = target.clone();
+    }
+    Some(reference)
+}
+
+/// Bare paths need the same explicit system-root resolution used for metadata.
+pub fn has_bare_paths(path: &Path) -> Result<bool> {
+    let text = read_mgl_text(path, "favourite MGL")?;
+    let mut reader = Reader::from_str(&text);
+    loop {
+        match reader
+            .read_event()
+            .map_err(|e| DegaussError::malformed("favourite MGL", path, e.to_string()))?
+        {
+            Event::Start(e) | Event::Empty(e) if e.name().as_ref().eq_ignore_ascii_case("file") => {
+                for a in e.attributes() {
+                    let a = a.map_err(|e| {
+                        DegaussError::malformed("favourite MGL", path, e.to_string())
+                    })?;
+                    if a.key.as_ref().eq_ignore_ascii_case("path") {
+                        let raw = a.normalized_value(XmlVersion::Implicit1_0).map_err(|e| {
+                            DegaussError::malformed("favourite MGL", path, e.to_string())
+                        })?;
+                        if !raw.starts_with('/')
+                            && !raw.starts_with("../")
+                            && !raw.starts_with("./")
+                        {
+                            return Ok(true);
+                        }
+                    }
+                }
+            }
+            Event::Eof => return Ok(false),
+            _ => {}
+        }
+    }
+}
+
+/// Relocating an MGL must not change the meaning of its relative file paths.
+/// Replace only path attribute values, preserving other actions and attributes.
+pub fn relocate_mgl(
+    text: &str,
+    original: &Path,
+    system: &crate::config::SystemConfig,
+) -> Result<String> {
+    let linked = std::fs::read_link(original)
+        .ok()
+        .map(|target| resolve_link_target(original, target));
+    let original = linked.as_deref().unwrap_or(original);
+    let mut reader = Reader::from_str(text);
+    let mut patches = Vec::new();
+    loop {
+        let start = reader.buffer_position() as usize;
+        match reader
+            .read_event()
+            .map_err(|e| DegaussError::malformed("favourite MGL", original, e.to_string()))?
+        {
+            Event::Start(e) | Event::Empty(e) if e.name().as_ref().eq_ignore_ascii_case("file") => {
+                for a in e.attributes() {
+                    let a = a.map_err(|e| {
+                        DegaussError::malformed("favourite MGL", original, e.to_string())
+                    })?;
+                    if !a.key.as_ref().eq_ignore_ascii_case("path") {
+                        continue;
+                    }
+                    let raw = a.normalized_value(XmlVersion::Implicit1_0).map_err(|e| {
+                        DegaussError::malformed("favourite MGL", original, e.to_string())
+                    })?;
+                    if raw.starts_with('/') {
+                        continue;
+                    }
+                    let target = if raw.starts_with("../") || raw.starts_with("./") {
+                        resolve_mgl_path(original, &raw)
+                    } else {
+                        std::iter::once(&system.path)
+                            .chain(system.extra_paths.iter())
+                            .map(|root| Path::new(root).join(raw.as_ref()))
+                            .find(|p| p.is_file() || crate::zip::validate_member(p).is_ok())
+                            .ok_or_else(|| {
+                                DegaussError::unsupported(
+                                    "favourite file",
+                                    format!(
+                                        "cannot resolve {raw:?} in {} game folders",
+                                        system.name
+                                    ),
+                                )
+                            })?
+                    };
+                    // The raw attribute value is a borrowed slice of the input.
+                    let bytes = a.value.as_ref();
+                    let offset = bytes.as_ptr() as usize - text.as_ptr() as usize;
+                    if offset < start || offset + bytes.len() > reader.buffer_position() as usize {
+                        return Err(DegaussError::unsupported(
+                            "favourite MGL",
+                            "cannot locate path attribute",
+                        ));
+                    }
+                    let escaped = quick_xml::escape::escape(target.to_str().ok_or_else(|| {
+                        DegaussError::unsupported("favourite file", "non UTF-8 path")
+                    })?)
+                    .into_owned();
+                    patches.push((offset..offset + bytes.len(), escaped));
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    let mut result = text.to_owned();
+    for (range, replacement) in patches.into_iter().rev() {
+        result.replace_range(range, &replacement);
+    }
+    Ok(result)
+}
+
 /// A name for an AmigaVision title that can be looked up like a path.
 ///
 /// Not a real path and never opened: it only has to be something no file
@@ -233,19 +435,32 @@ pub fn mgl_target(path: &Path) -> Result<Option<PathBuf>> {
     descriptor_reference(path, "favourite MGL").map(|reference| reference.target)
 }
 
-fn descriptor_reference(path: &Path, what: &'static str) -> Result<DescriptorReference> {
-    let size = std::fs::metadata(path)
-        .map_err(|error| DegaussError::io(what, path, error))?
-        .len();
-    if size > MAX_MGL_BYTES {
+/// Bound the bytes actually consumed, rather than relying on metadata from an
+/// earlier instant. A growing file or symlink target cannot bypass this limit.
+pub(crate) fn read_mgl_text(path: &Path, what: &'static str) -> Result<String> {
+    let file = File::open(path).map_err(|error| DegaussError::io(what, path, error))?;
+    let mut bytes = Vec::new();
+    file.take(MAX_MGL_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| DegaussError::io(what, path, error))?;
+    if bytes.len() as u64 > MAX_MGL_BYTES {
         return Err(DegaussError::unsupported(
             what,
             format!("{} is larger than {MAX_MGL_BYTES} bytes", path.display()),
         ));
     }
-    let file = File::open(path).map_err(|error| DegaussError::io(what, path, error))?;
-    let mut reader = Reader::from_reader(BufReader::new(file));
-    let mut buffer = Vec::new();
+    String::from_utf8(bytes).map_err(|error| {
+        DegaussError::io(
+            what,
+            path,
+            std::io::Error::new(std::io::ErrorKind::InvalidData, error),
+        )
+    })
+}
+
+fn descriptor_reference(path: &Path, what: &'static str) -> Result<DescriptorReference> {
+    let text = read_mgl_text(path, what)?;
+    let mut reader = Reader::from_str(&text);
     let mut target = None;
     let mut active = None;
     let mut value = String::new();
@@ -257,7 +472,7 @@ fn descriptor_reference(path: &Path, what: &'static str) -> Result<DescriptorRef
     // the companion written ahead of it, so the first path names the disc
     // and only the last one names the game the favourite is for.
     loop {
-        match reader.read_event_into(&mut buffer) {
+        match reader.read_event() {
             Ok(Event::Eof) => break,
             Ok(Event::Start(event)) => {
                 if event.name().as_ref().eq_ignore_ascii_case("file") {
@@ -327,7 +542,6 @@ fn descriptor_reference(path: &Path, what: &'static str) -> Result<DescriptorRef
                 ));
             }
         }
-        buffer.clear();
     }
     Ok(DescriptorReference {
         target,
@@ -575,6 +789,114 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("degauss-fav-{name}-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn bare_ra_favorites_use_shared_core_extension_and_root_priority() {
+        let root = temp("context-ra");
+        let primary = root.join("primary");
+        let secondary = root.join("secondary");
+        std::fs::create_dir_all(&primary).unwrap();
+        std::fs::create_dir_all(&secondary).unwrap();
+        for folder in [&primary, &secondary] {
+            std::fs::write(folder.join("Game.fds"), b"path fixture").unwrap();
+        }
+        let defs = crate::systems::parse_table(
+            r#"
+[[systems]]
+name = "NES"
+id = "NES"
+folders = ["NES"]
+rbf = "_Console/NES"
+extensions = ["nes"]
+[[systems]]
+name = "FDS"
+id = "FDS"
+folders = ["NES", "FDS"]
+rbf = "_Console/NES"
+setname = "FDS"
+extensions = ["fds"]
+"#,
+            Path::new("test"),
+        )
+        .unwrap();
+        let systems: Vec<_> = defs
+            .into_iter()
+            .map(|def| crate::systems::FoundSystem {
+                def,
+                paths: vec![primary.clone(), secondary.clone()],
+                logo_dir: None,
+                menu_folder: None,
+            })
+            .collect();
+        let favorite = root.join("Game.mgl");
+        std::fs::write(&favorite, "<mistergamedescription><rbf>_RA_Cores/Cores/NES</rbf><setname same_dir=\"1\">RA_NES</setname><file delay=\"1\" type=\"f\" index=\"1\" path=\"Game.fds\"/></mistergamedescription>").unwrap();
+        let reference = reference_of_with_systems(&favorite, &systems).unwrap();
+        assert_eq!(reference.owner_target, primary.join("Game.fds"));
+        let favorites = Favorites::read_with_systems(&root, &systems);
+        assert!(favorites.holds(&primary.join("Game.fds")));
+        assert_eq!(
+            favorites.file_for(&primary.join("Game.fds")),
+            Some(favorite.as_path())
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn oversized_symlink_descriptors_are_bounded_and_never_assigned_an_owner() {
+        let root = temp("oversized-linked-mgl");
+        let descriptor = root.join("oversized.mgl");
+        let file = File::create(&descriptor).unwrap();
+        file.set_len(MAX_MGL_BYTES + 1).unwrap();
+        let link = root.join("Favorite.mgl");
+        std::os::unix::fs::symlink(&descriptor, &link).unwrap();
+        let error = mgl_target(&link).unwrap_err().to_string();
+        assert!(error.contains("larger than"));
+        assert!(reference_of_with_systems(&link, &[]).is_none());
+        assert!(crate::launch::amiga_marker(&descriptor).is_none());
+        assert!(reference_of(&descriptor).is_none());
+        let system = crate::systems::parse_table(
+            r#"
+[[systems]]
+name = "NES"
+id = "NES"
+folders = ["NES"]
+rbf = "_Console/NES"
+extensions = ["nes", "mgl"]
+"#,
+            Path::new("bounded descriptor fixture"),
+        )
+        .unwrap()
+        .remove(0);
+        let found = crate::systems::FoundSystem {
+            def: system,
+            paths: vec![root.join("games/NES")],
+            logo_dir: None,
+            menu_folder: None,
+        };
+        let launch_error = crate::launch::plan_with_choice(
+            &found.to_config(),
+            &link,
+            &root.join("temp.mgl"),
+            &root,
+            false,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(launch_error.contains("larger than"));
+        assert!(has_bare_paths(&link)
+            .unwrap_err()
+            .to_string()
+            .contains("larger than"));
+        // Replacing the target with an ordinary valid descriptor still works.
+        std::fs::write(&descriptor, "<mistergamedescription><rbf>_Console/NES</rbf><file delay=\"1\" type=\"f\" index=\"1\" path=\"/media/fat/games/NES/Game.nes\"/></mistergamedescription>").unwrap();
+        assert_eq!(
+            mgl_target(&link).unwrap(),
+            Some(PathBuf::from("/media/fat/games/NES/Game.nes"))
+        );
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/gamelist.rs
+++ b/src/gamelist.rs
@@ -433,6 +433,15 @@ impl Gamelist {
         Ok(dirs)
     }
 
+    /// An archive containing several supported games cannot inherit a sibling's
+    /// or the archive's metadata through filename/title fallback matching.
+    pub fn lookup_exact(&self, rel_path: &str) -> Option<(&GameMeta, MatchKind)> {
+        let rel = normalise_rel(rel_path);
+        self.by_rel_path
+            .get(&rel)
+            .map(|&index| (&self.entries[index], MatchKind::RelPath))
+    }
+
     /// Look up metadata for a file, from strictest to loosest key. Returns
     /// which key matched so the caller can report the mix.
     pub fn lookup(&self, rel_path: &str) -> Option<(&GameMeta, MatchKind)> {

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -140,27 +140,45 @@ pub fn plan_amiga_vision(
 ///
 /// The first match in the folder wins, which is what MiSTer's own tooling
 /// does. A game with two CDs needs its own shortcut either way.
-fn companion_for(rule: &LaunchRule, game: &Path) -> Option<PathBuf> {
+fn companion_for(rule: &LaunchRule, game: &Path) -> Result<Option<PathBuf>> {
     if rule.companion_extensions.is_empty() {
-        return None;
+        return Ok(None);
     }
-    let dir = game.parent()?;
-    let mut found: Vec<PathBuf> = std::fs::read_dir(dir)
-        .ok()?
+    let accepts = |path: &Path| {
+        path.extension().and_then(|e| e.to_str()).is_some_and(|e| {
+            rule.companion_extensions
+                .iter()
+                .any(|x| x.eq_ignore_ascii_case(e))
+        })
+    };
+    if let Some((archive, member)) = crate::zip::split_member_path(game) {
+        let parent = Path::new(&member).parent().unwrap_or(Path::new(""));
+        let mut found: Vec<_> = crate::zip::entries(&archive)?
+            .into_iter()
+            .filter(|entry| entry.name != member)
+            .filter(|entry| Path::new(&entry.name).parent().unwrap_or(Path::new("")) == parent)
+            .filter(|entry| accepts(Path::new(&entry.name)))
+            .map(|entry| archive.join(entry.name))
+            .collect();
+        found.sort();
+        return Ok(found.into_iter().next());
+    }
+    let Some(dir) = game.parent() else {
+        return Ok(None);
+    };
+    // Preserve the established ordinary-folder behavior. Archive read errors
+    // must propagate because a failed listing cannot establish no companion.
+    let Ok(listing) = std::fs::read_dir(dir) else {
+        return Ok(None);
+    };
+    let mut found: Vec<PathBuf> = listing
         .flatten()
         .map(|item| item.path())
         .filter(|path| path != game)
-        .filter(|path| {
-            path.extension()
-                .and_then(|ext| ext.to_str())
-                .map(|ext| ext.to_ascii_lowercase())
-                .is_some_and(|ext| rule.companion_extensions.contains(&ext))
-        })
+        .filter(|path| accepts(path))
         .collect();
-    // Sorted so the same folder always produces the same MGL, rather than
-    // whatever order the filesystem happened to return.
     found.sort();
-    found.into_iter().next()
+    Ok(found.into_iter().next())
 }
 
 /// Encode text back to ISO-8859-1, the way AmigaVision wrote it.
@@ -306,7 +324,7 @@ pub fn favorite_mgl_amiga(system: &SystemConfig, install: &Path, title: &str) ->
 
 /// The AmigaVision title an MGL carries, where it carries one.
 pub fn amiga_marker(mgl: &Path) -> Option<(PathBuf, String)> {
-    let text = std::fs::read_to_string(mgl).ok()?;
+    let text = crate::favorites::read_mgl_text(mgl, "AmigaVision MGL marker").ok()?;
     let at = text.find(&format!("<{DEGAUSS_TAG} "))?;
     let rest = &text[at..];
     let install = attribute(rest, "install")?;
@@ -364,7 +382,7 @@ pub fn favorite_mgl(system: &SystemConfig, game: &Path) -> Result<Option<String>
         )
     })?;
     let mut items = Vec::new();
-    if let Some(companion) = companion_for(rule, game) {
+    if let Some(companion) = companion_for(rule, game)? {
         if let Some(path) = companion.to_str() {
             let mut extra = MglItem::new(rule, path)?;
             extra.index = rule.companion_index.unwrap_or(rule.index);
@@ -400,6 +418,83 @@ pub fn needs_system_core(game: &Path) -> bool {
         "mgl" => amiga_marker(game).is_some(),
         _ => true,
     }
+}
+
+/// Build a launch using the current preference without persisting variant data.
+/// Self-describing custom launchers remain untouched. Recognized Favorites are
+/// converted only into the temporary output, preserving the saved Favorite.
+#[cfg(test)]
+pub fn plan_with_preference(
+    system: &SystemConfig,
+    game: &Path,
+    mgl_path: &Path,
+    menu_root: &Path,
+    ra_first: bool,
+) -> Result<LaunchPlan> {
+    plan_with_choice(system, game, mgl_path, menu_root, ra_first, None)
+}
+
+#[cfg(test)]
+pub fn favorite_mgl_with_preference(
+    system: &SystemConfig,
+    game: &Path,
+    menu_root: &Path,
+    ra_first: bool,
+) -> Result<Option<String>> {
+    favorite_mgl_with_choice(system, game, menu_root, ra_first, None)
+}
+
+pub fn plan_with_choice(
+    system: &SystemConfig,
+    game: &Path,
+    mgl_path: &Path,
+    menu_root: &Path,
+    ra_first: bool,
+    selected: Option<&str>,
+) -> Result<LaunchPlan> {
+    if game
+        .extension()
+        .is_some_and(|s| s.eq_ignore_ascii_case("mgl"))
+        && amiga_marker(game).is_none()
+    {
+        if !crate::core_variants::recognized_favorite(game, system)? {
+            return plan(system, game, mgl_path);
+        }
+        let core = crate::core_choices::resolve(system, menu_root, selected, ra_first)?;
+        if !crate::core_variants::needs_conversion(game, &core)?
+            && !crate::favorites::has_bare_paths(game)?
+        {
+            return plan(system, game, mgl_path);
+        }
+        let text = crate::core_variants::convert_favorite(game, &core)?;
+        let mgl = crate::favorites::relocate_mgl(&text, game, system)?;
+        return Ok(LaunchPlan {
+            mgl,
+            mgl_path: mgl_path.to_path_buf(),
+            command: format!("load_core {}\n", mgl_path.display()),
+            boot_file: None,
+        });
+    }
+    let mut result = plan(system, game, mgl_path)?;
+    if needs_system_core(game) {
+        let core = crate::core_choices::resolve(system, menu_root, selected, ra_first)?;
+        result.mgl = crate::core_variants::apply(&result.mgl, mgl_path, &core)?;
+    }
+    Ok(result)
+}
+
+pub fn favorite_mgl_with_choice(
+    system: &SystemConfig,
+    game: &Path,
+    menu_root: &Path,
+    ra_first: bool,
+    selected: Option<&str>,
+) -> Result<Option<String>> {
+    let Some(text) = favorite_mgl(system, game)? else {
+        return Ok(None);
+    };
+    let core = crate::core_choices::resolve(system, menu_root, selected, ra_first)?;
+    crate::core_variants::apply(&text, game, &core).map(Some)
 }
 
 /// Work out how to start one entry.
@@ -456,7 +551,7 @@ pub fn plan(system: &SystemConfig, game: &Path, mgl_path: &Path) -> Result<Launc
     let mut items = Vec::new();
     // The companion is mounted first, so the disk the game boots from is
     // the last thing handed over.
-    if let Some(companion) = companion_for(rule, game) {
+    if let Some(companion) = companion_for(rule, game)? {
         let path = companion.to_str().ok_or_else(|| {
             DegaussError::unsupported(
                 "companion path",
@@ -534,8 +629,30 @@ mod tests {
         }
     }
 
+    #[test]
+    fn archive_companions_stay_in_the_selected_virtual_directory() {
+        let root = std::env::temp_dir().join(format!("degauss-companion-{}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        let archive = root.join("library.zip");
+        std::fs::write(
+            &archive,
+            crate::zip::tests_archive(&["Game/game.vhd", "Game/disc.chd", "Other/disc.chd"], false),
+        )
+        .unwrap();
+        let mut rule = c64().launch.remove(0);
+        rule.companion_extensions = vec!["chd".into()];
+        assert_eq!(
+            companion_for(&rule, &archive.join("Game/game.vhd")).unwrap(),
+            Some(archive.join("Game/disc.chd"))
+        );
+        std::fs::write(&archive, b"broken archive").unwrap();
+        assert!(companion_for(&rule, &archive.join("Game/game.vhd")).is_err());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
     fn c64() -> SystemConfig {
         SystemConfig {
+            preserve_rbf_stem: false,
             name: "C64".into(),
             path: "/media/fat/games/C64".into(),
             extensions: vec!["d64".into(), "prg".into(), "crt".into()],
@@ -592,6 +709,7 @@ mod tests {
         // AmigaVision then cannot match the name it wrote itself: the core
         // starts and the game does not.
         let system = SystemConfig {
+            preserve_rbf_stem: false,
             name: "Amiga".into(),
             path: "/media/fat/games/Amiga".into(),
             extensions: vec!["adf".into()],
@@ -620,6 +738,7 @@ mod tests {
     #[test]
     fn a_title_that_is_not_latin1_is_refused_rather_than_mangled() {
         let system = SystemConfig {
+            preserve_rbf_stem: false,
             name: "Amiga".into(),
             path: "/media/fat/games/Amiga".into(),
             extensions: vec!["adf".into()],
@@ -644,6 +763,7 @@ mod tests {
         // The library lives inside one disk image, so there is no file to
         // hand over: the game is chosen by name on the way up.
         let system = SystemConfig {
+            preserve_rbf_stem: false,
             name: "Amiga".into(),
             path: "/media/fat/games/Amiga".into(),
             extensions: vec!["adf".into()],
@@ -677,6 +797,7 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("degauss-ags-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let system = SystemConfig {
+            preserve_rbf_stem: false,
             name: "Amiga".into(),
             path: dir.to_string_lossy().into_owned(),
             extensions: vec!["adf".into()],
@@ -1009,6 +1130,7 @@ mod tests {
         // so the extra element costs nothing there: the stock menu starts
         // AmigaVision at its own menu and Degauss starts it at the title.
         let system = SystemConfig {
+            preserve_rbf_stem: false,
             name: "Amiga".into(),
             path: "/media/fat/games/Amiga".into(),
             extensions: vec![],
@@ -1042,6 +1164,7 @@ mod tests {
     #[test]
     fn a_title_with_characters_xml_cares_about_survives_the_round_trip() {
         let system = SystemConfig {
+            preserve_rbf_stem: false,
             name: "Amiga".into(),
             path: "/media/fat/games/Amiga".into(),
             extensions: vec![],
@@ -1073,6 +1196,7 @@ mod tests {
         // write the name where AmigaVision reads it before the core comes
         // up. Without this the favourite would start AmigaVision's menu.
         let system = SystemConfig {
+            preserve_rbf_stem: false,
             name: "Amiga".into(),
             path: "/media/fat/games/Amiga".into(),
             extensions: vec!["mgl".into()],

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ mod browse;
 mod cache;
 mod category_images;
 mod config;
+mod core_choices;
+mod core_variants;
 mod covers;
 mod error;
 mod favorites;
@@ -343,7 +345,10 @@ fn load_everything(args: &Args) -> Result<Loaded> {
         .systems
         .clone()
         .unwrap_or_else(|| beside_binary("systems.toml"));
-    let table = systems::load_table(&systems_path)?;
+    let table = systems::prepare_table(
+        systems::load_table(&systems_path)?,
+        Path::new(&config.menu_root),
+    )?;
 
     let roots: Vec<PathBuf> = config.game_roots.iter().map(PathBuf::from).collect();
     // Logos live beside the configuration, named after the system.
@@ -357,7 +362,7 @@ fn load_everything(args: &Args) -> Result<Loaded> {
     // Which group each system belongs to comes from where its core
     // actually is on this card, not from what the table guessed.
     let cores = systems::CoreIndex::read(Path::new(&config.menu_root));
-    let systems = systems::discover(&table, &roots, logo_dir.as_deref(), &cores);
+    let systems = systems::discover_checked(&table, &roots, logo_dir.as_deref(), &cores)?;
     // The names the stock menu shows for cores, arcade boards and
     // shortcuts, when the card carries the file that defines them.
     let names = browse::DisplayNames::read(&Path::new(&config.menu_root).join("names.txt"));
@@ -379,6 +384,97 @@ fn load_everything(args: &Args) -> Result<Loaded> {
 /// what a half-finished upgrade left behind. Reads everything, loads
 /// nothing into a UI, refuses nothing: the whole point is to keep working
 /// on the installation that does not come up.
+fn select_system(systems: &[FoundSystem], name: &str) -> Result<usize> {
+    if let Some(index) = systems.iter().position(|system| {
+        system.def.id.eq_ignore_ascii_case(name) || system.name().eq_ignore_ascii_case(name)
+    }) {
+        return Ok(index);
+    }
+    let aliases: Vec<usize> = systems
+        .iter()
+        .enumerate()
+        .filter_map(|(index, system)| {
+            system
+                .def
+                .folders
+                .iter()
+                .any(|folder| {
+                    Path::new(folder)
+                        .file_name()
+                        .is_some_and(|part| part.eq_ignore_ascii_case(name))
+                })
+                .then_some(index)
+        })
+        .collect();
+    match aliases.as_slice() {
+        [index] => Ok(*index),
+        [] => Err(DegaussError::unsupported(
+            "system",
+            format!("{name:?} is not on this machine"),
+        )),
+        _ => Err(DegaussError::unsupported(
+            "system",
+            format!(
+                "{name:?} is ambiguous; use {}",
+                aliases
+                    .iter()
+                    .map(|&i| systems[i].def.id.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        )),
+    }
+}
+
+/// Diagnostic launches share ownership and current virtual-target checks with
+/// the interactive path so their reported core choice is the one users select.
+fn diagnostic_launch_plan(
+    loaded: &Loaded,
+    system: &FoundSystem,
+    path: &Path,
+    mgl: &Path,
+) -> Result<launch::LaunchPlan> {
+    if zip::split_member_path(path).is_some() {
+        zip::validate_member_for_launch(path)?;
+    }
+    let reference = if system.category() == "Favorites" {
+        favorites::reference_of_with_systems(path, &loaded.systems)
+    } else {
+        None
+    };
+    if let Some(reference) = &reference {
+        if zip::split_member_path(&reference.owner_target).is_some() {
+            zip::validate_member_for_launch(&reference.owner_target)?;
+        }
+    }
+    let owner = if system.category() == "Favorites" {
+        reference
+            .and_then(|reference| app::owner_of_favorite(&loaded.systems, &reference))
+            .and_then(|id| {
+                loaded
+                    .systems
+                    .iter()
+                    .find(|candidate| candidate.def.id == id)
+            })
+            .unwrap_or(system)
+    } else {
+        system
+    };
+    launch::plan_with_choice(
+        &owner.to_config(),
+        path,
+        mgl,
+        Path::new(&loaded.config.menu_root),
+        loaded.settings.core_preference.unwrap_or_default()
+            == settings::CorePreference::RetroAchievementsFirst,
+        loaded
+            .settings
+            .core_choices
+            .get(&owner.def.id)
+            .map(String::as_str),
+    )
+}
+
 fn check_install(config_path: &Path) -> Result<()> {
     let dir = config_path.parent().unwrap_or(Path::new(".")).to_path_buf();
     let mut problems: Vec<String> = Vec::new();
@@ -635,17 +731,7 @@ fn run() -> Result<()> {
     // Which system was asked for, if any. `None` is not the same as the
     // first one: without the flag the browser opens where it always would.
     let chosen: Option<usize> = match &args.system {
-        Some(id) => Some(
-            loaded
-                .systems
-                .iter()
-                .position(|s| {
-                    s.def.id.eq_ignore_ascii_case(id) || s.name().eq_ignore_ascii_case(id)
-                })
-                .ok_or_else(|| {
-                    DegaussError::unsupported("system", format!("{id:?} is not on this machine"))
-                })?,
-        ),
+        Some(id) => Some(select_system(&loaded.systems, id)?),
         None => None,
     };
 
@@ -668,7 +754,7 @@ fn run() -> Result<()> {
             let mgl = Path::new("/tmp/degauss.mgl");
             let plan = match &entry.kind {
                 browse::Kind::Play(browse::Launch::File(path)) => {
-                    launch::plan(&system.to_config(), path, mgl)?
+                    diagnostic_launch_plan(&loaded, system, path, mgl)?
                 }
                 browse::Kind::Play(browse::Launch::AmigaVision { install, title }) => {
                     launch::plan_amiga_vision(&system.to_config(), install, title, mgl)?
@@ -771,7 +857,7 @@ fn import_favorites(loaded: &Loaded, list: &Path) -> Result<()> {
     let text = std::fs::read_to_string(list)
         .map_err(|e| error::DegaussError::io("reading the list", list, e))?;
     let root = PathBuf::from(&loaded.config.menu_root).join(favorites::FAVORITES_DIR);
-    let already = favorites::Favorites::read(&root);
+    let already = favorites::Favorites::read_with_systems(&root, &loaded.systems);
 
     let (mut written, mut skipped, mut missing, mut failed) = (0, 0, 0, 0);
     for line in text.lines() {
@@ -803,22 +889,42 @@ fn import_favorites(loaded: &Loaded, list: &Path) -> Result<()> {
         let path = PathBuf::from(path);
         let into = root.join(folder);
 
-        // Which system it belongs to, by the folder it sits in. The
-        // deepest match wins, so a system inside another system's folder
-        // is not answered by the outer one.
-        let owner = loaded
-            .systems
-            .iter()
-            .filter(|system| system.paths.iter().any(|dir| path.starts_with(dir)))
-            .max_by_key(|system| {
-                system
-                    .paths
-                    .iter()
-                    .filter(|dir| path.starts_with(dir))
-                    .map(|dir| dir.as_os_str().len())
-                    .max()
-                    .unwrap_or(0)
-            });
+        if title.is_empty() {
+            if zip::split_member_path(&path).is_some() {
+                if let Err(error) = zip::validate_member_for_launch(&path) {
+                    println!("failed       {}: {error}", path.display());
+                    failed += 1;
+                    continue;
+                }
+            } else if !path.exists() {
+                println!("gone         {}", path.display());
+                missing += 1;
+                continue;
+            }
+        }
+        let reference = if title.is_empty() {
+            favorites::reference_of_with_systems(&path, &loaded.systems)
+        } else {
+            None
+        };
+        if let Some(reference) = &reference {
+            if zip::split_member_path(&reference.owner_target).is_some() {
+                if let Err(error) = zip::validate_member_for_launch(&reference.owner_target) {
+                    println!("failed       {}: {error}", path.display());
+                    failed += 1;
+                    continue;
+                }
+            }
+        }
+        let owner_id = if title.is_empty() {
+            reference
+                .and_then(|reference| app::owner_of_favorite(&loaded.systems, &reference))
+                .or_else(|| app::owner_of_path(&loaded.systems, &path))
+        } else {
+            app::owner_of_path(&loaded.systems, &favorites::amiga_key(&path, title))
+        };
+        let owner =
+            owner_id.and_then(|id| loaded.systems.iter().find(|system| system.def.id == id));
         let Some(owner) = owner else {
             println!("skipped      no system owns {}", path.display());
             failed += 1;
@@ -827,16 +933,22 @@ fn import_favorites(loaded: &Loaded, list: &Path) -> Result<()> {
         let config = owner.to_config();
 
         if title.is_empty() {
-            if !path.exists() {
-                println!("gone         {}", path.display());
-                missing += 1;
-                continue;
-            }
             if already.holds(&path) {
                 skipped += 1;
                 continue;
             }
-            let outcome = match launch::favorite_mgl(&config, &path) {
+            let outcome = match launch::favorite_mgl_with_choice(
+                &config,
+                &path,
+                Path::new(&loaded.config.menu_root),
+                loaded.settings.core_preference.unwrap_or_default()
+                    == settings::CorePreference::RetroAchievementsFirst,
+                loaded
+                    .settings
+                    .core_choices
+                    .get(&owner.def.id)
+                    .map(String::as_str),
+            ) {
                 Ok(Some(mgl)) => {
                     let stem = path.file_stem().unwrap_or_default().to_string_lossy();
                     favorites::add_game(&into, &stem, &mgl)
@@ -1325,9 +1437,10 @@ fn effective_library(loaded: &Loaded, system: &FoundSystem) -> Result<EffectiveL
     let fingerprints = if cached_is_current {
         cached.map(|data| data.fingerprints).unwrap_or_default()
     } else if provider.health.usable() {
-        let source_cache = cached
-            .map(|data| data.cache)
-            .unwrap_or_else(|| cache::build_system(&library));
+        let source_cache = match cached {
+            Some(data) => data.cache,
+            None => cache::build_system_checked(&library)?,
+        };
         provider
             .fingerprints_for_cache(&source_cache, &cancelled, &mut |_, _| {})?
             .unwrap_or_default()
@@ -1550,6 +1663,171 @@ mod tests {
         parse_from(words.iter().map(|w| w.to_string()))
             .expect("parses")
             .expect("not --help")
+    }
+
+    fn diagnostic_test_systems(root: &Path) -> Vec<FoundSystem> {
+        let definitions = systems::parse_table(
+            r#"
+[[systems]]
+name = "Nintendo Entertainment System"
+id = "NES"
+folders = ["Shared", "Nintendo"]
+rbf = "_Console/NES"
+extensions = ["nes", "mgl"]
+[[systems.launch]]
+extensions = ["nes"]
+type = "f"
+index = 1
+delay = 1
+[[systems]]
+name = "Famicom Disk System"
+id = "FDS"
+folders = ["Shared", "NES"]
+rbf = "_Console/NES"
+setname = "FDS"
+extensions = ["fds", "mgl"]
+[[systems.launch]]
+extensions = ["fds"]
+type = "f"
+index = 1
+delay = 2
+[[systems]]
+name = "Favorites"
+id = "Favorites"
+folders = ["/media/fat/_@Favorites", "_@Favorites"]
+rbf = ""
+extensions = ["mgl", "rbf"]
+category = "Favorites"
+"#,
+            Path::new("diagnostic fixture"),
+        )
+        .unwrap();
+        definitions
+            .into_iter()
+            .map(|def| {
+                let folder = if def.id == "Favorites" {
+                    "_@Favorites"
+                } else {
+                    "games/NES"
+                };
+                FoundSystem {
+                    def,
+                    paths: vec![root.join(folder)],
+                    logo_dir: None,
+                    menu_folder: None,
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn diagnostic_ids_and_names_take_precedence_over_folder_aliases() {
+        let systems = diagnostic_test_systems(Path::new("/fixture"));
+        assert_eq!(select_system(&systems, "nes").unwrap(), 0);
+        assert_eq!(select_system(&systems, "FAMICOM DISK SYSTEM").unwrap(), 1);
+        assert_eq!(select_system(&systems, "fds").unwrap(), 1);
+        assert_eq!(select_system(&systems, "Nintendo").unwrap(), 0);
+        // Both configured spellings belong to one system, so this is unique.
+        assert_eq!(select_system(&systems, "_@favorites").unwrap(), 2);
+    }
+
+    #[test]
+    fn diagnostic_ambiguous_alias_lists_owner_ids_and_unknown_alias_errors() {
+        let systems = diagnostic_test_systems(Path::new("/fixture"));
+        let error = select_system(&systems, "Shared").unwrap_err().to_string();
+        assert!(error.contains("ambiguous"));
+        assert!(error.contains("NES, FDS"));
+        assert!(!error.contains("Favorites"));
+        assert!(select_system(&systems, "uninstalled")
+            .unwrap_err()
+            .to_string()
+            .contains("not on this machine"));
+    }
+
+    fn diagnostic_fixture(name: &str) -> (PathBuf, Loaded) {
+        let root = std::env::temp_dir().join(format!("degauss-cli-{name}-{}", std::process::id()));
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+        for folder in ["games/NES", "_@Favorites", "_Console", "_RA_Cores/Cores"] {
+            std::fs::create_dir_all(root.join(folder)).unwrap();
+        }
+        std::fs::write(root.join("_Console/NES.rbf"), b"discovery fixture").unwrap();
+        std::fs::write(root.join("_RA_Cores/Cores/NES.rbf"), b"discovery fixture").unwrap();
+        std::fs::write(root.join("_RA_Cores/NES.mgl"), "<mistergamedescription><rbf>_RA_Cores/Cores/NES</rbf><setname same_dir=\"1\">RA_NES</setname></mistergamedescription>").unwrap();
+        let mut config = Config::parse("[app]\n", Path::new("fixture")).unwrap();
+        config.menu_root = root.to_string_lossy().into_owned();
+        let loaded = Loaded {
+            config,
+            settings: Settings::default(),
+            settings_path: root.join("settings.toml"),
+            systems: diagnostic_test_systems(&root),
+            names: browse::DisplayNames::default(),
+            table: Vec::new(),
+            logo_dir: None,
+            themes_dir: root.join("themes"),
+            themes: theme::ThemeSet::default(),
+        };
+        (root, loaded)
+    }
+
+    #[test]
+    fn diagnostic_favorite_uses_the_owning_system_core_choice() {
+        let (root, mut loaded) = diagnostic_fixture("favorite-owner");
+        std::fs::write(root.join("games/NES/Game.fds"), b"path fixture").unwrap();
+        let favorite = root.join("_@Favorites/Game.mgl");
+        std::fs::write(&favorite, "<mistergamedescription><rbf>_Console/NES</rbf><setname>FDS</setname><file delay=\"2\" type=\"f\" index=\"1\" path=\"Game.fds\"/></mistergamedescription>").unwrap();
+        loaded
+            .settings
+            .core_choices
+            .insert("NES".into(), "standard".into());
+        loaded
+            .settings
+            .core_choices
+            .insert("FDS".into(), "ra".into());
+        let plan = diagnostic_launch_plan(
+            &loaded,
+            &loaded.systems[2],
+            &favorite,
+            &root.join("temp.mgl"),
+        )
+        .unwrap();
+        assert!(plan.mgl.contains("<rbf>_RA_Cores/Cores/NES</rbf>"));
+        assert!(plan
+            .mgl
+            .contains("<setname same_dir=\"1\">RA_NES</setname>"));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn favorites_import_accepts_zip_members_and_uses_shared_system_choice() {
+        let (root, mut loaded) = diagnostic_fixture("zip-import");
+        let archive = root.join("games/NES/library.zip");
+        std::fs::write(&archive, zip::tests_archive(&["Game.fds"], false)).unwrap();
+        let member = archive.join("Game.fds");
+        loaded
+            .settings
+            .core_choices
+            .insert("NES".into(), "standard".into());
+        loaded
+            .settings
+            .core_choices
+            .insert("FDS".into(), "ra".into());
+        let list = root.join("import.tsv");
+        std::fs::write(&list, format!("Test\t{}\n", member.display())).unwrap();
+        import_favorites(&loaded, &list).unwrap();
+        let result = std::fs::read_to_string(root.join("_@Favorites/Test/Game.mgl")).unwrap();
+        assert!(result.contains("<rbf>_RA_Cores/Cores/NES</rbf>"));
+        assert!(result.contains("library.zip/Game.fds"));
+        std::fs::write(&archive, b"corrupt archive").unwrap();
+        assert!(diagnostic_launch_plan(
+            &loaded,
+            &loaded.systems[1],
+            &member,
+            &root.join("temp.mgl")
+        )
+        .is_err());
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -446,7 +446,7 @@ fn diagnostic_launch_plan(
     if zip::split_member_path(path).is_some() {
         zip::validate_member_for_launch(path)?;
     }
-    let reference = if system.category() == "Favorites" {
+    let reference = if systems::is_favorites(system.category()) {
         favorites::reference_of_with_systems(path, &loaded.systems)
     } else {
         None
@@ -456,7 +456,7 @@ fn diagnostic_launch_plan(
             zip::validate_member_for_launch(&reference.owner_target)?;
         }
     }
-    let owner = if system.category() == "Favorites" {
+    let owner = if systems::is_favorites(system.category()) {
         reference
             .and_then(|reference| app::owner_of_favorite(&loaded.systems, &reference))
             .and_then(|id| {
@@ -1808,17 +1808,20 @@ category = "Favorites"
             .settings
             .core_choices
             .insert("FDS".into(), "ra".into());
-        let plan = diagnostic_launch_plan(
-            &loaded,
-            &loaded.systems[2],
-            &favorite,
-            &root.join("temp.mgl"),
-        )
-        .unwrap();
-        assert!(plan.mgl.contains("<rbf>_RA_Cores/Cores/NES</rbf>"));
-        assert!(plan
-            .mgl
-            .contains("<setname same_dir=\"1\">RA_NES</setname>"));
+        for category in ["Favorites", "favorites", "FAVORITES"] {
+            loaded.systems[2].def.category = Some(category.into());
+            let plan = diagnostic_launch_plan(
+                &loaded,
+                &loaded.systems[2],
+                &favorite,
+                &root.join("temp.mgl"),
+            )
+            .unwrap();
+            assert!(plan.mgl.contains("<rbf>_RA_Cores/Cores/NES</rbf>"));
+            assert!(plan
+                .mgl
+                .contains("<setname same_dir=\"1\">RA_NES</setname>"));
+        }
         std::fs::remove_dir_all(root).unwrap();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ degauss - a fast game browser for MiSTer FPGA
   --geometry <WxH>    geometry for --render and --bench
   --format <fmt>      rgb565 or xrgb8888, for --render and --bench
   --device <path>     framebuffer device (default /dev/fb0)
-  --present <mode>    direct (default) or staged
+  --present <mode>    direct or staged (default depends on framebuffer mapping)
   --help              this text
 
 With no flags it takes over the framebuffer and browses.
@@ -107,6 +107,15 @@ With no flags it takes over the framebuffer and browses.
   tab           this folder: random, favourites, letter, search, view
   space         menu: options, help, about, exit
 ";
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn default_present_mode(mapping_source: &str) -> PresentMode {
+    if mapping_source == "/dev/mem fallback" {
+        PresentMode::Staged
+    } else {
+        PresentMode::Direct
+    }
+}
 
 fn main() -> ExitCode {
     // The release build aborts on panic, which skips destructors, so the
@@ -1327,8 +1336,11 @@ fn run_on_framebuffer(
     };
     let mut terminal = input::TerminalGuard::acquire()?;
 
-    // The flag wins if it was given; otherwise the saved setting does.
-    let mut presenter = Presenter::new(geometry, args.present.unwrap_or(app.present_mode()));
+    // Physical framebuffer memory favours staged rendering. Explicit choices
+    // still win, and this runtime default never changes the saved settings.
+    let default = default_present_mode(framebuffer.mapping_source());
+    let mode = app.initialize_presentation(default, args.present);
+    let mut presenter = Presenter::new(geometry, mode);
     let outcome = app.run(&mut framebuffer, &mut input, &mut presenter);
 
     terminal.restore();
@@ -1720,6 +1732,15 @@ category = "Favorites"
                 }
             })
             .collect()
+    }
+
+    #[test]
+    fn physical_mapping_defaults_to_staged_and_native_keeps_direct() {
+        assert_eq!(
+            default_present_mode("/dev/mem fallback"),
+            PresentMode::Staged
+        );
+        assert_eq!(default_present_mode("fbdev"), PresentMode::Direct);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1134,6 +1134,7 @@ fn selftest(loaded: Loaded, args: Args, chosen: usize, frames: u32) -> Result<()
     app.open_system_by_index(chosen);
 
     let mut log = String::new();
+    let _ = writeln!(log, "mapping      {}", framebuffer.mapping_source());
     let _ = writeln!(
         log,
         "framebuffer  {} {}x{} {:?} stride {}",
@@ -1233,6 +1234,7 @@ fn run_on_framebuffer(
     let vsync = framebuffer.wait_for_vsync()?;
 
     note(&format!("degauss      {}", build_description()));
+    note(&format!("mapping      {}", framebuffer.mapping_source()));
     note(&format!(
         "framebuffer  {} {}x{} {:?} stride {}",
         args.device.display(),

--- a/src/options.rs
+++ b/src/options.rs
@@ -37,6 +37,10 @@ pub enum OptionId {
     ShowOther,
     /// Show the group holding the test and measurement cores.
     ShowUtility,
+    /// Show the collection of nightly cores.
+    ShowUnstable,
+    /// Preferred installed variant for ordinary game launches.
+    CorePreference,
     /// The strip along the bottom of the screen, while browsing.
     ShowBar,
     /// Read the card again into the written-down copy of it.
@@ -89,9 +93,11 @@ pub const OPTIONS: &[OptionId] = &[
     OptionId::HoldXFavorite,
     OptionId::FoldersLast,
     OptionId::RandomLaunches,
+    OptionId::CorePreference,
     OptionId::Spacer,
     OptionId::ShowOther,
     OptionId::ShowUtility,
+    OptionId::ShowUnstable,
     OptionId::ShowEmpty,
     OptionId::ShowHidden,
     OptionId::ResetHidden,
@@ -128,6 +134,8 @@ impl OptionId {
             OptionId::ShowEmpty => "Show systems with no games",
             OptionId::ShowOther => "Show Other folder",
             OptionId::ShowUtility => "Show Utility folder",
+            OptionId::ShowUnstable => "Show Unstable folder",
+            OptionId::CorePreference => "Core preference",
             OptionId::ShowBar => "Bottom bar while browsing",
             OptionId::RebuildCache => "Rebuild all system lists",
             OptionId::ScrapeAll => "Scrape All Systems",
@@ -181,6 +189,8 @@ impl OptionId {
             }
             OptionId::ShowOther => "Show the Other group: the cores that are not games.",
             OptionId::ShowUtility => "Show the Utility group: test patterns and measurement cores.",
+            OptionId::ShowUnstable => "Show the Unstable group: nightly core builds.",
+            OptionId::CorePreference => "Prefer standard or RetroAchievements cores when both are installed.",
             OptionId::ShowBar => "The strip with the time and the buttons. Menus always keep it.",
             OptionId::FoldersLast => {
                 "On, folders lead a system's listing; off, the games come first."

--- a/src/render.rs
+++ b/src/render.rs
@@ -509,5 +509,6 @@ mod tests {
             visible_pixels(&tinted_half) >= visible_pixels(&original_zero),
             "mixing a colour must not make any part of the logo disappear"
         );
+        crate::app::test_library_launch_flow(window.clone());
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -141,7 +141,7 @@ pub enum PresentMode {
     ///
     /// One extra copy, but every blend read hits cache and an unchanged
     /// screen copies nothing at all. The right answer on hardware whose
-    /// framebuffer reads are slow; on this one it is not the default.
+    /// framebuffer reads are slow; selected by default for physical /dev/mem mappings.
     Staged,
 }
 

--- a/src/scraper/gamelist_edit.rs
+++ b/src/scraper/gamelist_edit.rs
@@ -734,7 +734,7 @@ fn xml_attributes(element: &BytesStart<'_>, origin: &Path) -> Result<Vec<(String
                     ),
                 )
             })?;
-            let key = attribute.key.as_ref().to_ascii_lowercase();
+            let key = attribute.key.as_ref().to_owned();
             let value = attribute
                 .normalized_value(XmlVersion::Implicit1_0)
                 .map_err(|error| {
@@ -1082,7 +1082,7 @@ fn append_member_from_legacy(
     {
         let mut opening = String::from("<game");
         for (key, value) in xml_attributes(&start, folder)? {
-            if key != "id" {
+            if !key.eq_ignore_ascii_case("id") {
                 opening.push_str(&format!(
                     " {key}=\"{}\"",
                     escape(&value).replace('"', "&quot;")
@@ -2034,7 +2034,7 @@ mod tests {
     fn single_member_fill_preserves_legacy_fields_and_materializes_exact_entry() {
         let folder = temp("zip-legacy-fill");
         let path = folder.join("gamelist.xml");
-        let original = r#"<game id="old"><path>Only.zip</path><name>Keep name</name><custom>Keep custom</custom></game>"#;
+        let original = r#"<game ID="old" customFlag="Keep &amp; exact"><path>Only.zip</path><name>Keep name</name><custom>Keep custom</custom></game>"#;
         std::fs::write(&path, format!("<gameList>{original}</gameList>")).unwrap();
         let update = Update {
             relative_game_path: "./Only.zip/Game.rom".into(),
@@ -2050,7 +2050,12 @@ mod tests {
             .unwrap();
         let text = std::fs::read_to_string(&path).unwrap();
         assert!(text.contains(original));
-        assert_eq!(text.matches("id=\"old\"").count(), 1);
+        assert_eq!(text.matches("ID=\"old\"").count(), 1);
+        assert_eq!(text.matches("customFlag=\"Keep &amp; exact\"").count(), 2);
+        assert!(
+            !text.contains("customflag="),
+            "XML attribute names are case-sensitive"
+        );
         let list = crate::gamelist::Gamelist::load(&path, &folder).unwrap();
         let (member, _) = list.lookup_exact("./Only.zip/Game.rom").unwrap();
         assert_eq!(member.name.as_deref(), Some("Keep name"));

--- a/src/scraper/gamelist_edit.rs
+++ b/src/scraper/gamelist_edit.rs
@@ -161,6 +161,7 @@ struct OpenGame {
     field: Option<OpenField>,
 }
 
+#[cfg(test)]
 pub fn needs_many(
     gamelist_path: &Path,
     folder: &Path,
@@ -168,6 +169,33 @@ pub fn needs_many(
     image_policy: ImagePolicy,
     metadata_policy: MetadataPolicy,
 ) -> Result<Vec<Result<Needs>>> {
+    let fallback: Vec<bool> = relative_game_paths
+        .iter()
+        .map(|path| crate::zip::split_member_path(Path::new(path)).is_none())
+        .collect();
+    needs_many_with_fallback(
+        gamelist_path,
+        folder,
+        relative_game_paths,
+        &fallback,
+        image_policy,
+        metadata_policy,
+    )
+}
+
+pub fn needs_many_with_fallback(
+    gamelist_path: &Path,
+    folder: &Path,
+    relative_game_paths: &[String],
+    metadata_fallback: &[bool],
+    image_policy: ImagePolicy,
+    metadata_policy: MetadataPolicy,
+) -> Result<Vec<Result<Needs>>> {
+    if metadata_fallback.len() != relative_game_paths.len() {
+        return Err(Error::local(
+            "metadata policy count does not match scrape targets",
+        ));
+    }
     let Some(bytes) = read_optional(gamelist_path)? else {
         return Ok(relative_game_paths
             .iter()
@@ -180,7 +208,7 @@ pub fn needs_many(
             .collect());
     };
     let document = parse_document(&bytes, gamelist_path)?;
-    let resolved = resolve_games(&document, relative_game_paths);
+    let resolved = resolve_games(&document, relative_game_paths, metadata_fallback);
     Ok(resolved
         .into_iter()
         .map(|result| {
@@ -273,12 +301,34 @@ pub struct Update {
     pub metadata_policy: MetadataPolicy,
 }
 
+#[cfg(test)]
 pub fn apply_many(
     gamelist_path: &Path,
     folder: &Path,
     updates: &[Update],
     backups: &mut Backups,
 ) -> Result<Vec<Result<Change>>> {
+    let fallback: Vec<bool> = updates
+        .iter()
+        .map(|update| {
+            crate::zip::split_member_path(Path::new(&update.relative_game_path)).is_none()
+        })
+        .collect();
+    apply_many_with_fallback(gamelist_path, folder, updates, &fallback, backups)
+}
+
+pub fn apply_many_with_fallback(
+    gamelist_path: &Path,
+    folder: &Path,
+    updates: &[Update],
+    metadata_fallback: &[bool],
+    backups: &mut Backups,
+) -> Result<Vec<Result<Change>>> {
+    if metadata_fallback.len() != updates.len() {
+        return Err(Error::local(
+            "metadata policy count does not match scrape updates",
+        ));
+    }
     if updates.is_empty() {
         return Ok(Vec::new());
     }
@@ -292,7 +342,7 @@ pub fn apply_many(
         .iter()
         .map(|update| update.relative_game_path.clone())
         .collect();
-    let resolved = resolve_games(&document, &relative_paths);
+    let resolved = resolve_games(&document, &relative_paths, metadata_fallback);
     let mut outcomes = vec![Ok(Change::default()); updates.len()];
     let mut replacements = Vec::new();
     let mut appended = Vec::new();
@@ -300,7 +350,14 @@ pub fn apply_many(
     for (at, (update, resolved)) in updates.iter().zip(resolved).enumerate() {
         let edits = match resolved {
             Ok(Some(index)) => {
-                existing_edits(source, &document, &document.games[index], folder, update)
+                let game = &document.games[index];
+                if crate::zip::split_member_path(Path::new(&update.relative_game_path)).is_some()
+                    && game.path != normalise_rel(&update.relative_game_path)
+                {
+                    append_member_from_legacy(source, &document, game, folder, update)
+                } else {
+                    existing_edits(source, &document, game, folder, update)
+                }
             }
             Ok(None) => append_game_bytes(source, &document, update)
                 .map(|(bytes, change)| (Vec::new(), bytes, change)),
@@ -695,10 +752,18 @@ fn xml_attributes(element: &BytesStart<'_>, origin: &Path) -> Result<Vec<(String
         .collect()
 }
 
-fn matching_game<'a>(document: &'a Document, relative: &str) -> Result<Option<&'a Game>> {
+fn matching_game<'a>(
+    document: &'a Document,
+    relative: &str,
+    metadata_fallback: bool,
+) -> Result<Option<&'a Game>> {
     let wanted = normalise_rel(relative);
     if let Some(found) = unique_at(document, relative, |game| game.path == wanted)? {
         return Ok(Some(found));
+    }
+
+    if !metadata_fallback {
+        return Ok(None);
     }
 
     let file_name = file_name_of(&wanted).to_ascii_lowercase();
@@ -754,8 +819,12 @@ fn matching_game<'a>(document: &'a Document, relative: &str) -> Result<Option<&'
     Ok(None)
 }
 
-fn matching_game_index(document: &Document, relative: &str) -> Result<Option<usize>> {
-    matching_game(document, relative).map(|matched| {
+fn matching_game_index(
+    document: &Document,
+    relative: &str,
+    metadata_fallback: bool,
+) -> Result<Option<usize>> {
+    matching_game(document, relative, metadata_fallback).map(|matched| {
         matched.and_then(|matched| {
             document
                 .games
@@ -770,10 +839,15 @@ fn matching_game_index(document: &Document, relative: &str) -> Result<Option<usi
 /// A single existing entry, or a single as-yet missing path, may not receive
 /// two scrape results in the same batch. Refusing both targets is safer than
 /// choosing an order-dependent winner after title/slug fallback matching.
-fn resolve_games(document: &Document, relative_paths: &[String]) -> Vec<Result<Option<usize>>> {
+fn resolve_games(
+    document: &Document,
+    relative_paths: &[String],
+    metadata_fallback: &[bool],
+) -> Vec<Result<Option<usize>>> {
     let mut resolved: Vec<Result<Option<usize>>> = relative_paths
         .iter()
-        .map(|relative| matching_game_index(document, relative))
+        .enumerate()
+        .map(|(index, relative)| matching_game_index(document, relative, metadata_fallback[index]))
         .collect();
     let mut existing: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
     let mut missing: BTreeMap<String, Vec<usize>> = BTreeMap::new();
@@ -976,6 +1050,62 @@ fn existing_edits(
         replacements.push((game.close_start..game.close_start, bytes));
     }
     Ok((replacements, Vec::new(), change))
+}
+
+/// Materialize a single-member legacy overlay at its exact member path before
+/// editing it. Existing fields, unknown tags and parent links survive; the
+/// shared archive/title row is never modified or given a duplicate id.
+fn append_member_from_legacy(
+    source: &[u8],
+    document: &Document,
+    game: &Game,
+    folder: &Path,
+    update: &Update,
+) -> Result<ExistingEdits> {
+    let (mut replacements, _, mut change) = existing_edits(source, document, game, folder, update)?;
+    if !change.changed() {
+        return Ok((Vec::new(), Vec::new(), change));
+    }
+    let path = game
+        .fields
+        .get("path")
+        .ok_or_else(|| Error::local("legacy metadata entry has no path field"))?;
+    replacements.push((
+        path.whole.clone(),
+        element("path", &update.relative_game_path).into_bytes(),
+    ));
+    let original = &source[game.whole.clone()];
+    let mut reader = Reader::from_reader(original);
+    if let Event::Start(start) = reader
+        .read_event()
+        .map_err(|error| Error::local(error.to_string()))?
+    {
+        let mut opening = String::from("<game");
+        for (key, value) in xml_attributes(&start, folder)? {
+            if key != "id" {
+                opening.push_str(&format!(
+                    " {key}=\"{}\"",
+                    escape(&value).replace('"', "&quot;")
+                ));
+            }
+        }
+        opening.push('>');
+        replacements.push((
+            game.whole.start..game.whole.start + reader.buffer_position() as usize,
+            opening.into_bytes(),
+        ));
+    }
+    for (range, _) in &mut replacements {
+        range.start -= game.whole.start;
+        range.end -= game.whole.start;
+    }
+    let cloned = apply_replacements(original, replacements)?;
+    let mut insertion = Vec::new();
+    insertion.extend_from_slice(document.newline.as_bytes());
+    insertion.extend_from_slice(&cloned);
+    insertion.extend_from_slice(document.newline.as_bytes());
+    change.created_entry = true;
+    Ok((Vec::new(), insertion, change))
 }
 
 fn append_game_bytes(
@@ -1874,5 +2004,58 @@ mod tests {
             "./media/screenscraper/3-42-abc.png",
             "./media/screenscraper/3-43-abc.png"
         ));
+    }
+    #[test]
+    fn multigame_zip_scrape_never_edits_an_archive_or_basename_match() {
+        let folder = temp("zip-exact");
+        let path = folder.join("gamelist.xml");
+        let archive_row = "<game><path>library.zip</path><name>Archive</name></game>";
+        std::fs::write(&path, format!("<gameList>{archive_row}</gameList>")).unwrap();
+        let update = Update {
+            relative_game_path: "./library.zip/folder/Game.rom".into(),
+            metadata: metadata("Member"),
+            image_path: None,
+            image_created: false,
+            image_policy: ImagePolicy::Off,
+            metadata_policy: MetadataPolicy::FillMissing,
+        };
+        apply_many_with_fallback(&path, &folder, &[update], &[false], &mut Backups::default())
+            .unwrap()[0]
+            .as_ref()
+            .unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.contains(archive_row));
+        assert!(text.contains("<path>./library.zip/folder/Game.rom</path>"));
+        assert!(text.contains("<name>Member</name>"));
+        std::fs::remove_dir_all(folder).unwrap();
+    }
+
+    #[test]
+    fn single_member_fill_preserves_legacy_fields_and_materializes_exact_entry() {
+        let folder = temp("zip-legacy-fill");
+        let path = folder.join("gamelist.xml");
+        let original = r#"<game id="old"><path>Only.zip</path><name>Keep name</name><custom>Keep custom</custom></game>"#;
+        std::fs::write(&path, format!("<gameList>{original}</gameList>")).unwrap();
+        let update = Update {
+            relative_game_path: "./Only.zip/Game.rom".into(),
+            metadata: metadata("Replacement name"),
+            image_path: None,
+            image_created: false,
+            image_policy: ImagePolicy::Off,
+            metadata_policy: MetadataPolicy::FillMissing,
+        };
+        apply_many_with_fallback(&path, &folder, &[update], &[true], &mut Backups::default())
+            .unwrap()[0]
+            .as_ref()
+            .unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.contains(original));
+        assert_eq!(text.matches("id=\"old\"").count(), 1);
+        let list = crate::gamelist::Gamelist::load(&path, &folder).unwrap();
+        let (member, _) = list.lookup_exact("./Only.zip/Game.rom").unwrap();
+        assert_eq!(member.name.as_deref(), Some("Keep name"));
+        assert_eq!(member.developer.as_deref(), Some("New developer"));
+        assert_eq!(text.matches("<custom>Keep custom</custom>").count(), 2);
+        std::fs::remove_dir_all(folder).unwrap();
     }
 }

--- a/src/scraper/platforms.rs
+++ b/src/scraper/platforms.rs
@@ -141,6 +141,8 @@ mod tests {
     fn an_unreviewed_system_is_not_guessed() {
         assert_eq!(id_for("AppleLisa", &BTreeMap::new()), None);
         assert_eq!(id_for("OtherCores", &BTreeMap::new()), None);
+        // This collection contains core builds, not one scrapeable game system.
+        assert_eq!(id_for("UnstableCores", &BTreeMap::new()), None);
         assert_eq!(id_for("Laser", &BTreeMap::new()), None);
         assert_eq!(id_for("TomyTutor", &BTreeMap::new()), None);
     }
@@ -196,6 +198,7 @@ mod tests {
             "TatungEinstein",
             "TomyTutor",
             "UK101",
+            "UnstableCores",
             "UtilityCores",
             "Vector06C",
             "ZXNext",

--- a/src/scraper/targets.rs
+++ b/src/scraper/targets.rs
@@ -50,6 +50,8 @@ pub struct Target {
     pub match_path: Option<PathBuf>,
     pub folder: PathBuf,
     pub relative_path: String,
+    /// Only a single supported ZIP member can inherit archive-level metadata.
+    pub metadata_fallback: bool,
 }
 
 impl Target {
@@ -162,7 +164,13 @@ pub fn collect(
             on_progress(&system.def.name);
             check_cancelled(cancelled)?;
             Ok(TargetBatch {
-                targets: vec![target_for(system, platform, launch, title)?],
+                targets: vec![target_for(
+                    system,
+                    platform,
+                    launch,
+                    title,
+                    &mut crate::zip::ArchiveCache::default(),
+                )?],
                 ..Default::default()
             })
         }
@@ -306,6 +314,7 @@ fn walk(
     cancelled: &AtomicBool,
 ) -> Result<Walked> {
     let mut walked = Walked::default();
+    let mut archives = crate::zip::ArchiveCache::default();
     let mut queue = VecDeque::from([(start, 0usize)]);
     let mut seen = HashSet::new();
     while let Some((place, depth)) = queue.pop_front() {
@@ -340,13 +349,15 @@ fn walk(
             check_cancelled(cancelled)?;
             match &row.kind {
                 Kind::Enter(next) => queue.push_back((next.clone(), depth + 1)),
-                Kind::Play(launch) => match target_for(system, platform, launch, &row.name) {
-                    Ok(target) => walked.targets.push(target),
-                    Err(error) => walked.issues.push(TargetIssue {
-                        system: system.def.name.clone(),
-                        detail: error.to_string(),
-                    }),
-                },
+                Kind::Play(launch) => {
+                    match target_for(system, platform, launch, &row.name, &mut archives) {
+                        Ok(target) => walked.targets.push(target),
+                        Err(error) => walked.issues.push(TargetIssue {
+                            system: system.def.name.clone(),
+                            detail: error.to_string(),
+                        }),
+                    }
+                }
             }
         }
     }
@@ -361,7 +372,13 @@ fn check_cancelled(cancelled: &AtomicBool) -> Result<()> {
     }
 }
 
-fn target_for(system: &FoundSystem, platform: u32, launch: &Launch, title: &str) -> Result<Target> {
+fn target_for(
+    system: &FoundSystem,
+    platform: u32,
+    launch: &Launch,
+    title: &str,
+    archives: &mut crate::zip::ArchiveCache,
+) -> Result<Target> {
     let (folder, relative_path, match_path, query) = match launch {
         Launch::File(path) => {
             let folder = root_for(system, path).ok_or_else(|| {
@@ -393,7 +410,26 @@ fn target_for(system: &FoundSystem, platform: u32, launch: &Launch, title: &str)
             (folder, format!("./Games/{title}"), None, title.to_string())
         }
     };
+    let metadata_fallback = if let Launch::File(path) = launch {
+        if let Some((archive, _)) = crate::zip::split_member_path(path) {
+            let contents = archives
+                .read(&archive)
+                .map_err(|error| Error::local(error.to_string()))?;
+            let config = system.to_config();
+            contents
+                .entries
+                .iter()
+                .filter(|entry| config.accepts(Path::new(&entry.name)))
+                .count()
+                == 1
+        } else {
+            true
+        }
+    } else {
+        true
+    };
     Ok(Target {
+        metadata_fallback,
         system_id: system.def.id.clone(),
         affected_system_ids: vec![system.def.id.clone()],
         system_name: system.def.name.clone(),
@@ -529,6 +565,7 @@ fn remove_ambiguous(batch: &mut TargetBatch) {
             target.screen_scraper_system_id,
         );
         if let Some(existing) = positions.get(&key).copied() {
+            merged[existing].metadata_fallback &= target.metadata_fallback;
             for system_id in target.affected_system_ids {
                 if !merged[existing].affected_system_ids.contains(&system_id) {
                     merged[existing].affected_system_ids.push(system_id);
@@ -794,6 +831,7 @@ mod tests {
     #[test]
     fn case_sensitive_storage_keeps_distinct_paths_distinct() {
         let target = |folder: &str, system: &str| Target {
+            metadata_fallback: true,
             system_id: system.into(),
             affected_system_ids: vec![system.into()],
             system_name: system.into(),
@@ -827,6 +865,7 @@ mod tests {
         std::fs::create_dir(&root).unwrap();
         std::os::unix::fs::symlink(&root, &alias).unwrap();
         let target = |folder: PathBuf, system: &str| Target {
+            metadata_fallback: true,
             system_id: system.into(),
             affected_system_ids: vec![system.into()],
             system_name: system.into(),

--- a/src/scraper/targets.rs
+++ b/src/scraper/targets.rs
@@ -192,7 +192,7 @@ fn expand_affected_systems(
 ) {
     let mut readers: HashMap<PathBuf, Vec<String>> = HashMap::new();
     for system in systems {
-        if system.def.id.eq_ignore_ascii_case("Favorites")
+        if is_favorites_target(system)
             || artwork_pack_system_ids
                 .iter()
                 .any(|id| id.eq_ignore_ascii_case(&system.def.id))
@@ -231,7 +231,7 @@ fn collect_all(
     let mut batch = TargetBatch::default();
     for system in systems {
         check_cancelled(cancelled)?;
-        if system.def.id.eq_ignore_ascii_case("Favorites") {
+        if is_favorites_target(system) {
             continue;
         }
         if artwork_pack_system_ids
@@ -276,12 +276,6 @@ fn collect_system(
     cancelled: &AtomicBool,
     on_progress: &mut dyn FnMut(&str),
 ) -> Result<TargetBatch> {
-    if system.def.id.eq_ignore_ascii_case("Favorites") {
-        return Err(Error::new(
-            ErrorKind::Configuration,
-            "the master Favourites shelf is not a scrape target",
-        ));
-    }
     let platform = platform_id(system, overrides)?;
     on_progress(&system.def.name);
     check_cancelled(cancelled)?;
@@ -449,7 +443,19 @@ fn find_system<'a>(systems: &'a [FoundSystem], id: &str) -> Result<&'a FoundSyst
         .ok_or_else(|| Error::new(ErrorKind::Configuration, format!("unknown system {id}")))
 }
 
+// Retain the reserved-ID exclusion for older custom tables without a category.
+pub(super) fn is_favorites_target(system: &FoundSystem) -> bool {
+    crate::systems::is_favorites(system.category())
+        || system.def.id.eq_ignore_ascii_case("Favorites")
+}
+
 fn platform_id(system: &FoundSystem, overrides: &BTreeMap<String, u32>) -> Result<u32> {
+    if is_favorites_target(system) {
+        return Err(Error::new(
+            ErrorKind::Configuration,
+            "the master Favourites shelf is not a scrape target",
+        ));
+    }
     platforms::id_for(&system.def.id, overrides).ok_or_else(|| {
         Error::new(
             ErrorKind::Configuration,
@@ -954,6 +960,49 @@ mod tests {
         std::fs::write(&ordinary, b"rom bytes").unwrap();
         assert!(hashable(&ordinary));
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn renamed_favourites_are_excluded_from_all_scopes_and_shared_refreshes() {
+        let root = temp("renamed-favorites");
+        let game = root.join("Game.rom");
+        std::fs::write(&game, b"game").unwrap();
+        for category in ["Favorites", "favorites", "FAVORITES"] {
+            let mut favorite = system("MyShelf", "My shelf", &root, &["rom"]);
+            favorite.menu_folder = None;
+            favorite.def.category = Some(category.into());
+            let ordinary = system("NES", "Nintendo", &root, &["rom"]);
+            let systems = [ordinary, favorite];
+            let overrides = BTreeMap::from([("MyShelf".into(), 3)]);
+            let batch =
+                collect_now(&systems, &DisplayNames::default(), &Scope::All, &overrides).unwrap();
+            assert_eq!(batch.targets.len(), 1);
+            assert_eq!(batch.targets[0].affected_system_ids, vec!["NES"]);
+            assert!(batch.unsupported_systems.is_empty());
+            for scope in [
+                Scope::System {
+                    system_id: "MyShelf".into(),
+                    place: Place::Dir(root.clone()),
+                    display_name: "My shelf".into(),
+                },
+                Scope::Folder {
+                    system_id: "MyShelf".into(),
+                    place: Place::Dir(root.clone()),
+                    display_name: "My shelf".into(),
+                },
+                Scope::Game {
+                    system_id: "MyShelf".into(),
+                    launch: Launch::File(game.clone()),
+                    title: "Game".into(),
+                },
+            ] {
+                let error = collect_now(&systems, &DisplayNames::default(), &scope, &overrides)
+                    .unwrap_err();
+                assert_eq!(error.kind, ErrorKind::Configuration);
+                assert!(error.to_string().contains("not a scrape target"));
+            }
+        }
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/scraper/worker.rs
+++ b/src/scraper/worker.rs
@@ -1176,10 +1176,14 @@ fn plan_work(
             .iter()
             .map(|target| target.relative_path.clone())
             .collect();
-        let outcomes = gamelist_edit::needs_many(
+        let outcomes = gamelist_edit::needs_many_with_fallback(
             &gamelist_path,
             &targets[0].folder,
             &relative_paths,
+            &targets
+                .iter()
+                .map(|target| target.metadata_fallback)
+                .collect::<Vec<_>>(),
             settings.image_policy,
             settings.metadata_policy,
         );
@@ -1865,7 +1869,16 @@ fn flush_one_gamelist(
             metadata_policy: settings.metadata_policy,
         })
         .collect();
-    match gamelist_edit::apply_many(&gamelist_path, &pending[0].target.folder, &updates, backups) {
+    match gamelist_edit::apply_many_with_fallback(
+        &gamelist_path,
+        &pending[0].target.folder,
+        &updates,
+        &pending
+            .iter()
+            .map(|item| item.target.metadata_fallback)
+            .collect::<Vec<_>>(),
+        backups,
+    ) {
         Ok(outcomes) => {
             for (item, outcome) in pending.iter().zip(outcomes) {
                 progress.current = item.target.title.clone();
@@ -3584,6 +3597,7 @@ mod tests {
     fn a_conflicting_content_named_image_is_never_trusted_or_overwritten() {
         let root = temp("media-conflict");
         let target = Target {
+            metadata_fallback: true,
             system_id: "NES".into(),
             affected_system_ids: vec!["NES".into()],
             system_name: "Nintendo".into(),
@@ -3629,6 +3643,7 @@ mod tests {
         let absolute = directory.join("new.png");
         let relative = "./media/screenscraper/new.png".to_string();
         let target = Target {
+            metadata_fallback: true,
             system_id: "NES".into(),
             affected_system_ids: vec!["NES".into()],
             system_name: "Nintendo".into(),

--- a/src/scraper/worker.rs
+++ b/src/scraper/worker.rs
@@ -1134,7 +1134,7 @@ fn scope_has_only_artwork_pack_systems(
         Scope::All => {
             let mut candidates = systems
                 .iter()
-                .filter(|system| !system.def.id.eq_ignore_ascii_case("Favorites"));
+                .filter(|system| !super::targets::is_favorites_target(system));
             let Some(first) = candidates.next() else {
                 return false;
             };
@@ -2256,6 +2256,32 @@ mod tests {
             paths: vec![root.to_path_buf()],
             logo_dir: None,
             menu_folder: Some("Console".into()),
+        }
+    }
+
+    #[test]
+    fn all_artwork_pack_scope_ignores_renamed_favourites_categories() {
+        let ordinary = system(Path::new("/games/NES"));
+        for category in ["Favorites", "favorites", "FAVORITES"] {
+            let mut favorite = system(Path::new("/games/MyShelf"));
+            favorite.def.id = "MyShelf".into();
+            favorite.def.category = Some(category.into());
+            favorite.menu_folder = None;
+            assert!(scope_has_only_artwork_pack_systems(
+                &Scope::All,
+                &[ordinary.clone(), favorite.clone()],
+                &HashSet::from(["NES".into()])
+            ));
+            assert!(!scope_has_only_artwork_pack_systems(
+                &Scope::All,
+                &[favorite],
+                &HashSet::from(["MyShelf".into()])
+            ));
+            assert!(!scope_has_only_artwork_pack_systems(
+                &Scope::All,
+                std::slice::from_ref(&ordinary),
+                &HashSet::new()
+            ));
         }
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -15,6 +15,31 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{DegaussError, Result};
 
+/// Preference applies only when both supported launch variants are installed.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CorePreference {
+    #[default]
+    StandardFirst,
+    RetroAchievementsFirst,
+}
+
+impl CorePreference {
+    pub fn next(self) -> Self {
+        match self {
+            Self::StandardFirst => Self::RetroAchievementsFirst,
+            Self::RetroAchievementsFirst => Self::StandardFirst,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::StandardFirst => "Standard first",
+            Self::RetroAchievementsFirst => "RetroAchievements first",
+        }
+    }
+}
+
 /// Views chosen for exact places in the browser. The shape is deliberately
 /// nested rather than encoded into one string key: category names, system ids
 /// and filesystem paths are user-controlled and must not be able to collide.
@@ -132,6 +157,14 @@ pub struct Settings {
     pub show_other: Option<bool>,
     /// Show the Utility group: test patterns and measurement cores.
     pub show_utility: Option<bool>,
+    /// Nightly cores are visible unless explicitly switched off.
+    pub show_unstable: Option<bool>,
+    /// Absent preserves standard-first launches.
+    pub core_preference: Option<CorePreference>,
+    /// Explicit per-system core version. Absence uses the global preference.
+    /// Values are standard, ra, or an exact menu-relative Unstable RBF path.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub core_choices: BTreeMap<String, String>,
     /// The strip along the bottom. Off by default: the screen is 240 lines
     /// and the list is what it is for.
     pub show_bar: Option<bool>,
@@ -492,5 +525,65 @@ mod tests {
             "must point at the documented file"
         );
         std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn old_settings_keep_standard_preference_and_show_nightlies() {
+        let old: Settings =
+            toml::from_str(include_str!("../tests/fixtures/v0.2.0-settings.toml")).unwrap();
+        assert!(old.show_other.unwrap());
+        assert!(!Settings::default().show_other.unwrap_or(false));
+        for settings in [Settings::default(), old] {
+            assert!(settings.show_unstable.unwrap_or(true));
+            assert_eq!(
+                settings.core_preference.unwrap_or_default(),
+                CorePreference::StandardFirst
+            );
+            assert!(!settings.show_utility.unwrap_or(false));
+        }
+    }
+
+    #[test]
+    fn nightly_visibility_and_core_preference_round_trip_without_hiding_items() {
+        let settings = Settings {
+            show_unstable: Some(false),
+            core_preference: Some(CorePreference::RetroAchievementsFirst),
+            hidden: vec!["NES".into()],
+            hidden_paths: vec!["d:/games/example".into()],
+            ..Settings::default()
+        };
+        let encoded = toml::to_string(&settings).unwrap();
+        let decoded: Settings = toml::from_str(&encoded).unwrap();
+        assert_eq!(decoded.show_unstable, Some(false));
+        assert_eq!(
+            decoded.core_preference,
+            Some(CorePreference::RetroAchievementsFirst)
+        );
+        assert_eq!(decoded.hidden, settings.hidden);
+        assert_eq!(decoded.hidden_paths, settings.hidden_paths);
+        assert_eq!(
+            CorePreference::StandardFirst.next().next(),
+            CorePreference::StandardFirst
+        );
+    }
+
+    #[test]
+    fn per_system_core_choices_preserve_legacy_defaults_and_exact_nightly_paths() {
+        let old: Settings =
+            toml::from_str(include_str!("../tests/fixtures/v0.2.0-settings.toml")).unwrap();
+        assert!(old.core_choices.is_empty());
+        assert!(!toml::to_string(&Settings::default())
+            .unwrap()
+            .contains("core_choices"));
+        let mut settings = Settings::default();
+        settings.core_choices.insert(
+            "NES".into(),
+            "_Unstable/NES_unstable_20260907_a1b2.rbf".into(),
+        );
+        settings.core_choices.insert("SMS".into(), "ra".into());
+        let encoded = toml::to_string(&settings).unwrap();
+        let decoded: Settings = toml::from_str(&encoded).unwrap();
+        assert_eq!(decoded.core_choices, settings.core_choices);
+        assert_eq!(decoded.core_preference, None);
     }
 }

--- a/src/source_cache.rs
+++ b/src/source_cache.rs
@@ -313,6 +313,7 @@ mod tests {
 
     fn config(path: &std::path::Path, extension: &str) -> SystemConfig {
         SystemConfig {
+            preserve_rbf_stem: false,
             name: "Test".to_string(),
             path: path.to_string_lossy().into_owned(),
             extensions: vec![extension.to_string()],
@@ -630,6 +631,12 @@ mod tests {
     #[test]
     fn a_pre_cancelled_worker_returns_no_staged_cache() {
         let root = temp("cancelled");
+        let cache_dir = root.join("cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        let cache_path = crate::cache::system_path(&cache_dir, "Test");
+        let index_path = crate::cache::index_path(&cache_dir);
+        std::fs::write(&cache_path, b"previous-cache").unwrap();
+        std::fs::write(&index_path, b"previous-index").unwrap();
         let (sender, receiver) = mpsc::sync_channel(EVENT_QUEUE);
         let cancelled = Arc::new(AtomicBool::new(true));
         run(
@@ -650,6 +657,9 @@ mod tests {
         );
         assert!(matches!(receiver.recv().unwrap(), Event::Cancelled(_)));
         assert!(receiver.try_recv().is_err());
+        assert_eq!(std::fs::read(&cache_path).unwrap(), b"previous-cache");
+        assert_eq!(std::fs::read(&index_path).unwrap(), b"previous-index");
+        assert_eq!(std::fs::read_dir(&cache_dir).unwrap().count(), 2);
         std::fs::remove_dir_all(root).ok();
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -55,6 +55,12 @@ impl SavedPlace {
                 install: String::new(),
                 selected,
             },
+            Place::ArchiveDirectory { archive, prefix } => SavedPlace {
+                kind: "archive-directory".into(),
+                path: archive.to_string_lossy().into_owned(),
+                install: prefix.clone(),
+                selected,
+            },
             Place::Listing { install, file } => SavedPlace {
                 kind: "listing".into(),
                 path: file.to_string_lossy().into_owned(),
@@ -78,6 +84,14 @@ impl SavedPlace {
             "archive" => PathBuf::from(&self.path)
                 .exists()
                 .then(|| Place::Archive(PathBuf::from(&self.path))),
+            "archive-directory" => {
+                PathBuf::from(&self.path)
+                    .is_file()
+                    .then(|| Place::ArchiveDirectory {
+                        archive: PathBuf::from(&self.path),
+                        prefix: self.install.clone(),
+                    })
+            }
             "listing" => PathBuf::from(&self.path).exists().then(|| Place::Listing {
                 install: PathBuf::from(&self.install),
                 file: PathBuf::from(&self.path),
@@ -147,6 +161,10 @@ pub struct State {
     /// Where the cursor sat in the folder on screen.
     #[serde(default)]
     pub selected: usize,
+    /// Exact selected row identity. A search index belongs to the filtered list,
+    /// while returning from a game lists the whole folder again.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_row: Option<String>,
     /// The row every visited folder was left on, so coming back to one
     /// lands where browsing left off, not only after a game.
     #[serde(default)]
@@ -175,6 +193,7 @@ impl State {
                 .map(|(place, selected)| SavedPlace::of(place, *selected))
                 .collect(),
             selected,
+            selected_row: None,
             left_at: left_at.to_vec(),
         }
     }
@@ -253,6 +272,10 @@ mod tests {
         let state: State = toml::from_str(text).expect("v0.2.0 state must keep parsing");
         assert_eq!(state.system, "SNES");
         assert_eq!(state.selected, 42);
+        assert!(
+            state.selected_row.is_none(),
+            "old states keep their numeric selection"
+        );
         assert_eq!(state.trail.len(), 2, "the walked path survives");
     }
 
@@ -439,5 +462,26 @@ mod tests {
         assert!(take_position(false, &dir.join("state.toml")).is_none());
         assert!(take_position(true, &dir.join("state.toml")).is_none());
         std::fs::remove_dir_all(&dir).ok();
+    }
+    #[test]
+    fn virtual_directory_state_round_trips_without_checking_a_virtual_child_on_disk() {
+        let archive =
+            std::env::temp_dir().join(format!("degauss-state-{}.zip", std::process::id()));
+        std::fs::write(
+            &archive,
+            crate::zip::tests_archive(&["folder/Game.neo"], false),
+        )
+        .unwrap();
+        let place = Place::ArchiveDirectory {
+            archive: archive.clone(),
+            prefix: "folder".into(),
+        };
+        let saved = SavedPlace::of(&place, 3);
+        let text = toml::to_string(&saved).unwrap();
+        let loaded: SavedPlace = toml::from_str(&text).unwrap();
+        assert_eq!(loaded.to_place(), Some(place));
+        assert_eq!(loaded.selected(), 3);
+        std::fs::remove_file(archive).unwrap();
+        assert_eq!(loaded.to_place(), None);
     }
 }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -184,6 +184,7 @@ pub use linux::Framebuffer;
 mod linux {
     use std::fs::{File, OpenOptions};
     use std::os::fd::AsRawFd;
+    use std::os::unix::fs::OpenOptionsExt;
     use std::path::Path;
 
     use super::{Geometry, PixelFormat, Surface};
@@ -267,11 +268,191 @@ mod linux {
         }
     }
 
+    fn checked_geometry(var: &FbVarScreeninfo, fix: &FbFixScreeninfo) -> Result<(Geometry, usize)> {
+        let format = match var.bits_per_pixel {
+            16 => PixelFormat::Rgb565,
+            32 => PixelFormat::Xrgb8888,
+            other => {
+                return Err(DegaussError::unsupported(
+                    "framebuffer pixel format",
+                    format!("{other} bits per pixel (only 16 and 32 are handled)"),
+                ))
+            }
+        };
+
+        // Channel order is checked, not assumed: a 16bpp surface that is
+        // actually BGR565 would render with red and blue swapped.
+        let (r_off, g_off, b_off) = (var.red.offset, var.green.offset, var.blue.offset);
+        let expected = match format {
+            PixelFormat::Rgb565 => (11, 5, 0),
+            PixelFormat::Xrgb8888 => (16, 8, 0),
+        };
+        if (r_off, g_off, b_off) != expected {
+            return Err(DegaussError::unsupported(
+                "framebuffer channel order",
+                format!(
+                    "red/green/blue offsets {r_off}/{g_off}/{b_off}, expected {}/{}/{}",
+                    expected.0, expected.1, expected.2
+                ),
+            ));
+        }
+
+        let geometry = Geometry {
+            width: var.xres,
+            height: var.yres,
+            line_length: fix.line_length as usize,
+            format,
+        };
+        if geometry.width == 0 || geometry.height == 0 || geometry.line_length == 0 {
+            return Err(DegaussError::unsupported(
+                "framebuffer geometry",
+                format!(
+                    "{}x{} line_length {}",
+                    geometry.width, geometry.height, geometry.line_length
+                ),
+            ));
+        }
+
+        // A row must fit the stride the driver reports, or every write
+        // past the row's width lands in the next line.
+        let row_bytes = (geometry.width as usize)
+            .checked_mul(geometry.format.bytes_per_pixel())
+            .ok_or_else(|| {
+                DegaussError::unsupported("framebuffer geometry", "row size overflow")
+            })?;
+        if geometry.line_length < row_bytes {
+            return Err(DegaussError::unsupported(
+                "framebuffer geometry",
+                format!(
+                    "line_length {} is shorter than a {}px row of {} bytes",
+                    geometry.line_length, geometry.width, row_bytes
+                ),
+            ));
+        }
+
+        // One visible frame is all this driver ever exposes, and the
+        // driver has to actually have that much: mapping more than it
+        // owns turns every later write into a SIGBUS, which on this
+        // machine is the menu disappearing.
+        let map_len = geometry
+            .line_length
+            .checked_mul(geometry.height as usize)
+            .filter(|len| *len <= isize::MAX as usize)
+            .ok_or_else(|| {
+                DegaussError::unsupported("framebuffer memory", "frame size overflow")
+            })?;
+        if (fix.smem_len as usize) < map_len {
+            return Err(DegaussError::unsupported(
+                "framebuffer memory",
+                format!(
+                    "driver reports {} bytes, a {}x{} frame needs {map_len}",
+                    fix.smem_len, geometry.width, geometry.height
+                ),
+            ));
+        }
+        Ok((geometry, map_len))
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct PhysicalRange {
+        base: u64,
+        delta: usize,
+        len: usize,
+    }
+
+    fn physical_range(
+        start: u64,
+        available: usize,
+        requested: usize,
+        page_size: usize,
+        pixel_bytes: usize,
+    ) -> Result<PhysicalRange> {
+        let invalid = || {
+            DegaussError::unsupported(
+                "framebuffer /dev/mem fallback after fbdev ENODEV",
+                "invalid or overflowing physical framebuffer range",
+            )
+        };
+        if start == 0 || requested == 0 || requested > available || !page_size.is_power_of_two() {
+            return Err(invalid());
+        }
+        if !matches!(pixel_bytes, 2 | 4) || !start.is_multiple_of(pixel_bytes as u64) {
+            return Err(DegaussError::unsupported(
+                "framebuffer /dev/mem fallback after fbdev ENODEV",
+                format!("physical framebuffer address is not aligned to {pixel_bytes}-byte pixels"),
+            ));
+        }
+        start.checked_add(available as u64).ok_or_else(invalid)?;
+        let delta = (start % page_size as u64) as usize;
+        let base = start - delta as u64;
+        let len = requested
+            .checked_add(delta)
+            .filter(|len| *len <= isize::MAX as usize)
+            .ok_or_else(invalid)?;
+        // Linux rounds mmap's length up to full pages. Check that rounding
+        // cannot overflow; the extra tail is only the page containing the
+        // requested framebuffer end, as on the native fbdev mapping.
+        let page_span = len.checked_add(page_size - 1).ok_or_else(invalid)? & !(page_size - 1);
+        base.checked_add(page_span as u64).ok_or_else(invalid)?;
+        // mmap64 accepts a signed offset even on 32-bit ARM.
+        i64::try_from(base).map_err(|_| invalid())?;
+        Ok(PhysicalRange { base, delta, len })
+    }
+
+    fn fallback_error(framebuffer: &Path, operation: &str, error: std::io::Error) -> DegaussError {
+        DegaussError::io(
+            "mapping framebuffer after fbdev ENODEV",
+            Path::new("/dev/mem"),
+            std::io::Error::new(
+                error.kind(),
+                format!(
+                    "{} returned ENODEV; {operation}: {error}",
+                    framebuffer.display()
+                ),
+            ),
+        )
+    }
+
+    fn with_enodev_fallback<T>(
+        native: std::io::Result<T>,
+        path: &Path,
+        fallback: impl FnOnce() -> Result<T>,
+    ) -> Result<T> {
+        match native {
+            Ok(mapping) => Ok(mapping),
+            Err(error) if error.raw_os_error() == Some(libc::ENODEV) => fallback(),
+            Err(error) => Err(DegaussError::io("mapping framebuffer", path, error)),
+        }
+    }
+
+    fn map_device(file: &File, len: usize, offset: u64) -> std::io::Result<*mut libc::c_void> {
+        // SAFETY: length and physical offset are validated before fallback;
+        // the native mapping uses the checked visible-frame length and offset zero.
+        let map = unsafe {
+            libc::mmap64(
+                std::ptr::null_mut(),
+                len,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                file.as_raw_fd(),
+                offset as libc::off64_t,
+            )
+        };
+        if map == libc::MAP_FAILED {
+            // Capture errno before any other syscall can change it.
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(map)
+        }
+    }
+
     /// The real framebuffer device.
     pub struct Framebuffer {
         file: File,
         map: *mut libc::c_void,
         map_len: usize,
+        pixel_offset: usize,
+        mapping_source: &'static str,
         geometry: Geometry,
     }
 
@@ -279,6 +460,10 @@ mod linux {
     unsafe impl Send for Framebuffer {}
 
     impl Framebuffer {
+        pub fn mapping_source(&self) -> &'static str {
+            self.mapping_source
+        }
+
         pub fn open(path: &Path) -> Result<Self> {
             let file = OpenOptions::new()
                 .read(true)
@@ -302,101 +487,36 @@ mod linux {
                 ));
             }
 
-            let format = match var.bits_per_pixel {
-                16 => PixelFormat::Rgb565,
-                32 => PixelFormat::Xrgb8888,
-                other => {
-                    return Err(DegaussError::unsupported(
-                        "framebuffer pixel format",
-                        format!("{other} bits per pixel (only 16 and 32 are handled)"),
-                    ))
-                }
-            };
-
-            // Channel order is checked, not assumed: a 16bpp surface that is
-            // actually BGR565 would render with red and blue swapped.
-            let (r_off, g_off, b_off) = (var.red.offset, var.green.offset, var.blue.offset);
-            let expected = match format {
-                PixelFormat::Rgb565 => (11, 5, 0),
-                PixelFormat::Xrgb8888 => (16, 8, 0),
-            };
-            if (r_off, g_off, b_off) != expected {
-                return Err(DegaussError::unsupported(
-                    "framebuffer channel order",
-                    format!(
-                        "red/green/blue offsets {r_off}/{g_off}/{b_off}, expected {}/{}/{}",
-                        expected.0, expected.1, expected.2
-                    ),
-                ));
-            }
-
-            let geometry = Geometry {
-                width: var.xres,
-                height: var.yres,
-                line_length: fix.line_length as usize,
-                format,
-            };
-            if geometry.width == 0 || geometry.height == 0 || geometry.line_length == 0 {
-                return Err(DegaussError::unsupported(
-                    "framebuffer geometry",
-                    format!(
-                        "{}x{} line_length {}",
-                        geometry.width, geometry.height, geometry.line_length
-                    ),
-                ));
-            }
-
-            // A row must fit the stride the driver reports, or every write
-            // past the row's width lands in the next line.
-            let row_bytes = geometry.width as usize * geometry.format.bytes_per_pixel();
-            if geometry.line_length < row_bytes {
-                return Err(DegaussError::unsupported(
-                    "framebuffer geometry",
-                    format!(
-                        "line_length {} is shorter than a {}px row of {} bytes",
-                        geometry.line_length, geometry.width, row_bytes
-                    ),
-                ));
-            }
-
-            // One visible frame is all this driver ever exposes, and the
-            // driver has to actually have that much: mapping more than it
-            // owns turns every later write into a SIGBUS, which on this
-            // machine is the menu disappearing.
-            let map_len = geometry.frame_bytes();
-            if (fix.smem_len as usize) < map_len {
-                return Err(DegaussError::unsupported(
-                    "framebuffer memory",
-                    format!(
-                        "driver reports {} bytes, a {}x{} frame needs {map_len}",
-                        fix.smem_len, geometry.width, geometry.height
-                    ),
-                ));
-            }
-            // SAFETY: mapping the device's own memory, length taken from the
-            // driver's reported values, kept alive alongside the file.
-            let map = unsafe {
-                libc::mmap(
-                    std::ptr::null_mut(),
-                    map_len,
-                    libc::PROT_READ | libc::PROT_WRITE,
-                    libc::MAP_SHARED,
-                    file.as_raw_fd(),
-                    0,
-                )
-            };
-            if map == libc::MAP_FAILED {
-                return Err(DegaussError::io(
-                    "mapping framebuffer",
-                    path,
-                    std::io::Error::last_os_error(),
-                ));
-            }
+            let (geometry, frame_len) = checked_geometry(&var, &fix)?;
+            let native = map_device(&file, frame_len, 0);
+            let (map, map_len, pixel_offset, mapping_source) =
+                with_enodev_fallback(native.map(|map| (map, frame_len, 0, "fbdev")), path, || {
+                    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+                    let range = physical_range(
+                        fix.smem_start as u64,
+                        fix.smem_len as usize,
+                        frame_len,
+                        usize::try_from(page_size).unwrap_or(0),
+                        geometry.format.bytes_per_pixel(),
+                    )?;
+                    let mem_path = Path::new("/dev/mem");
+                    let memory = OpenOptions::new()
+                        .read(true)
+                        .write(true)
+                        .custom_flags(libc::O_SYNC | libc::O_CLOEXEC)
+                        .open(mem_path)
+                        .map_err(|error| fallback_error(path, "opening /dev/mem", error))?;
+                    let map = map_device(&memory, range.len, range.base)
+                        .map_err(|error| fallback_error(path, "mapping /dev/mem", error))?;
+                    Ok((map, range.len, range.delta, "/dev/mem fallback"))
+                })?;
 
             Ok(Framebuffer {
                 file,
                 map,
                 map_len,
+                pixel_offset,
+                mapping_source,
                 geometry,
             })
         }
@@ -415,7 +535,9 @@ mod linux {
             // Note this memory is WRITE-COMBINED: writes stream out cheaply
             // but reads are uncached and slow, which is why the staged
             // presentation path exists.
-            unsafe { std::slice::from_raw_parts_mut(self.map as *mut u8, len) }
+            unsafe {
+                std::slice::from_raw_parts_mut((self.map as *mut u8).add(self.pixel_offset), len)
+            }
         }
 
         fn present(&mut self) -> Result<()> {
@@ -451,6 +573,245 @@ mod linux {
             unsafe {
                 libc::munmap(self.map, self.map_len);
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::cell::Cell;
+
+        #[test]
+        fn only_enodev_uses_the_physical_mapping() {
+            let calls = Cell::new(0);
+            let fallback = || {
+                calls.set(calls.get() + 1);
+                Ok(42)
+            };
+            assert_eq!(
+                with_enodev_fallback(Ok(7), Path::new("/dev/fb0"), fallback).unwrap(),
+                7
+            );
+            assert_eq!(calls.get(), 0);
+            for errno in [
+                libc::EACCES,
+                libc::EINVAL,
+                libc::ENOMEM,
+                libc::EIO,
+                libc::EPERM,
+            ] {
+                let error = with_enodev_fallback(
+                    Err(std::io::Error::from_raw_os_error(errno)),
+                    Path::new("/dev/fb0"),
+                    fallback,
+                )
+                .unwrap_err();
+                assert!(error
+                    .to_string()
+                    .contains(&std::io::Error::from_raw_os_error(errno).to_string()));
+            }
+            assert_eq!(calls.get(), 0);
+            assert_eq!(
+                with_enodev_fallback(
+                    Err(std::io::Error::from_raw_os_error(libc::ENODEV)),
+                    Path::new("/dev/fb0"),
+                    fallback
+                )
+                .unwrap(),
+                42
+            );
+            assert_eq!(calls.get(), 1);
+        }
+
+        #[test]
+        fn fallback_failures_name_both_device_boundaries() {
+            for operation in ["opening /dev/mem", "mapping /dev/mem"] {
+                let error = fallback_error(
+                    Path::new("/dev/fb9"),
+                    operation,
+                    std::io::Error::from_raw_os_error(libc::EACCES),
+                )
+                .to_string();
+                assert!(error.contains("/dev/fb9 returned ENODEV"));
+                assert!(error.contains(operation));
+                assert!(
+                    error.contains(&std::io::Error::from_raw_os_error(libc::EACCES).to_string())
+                );
+            }
+        }
+
+        #[test]
+        fn physical_mapping_preserves_driver_address_and_checks_bounds() {
+            assert_eq!(
+                physical_range(0x2000, 4096, 1000, 4096, 2).unwrap(),
+                PhysicalRange {
+                    base: 0x2000,
+                    delta: 0,
+                    len: 1000
+                }
+            );
+            assert_eq!(
+                physical_range(0x2082, 4096, 1000, 4096, 2).unwrap(),
+                PhysicalRange {
+                    base: 0x2000,
+                    delta: 130,
+                    len: 1130
+                }
+            );
+            for pixel_bytes in [2, 4] {
+                assert!(physical_range(0x2001, 4096, 1000, 4096, pixel_bytes).is_err());
+                assert!(physical_range(0x2084, 4096, 1000, 4096, pixel_bytes).is_ok());
+            }
+            assert!(physical_range(0x2002, 4096, 1000, 4096, 4).is_err());
+            // The queried ARM physical address may exceed a signed 32-bit offset.
+            assert_eq!(
+                physical_range(0xe0000000, 4096, 1000, 4096, 4)
+                    .unwrap()
+                    .base,
+                0xe0000000
+            );
+            for (start, available, requested, page) in [
+                (0, 4096, 1000, 4096),
+                (0x2000, 999, 1000, 4096),
+                (0x2000, 4096, 0, 4096),
+                (0x2000, 4096, 1000, 0),
+                (0x2000, 4096, 1000, 3),
+                (u64::MAX - 3, 4, 4, 4096),
+                (0x2002, usize::MAX, usize::MAX, 4096),
+                // Requested range fits u64, but the enclosing page does not.
+                (u64::MAX - 4095, 2, 2, 4096),
+                // The adjusted slice would exceed isize::MAX on either target.
+                (0x2002, isize::MAX as usize, isize::MAX as usize, 4096),
+                (1u64 << 63, 4096, 1000, 4096),
+            ] {
+                assert!(physical_range(start, available, requested, page, 2).is_err());
+            }
+        }
+
+        fn screen(format: PixelFormat) -> (FbVarScreeninfo, FbFixScreeninfo) {
+            let (bits, red, green) = match format {
+                PixelFormat::Rgb565 => (16, 11, 5),
+                PixelFormat::Xrgb8888 => (32, 16, 8),
+            };
+            let var = FbVarScreeninfo {
+                xres: 640,
+                yres: 240,
+                bits_per_pixel: bits,
+                red: FbBitfield {
+                    offset: red,
+                    ..Default::default()
+                },
+                green: FbBitfield {
+                    offset: green,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let stride = 640 * format.bytes_per_pixel() as u32 + 64;
+            (
+                var,
+                FbFixScreeninfo {
+                    line_length: stride,
+                    smem_len: stride * 240,
+                    ..Default::default()
+                },
+            )
+        }
+
+        #[test]
+        fn both_pixel_formats_keep_geometry_stride_and_memory_validation() {
+            for format in [PixelFormat::Rgb565, PixelFormat::Xrgb8888] {
+                let (var, fix) = screen(format);
+                let (geometry, len) = checked_geometry(&var, &fix).unwrap();
+                assert_eq!(geometry.format, format);
+                assert_eq!(geometry.width, 640);
+                assert_eq!(len, fix.line_length as usize * 240);
+                assert!(checked_geometry(&FbVarScreeninfo { xres: 0, ..var }, &fix).is_err());
+                assert!(checked_geometry(
+                    &FbVarScreeninfo {
+                        red: FbBitfield::default(),
+                        ..var
+                    },
+                    &fix
+                )
+                .is_err());
+                assert!(checked_geometry(
+                    &FbVarScreeninfo {
+                        bits_per_pixel: 24,
+                        ..var
+                    },
+                    &fix
+                )
+                .is_err());
+                assert!(checked_geometry(
+                    &var,
+                    &FbFixScreeninfo {
+                        line_length: 1,
+                        ..fix
+                    }
+                )
+                .is_err());
+                assert!(checked_geometry(
+                    &var,
+                    &FbFixScreeninfo {
+                        smem_len: fix.smem_len - 1,
+                        ..fix
+                    }
+                )
+                .is_err());
+                assert!(checked_geometry(
+                    &FbVarScreeninfo {
+                        xres: u32::MAX,
+                        yres: u32::MAX,
+                        ..var
+                    },
+                    &fix
+                )
+                .is_err());
+            }
+        }
+
+        #[test]
+        fn adjusted_pixels_and_drop_use_different_addresses() {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open("/dev/zero")
+                .unwrap();
+            let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
+            let map = map_device(&file, page * 2, 0).unwrap();
+            let mut fb = Framebuffer {
+                file,
+                map,
+                map_len: page * 2,
+                pixel_offset: 128,
+                mapping_source: "/dev/mem fallback",
+                geometry: Geometry {
+                    width: 2,
+                    height: 1,
+                    line_length: 8,
+                    format: PixelFormat::Xrgb8888,
+                },
+            };
+            assert_eq!(fb.mapping_source(), "/dev/mem fallback");
+            fb.back_buffer().fill(0xa5);
+            // SAFETY: both regions lie inside this live, exclusively held mapping.
+            unsafe {
+                assert_eq!(*(map as *const u8), 0);
+                assert_eq!(*((map as *const u8).add(128)), 0xa5);
+                assert_eq!(*((map as *const u8).add(136)), 0);
+            }
+            drop(fb);
+            // mincore reports ENOMEM for the now-unmapped original page range.
+            let mut residency = [0u8; 2];
+            assert_eq!(
+                unsafe { libc::mincore(map, page * 2, residency.as_mut_ptr()) },
+                -1
+            );
+            assert_eq!(
+                std::io::Error::last_os_error().raw_os_error(),
+                Some(libc::ENOMEM)
+            );
         }
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -135,6 +135,7 @@ impl FoundSystem {
     /// extensions that count, and how to start each of them.
     pub fn to_config(&self) -> crate::config::SystemConfig {
         crate::config::SystemConfig {
+            preserve_rbf_stem: self.category() == "Unstable",
             name: self.def.name.clone(),
             path: self.path().to_string_lossy().into_owned(),
             extra_paths: self
@@ -193,20 +194,118 @@ pub fn parse_table(text: &str, origin: &Path) -> Result<Vec<SystemDef>> {
     Ok(file.systems)
 }
 
+/// Built-in collection identity is reserved only for the exact legacy path
+/// and raw-core shape. User-authored absolute folders otherwise stay literal.
+const COLLECTIONS: [(&str, &str, &str); 4] = [
+    ("OtherCores", "Other", "_Other"),
+    ("UtilityCores", "Utility", "_Utility"),
+    ("UnstableCores", "Unstable", "_Unstable"),
+    ("Favorites", "Favorites", "_@Favorites"),
+];
+
+fn direct_collection(def: &SystemDef) -> bool {
+    def.rbf.is_empty()
+        && def.launch.is_empty()
+        && def.folders.len() == 1
+        && ["rbf", "mra", "mgl"].iter().all(|extension| {
+            def.extensions
+                .iter()
+                .any(|held| held.eq_ignore_ascii_case(extension))
+        })
+        && def.extensions.len() == 3
+}
+
+/// Resolve shipped collection paths without rewriting the user's table.
+/// Existing equivalent rows keep their IDs, labels, artwork and hidden state.
+pub fn prepare_table(mut table: Vec<SystemDef>, menu_root: &Path) -> Result<Vec<SystemDef>> {
+    for def in &mut table {
+        if !direct_collection(def) {
+            continue;
+        }
+        for (id, category, folder) in COLLECTIONS {
+            if def.id == id
+                && def.category.as_deref() == Some(category)
+                && (def.folders[0] == folder || def.folders[0] == format!("/media/fat/{folder}"))
+            {
+                def.folders[0] = menu_root.join(folder).to_string_lossy().into_owned();
+            }
+        }
+    }
+    // Compare resolved directory identities, including symlink aliases when
+    // present. A missing folder remains a literal identity until discovery.
+    let identity = |path: &Path| -> Result<PathBuf> {
+        match std::fs::canonicalize(path) {
+            Ok(path) => Ok(path),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(path.to_path_buf()),
+            Err(error) => Err(DegaussError::io("resolving collection folder", path, error)),
+        }
+    };
+    let mut targets = Vec::new();
+    for (_, category, folder) in COLLECTIONS {
+        targets.push((category, identity(&menu_root.join(folder))?));
+    }
+    let mut seen = BTreeMap::<&str, usize>::new();
+    let mut prepared: Vec<SystemDef> = Vec::new();
+    for mut def in table {
+        if direct_collection(&def) && Path::new(&def.folders[0]).is_absolute() {
+            let path = identity(Path::new(&def.folders[0]))?;
+            if let Some((category, _)) = targets.iter().find(|(_, target)| *target == path) {
+                def.category = Some((*category).to_string());
+                if let Some(&position) = seen.get(category) {
+                    let builtin_id = COLLECTIONS
+                        .iter()
+                        .find(|(_, label, _)| label == category)
+                        .map(|(id, _, _)| *id)
+                        .expect("known collection");
+                    // Prefer a user's already-existing identity over a newly
+                    // shipped duplicate, regardless of table order.
+                    if prepared[position].id == builtin_id && def.id != builtin_id {
+                        prepared[position] = def;
+                    }
+                    continue;
+                }
+                seen.insert(*category, prepared.len());
+            }
+        }
+        prepared.push(def);
+    }
+    if !seen.contains_key("Unstable") {
+        // A reserved ID used for a different user collection must not collide
+        // with persisted cache and hidden-state keys.
+        let mut id = "UnstableCores".to_string();
+        while prepared.iter().any(|def| def.id == id) {
+            id.push('_');
+        }
+        prepared.push(SystemDef {
+            name: "Cores".into(),
+            id,
+            folders: vec![menu_root.join("_Unstable").to_string_lossy().into_owned()],
+            rbf: String::new(),
+            extensions: vec!["rbf".into(), "mra".into(), "mgl".into()],
+            launch: Vec::new(),
+            logo: None,
+            category: Some("Unstable".into()),
+            skip_folders: Vec::new(),
+            setname: None,
+        });
+    }
+    Ok(prepared)
+}
+
 /// Find the systems whose folders exist under any of the given roots.
 ///
 /// Order follows the table, so the list reads the same on every machine.
 /// A system with several possible folder names contributes once, using the
 /// first that exists.
-pub fn discover(
+pub fn discover_checked(
     table: &[SystemDef],
     roots: &[PathBuf],
     logo_dir: Option<&Path>,
     cores: &CoreIndex,
-) -> Vec<FoundSystem> {
+) -> Result<Vec<FoundSystem>> {
     let mut found = Vec::new();
     for def in table {
-        let paths = existing_folders(def, roots);
+        let paths = existing_folders_checked(def, roots)?;
         if paths.is_empty() {
             continue;
         }
@@ -215,16 +314,30 @@ pub fn discover(
             // the system itself. A table entry can name a core this card
             // does not have: several systems run on more than one core, and
             // the table can only name one of them.
-            menu_folder: cores
-                .folder_of(&def.rbf)
-                .or_else(|| cores.folder_of(&def.id))
-                .map(str::to_string),
+            menu_folder: if direct_collection(def) {
+                None
+            } else {
+                cores
+                    .folder_of(&def.rbf)
+                    .or_else(|| cores.folder_of(&def.id))
+                    .map(str::to_string)
+            },
             def: def.clone(),
             paths,
             logo_dir: logo_dir.map(|d| d.to_path_buf()),
         });
     }
-    found
+    Ok(found)
+}
+
+#[cfg(test)]
+fn discover(
+    table: &[SystemDef],
+    roots: &[PathBuf],
+    logo_dir: Option<&Path>,
+    cores: &CoreIndex,
+) -> Vec<FoundSystem> {
+    discover_checked(table, roots, logo_dir, cores).unwrap()
 }
 
 /// Which menu folder each installed core sits in.
@@ -239,7 +352,21 @@ pub fn discover(
 pub struct CoreIndex {
     /// Lowercased core name, without its date stamp, to the menu folder
     /// holding it and how deep inside that folder it sits.
-    folders: BTreeMap<String, (String, usize)>,
+    folders: BTreeMap<String, Vec<CoreCandidate>>,
+}
+
+#[derive(Debug)]
+struct CoreCandidate {
+    folder: String,
+    depth: usize,
+    relative: Vec<u8>,
+    folded: Vec<u8>,
+}
+
+impl CoreCandidate {
+    fn rank(&self) -> (usize, &[u8], &[u8]) {
+        (self.depth, &self.folded, &self.relative)
+    }
 }
 
 impl CoreIndex {
@@ -252,17 +379,20 @@ impl CoreIndex {
         };
         for item in listing.flatten() {
             let name = item.file_name().to_string_lossy().into_owned();
-            if !name.starts_with('_') || !item.path().is_dir() {
+            if !name.starts_with('_')
+                || name.eq_ignore_ascii_case("_Unstable")
+                || !item.path().is_dir()
+            {
                 continue;
             }
             // What the stock menu prints: the folder without its marker.
             let label = name.trim_start_matches('_').to_string();
-            index.walk(&item.path(), &label, 0);
+            index.walk(root, &item.path(), &label, 0);
         }
         index
     }
 
-    fn walk(&mut self, dir: &Path, label: &str, depth: usize) {
+    fn walk(&mut self, root: &Path, dir: &Path, label: &str, depth: usize) {
         // Cores sit at the top of a menu folder, or one level in, in the
         // `*_extra` folders the community ships. Nothing deeper is a core
         // the menu offers, and going further means reading every genre
@@ -276,29 +406,46 @@ impl CoreIndex {
         for item in listing.flatten() {
             let path = item.path();
             if path.is_dir() {
-                self.walk(&path, label, depth + 1);
+                // RA runtime binaries are support files, not menu entries.
+                if label.eq_ignore_ascii_case("RA_Cores")
+                    && item
+                        .file_name()
+                        .to_string_lossy()
+                        .eq_ignore_ascii_case("Cores")
+                {
+                    continue;
+                }
+                self.walk(root, &path, label, depth + 1);
                 continue;
             }
-            let name = item.file_name().to_string_lossy().into_owned();
-            let Some(stem) = name
-                .strip_suffix(".rbf")
-                .or_else(|| name.strip_suffix(".RBF"))
-            else {
+            if !path.is_file() {
+                continue;
+            }
+            let Some(extension) = path.extension().and_then(|ext| ext.to_str()) else {
                 continue;
             };
-            // The shallowest copy of a core wins. This is not a tie-break:
-            // `_Arcade/cores` holds a copy of several console cores, because
-            // that is where an `.mra` loads its core from. Those are support
-            // files, never shown in the menu, and letting one of them answer
-            // puts the Master System under Arcade.
-            let key = core_name(stem);
-            let better = match self.folders.get(&key) {
-                Some((_, seen)) => depth < *seen,
-                None => true,
-            };
-            if better {
-                self.folders.insert(key, (label.to_string(), depth));
+            if !extension.eq_ignore_ascii_case("rbf") {
+                continue;
             }
+            let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                continue;
+            };
+            let relative = path
+                .strip_prefix(root)
+                .expect("walk stays under root")
+                .as_os_str()
+                .as_encoded_bytes()
+                .to_vec();
+            let folded = relative.iter().map(u8::to_ascii_lowercase).collect();
+            self.folders
+                .entry(core_name(stem))
+                .or_default()
+                .push(CoreCandidate {
+                    folder: label.to_string(),
+                    depth,
+                    relative,
+                    folded,
+                });
         }
     }
 
@@ -309,9 +456,17 @@ impl CoreIndex {
         if core.is_empty() {
             return None;
         }
-        self.folders
-            .get(&core_name(core))
-            .map(|(folder, _)| folder.as_str())
+        let candidates = self.folders.get(&core_name(core))?;
+        let declared = rbf
+            .split_once('/')
+            .map(|(folder, _)| folder.trim_start_matches('_'));
+        let preferred = candidates
+            .iter()
+            .filter(|candidate| declared.is_some_and(|folder| folder == candidate.folder))
+            .min_by(|a, b| a.rank().cmp(&b.rank()));
+        preferred
+            .or_else(|| candidates.iter().min_by(|a, b| a.rank().cmp(&b.rank())))
+            .map(|candidate| candidate.folder.as_str())
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
@@ -331,6 +486,7 @@ impl CoreIndex {
 /// whose real file is gone. This looks only where MiSTer will look, and
 /// compares through the same `core_name` the walk uses, so a dated file
 /// counts and a different core that merely shares a prefix does not.
+#[cfg(test)]
 pub fn core_file_exists(menu_root: &Path, rbf: &str) -> bool {
     let (folder, core) = match rbf.rsplit_once('/') {
         Some((folder, core)) => (Some(folder), core),
@@ -374,7 +530,7 @@ pub fn core_file_exists(menu_root: &Path, rbf: &str) -> bool {
 /// whichever build was installed last. Punctuation goes because the same
 /// system is written `NeoGeoPocket-Color` as a file and `NeoGeoPocketColor`
 /// as an id, and they have to meet.
-fn core_name(stem: &str) -> String {
+pub(crate) fn core_name(stem: &str) -> String {
     let trimmed = match stem.rsplit_once('_') {
         // Compared as bytes, not sliced as a string. A date stamp is eight
         // ASCII digits either way, and `&after[..8]` panics when byte 8 lands
@@ -405,17 +561,26 @@ fn core_name(stem: &str) -> String {
 ///
 /// `discover` asks this for every system; the single-system rebuild asks
 /// it again for one, because a folder can appear or go after discovery.
-pub fn existing_folders(def: &SystemDef, roots: &[PathBuf]) -> Vec<PathBuf> {
-    // Unmounted roots are dropped before the folder walk, so a missing
-    // mount costs one failed stat per system rather than one per folder
-    // name: with six USB slots in the defaults, most of this list does
-    // not exist on most machines.
-    let live: Vec<&PathBuf> = roots.iter().filter(|root| root.is_dir()).collect();
-    let mut found: Vec<PathBuf> = Vec::new();
+pub fn existing_folders_checked(def: &SystemDef, roots: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    fn directory(path: &Path) -> Result<bool> {
+        match std::fs::metadata(path) {
+            Ok(meta) => Ok(meta.is_dir()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(DegaussError::io("checking system folder", path, error)),
+        }
+    }
+    let mut found = Vec::new();
     for folder in &def.folders {
-        for root in &live {
-            // An absolute folder in the table stands on its own; joining
-            // replaces the root, which is what we want.
+        let path = Path::new(folder);
+        if path.is_absolute() {
+            if directory(path)? && !found.contains(&path.to_path_buf()) {
+                found.push(path.to_path_buf());
+            }
+            continue;
+        }
+        // Preserve ordinary game-root discovery: absent or unavailable
+        // mounts are ignored, and the first existing alias wins.
+        for root in roots.iter().filter(|root| root.is_dir()) {
             let candidate = root.join(folder);
             if candidate.is_dir() {
                 if !found.contains(&candidate) {
@@ -425,7 +590,12 @@ pub fn existing_folders(def: &SystemDef, roots: &[PathBuf]) -> Vec<PathBuf> {
             }
         }
     }
-    found
+    Ok(found)
+}
+
+#[cfg(test)]
+fn existing_folders(def: &SystemDef, roots: &[PathBuf]) -> Vec<PathBuf> {
+    existing_folders_checked(def, roots).unwrap()
 }
 
 #[cfg(test)]
@@ -970,5 +1140,201 @@ extensions = ["ngp"]
         let cores = CoreIndex::read(Path::new("/definitely/not/a/card"));
         assert_eq!(cores.len(), 0);
         assert_eq!(cores.folder_of("_Console/NeoGeo"), None);
+    }
+
+    #[test]
+    fn legacy_collections_follow_menu_root_without_game_mounts() {
+        let menu = temp_dir("legacy-collections");
+        for (_, _, folder) in COLLECTIONS {
+            std::fs::create_dir_all(menu.join(folder)).unwrap();
+            std::fs::write(menu.join(folder).join("Core.rbf"), b"fixture").unwrap();
+        }
+        let legacy = parse_table(
+            include_str!("../tests/fixtures/v0.1.0-and-v0.2.0-systems.toml"),
+            Path::new("legacy"),
+        )
+        .unwrap();
+        let table = prepare_table(legacy, &menu).unwrap();
+        let found = discover_checked(&table, &[], None, &CoreIndex::read(&menu)).unwrap();
+        for (_, category, folder) in COLLECTIONS {
+            let rows: Vec<_> = found
+                .iter()
+                .filter(|row| row.category() == category)
+                .collect();
+            assert_eq!(rows.len(), 1, "one {category} collection");
+            assert_eq!(rows[0].path(), menu.join(folder));
+        }
+        let again = prepare_table(table, &menu).unwrap();
+        assert_eq!(
+            again
+                .iter()
+                .filter(|def| def.category.as_deref() == Some("Unstable"))
+                .count(),
+            1
+        );
+        std::fs::remove_dir_all(menu).unwrap();
+    }
+
+    #[test]
+    fn custom_absolute_collections_keep_their_paths_and_identity() {
+        let menu = temp_dir("custom-collections");
+        let outside = temp_dir("outside-collections");
+        let mut def = one_system(&[outside.to_str().unwrap()]);
+        def.id = "OtherCores".into();
+        def.rbf.clear();
+        def.launch.clear();
+        def.extensions = vec!["rbf".into(), "mra".into(), "mgl".into()];
+        def.category = Some("Other".into());
+        let table = prepare_table(vec![def], &menu).unwrap();
+        assert_eq!(table[0].folders, vec![outside.to_string_lossy()]);
+        assert_eq!(
+            existing_folders_checked(&table[0], &[]).unwrap(),
+            vec![outside.clone()]
+        );
+        std::fs::remove_dir_all(menu).unwrap();
+        std::fs::remove_dir_all(outside).unwrap();
+    }
+
+    #[test]
+    fn equivalent_unstable_collection_keeps_custom_id_without_duplicate() {
+        let menu = temp_dir("deduplicate-unstable");
+        std::fs::create_dir_all(menu.join("_Unstable")).unwrap();
+        let mut table = prepare_table(vec![one_system(&["NES"])], &menu).unwrap();
+        let mut custom = table.last().unwrap().clone();
+        custom.id = "MyNightlies".into();
+        custom.name = "My builds".into();
+        table.push(custom);
+        let prepared = prepare_table(table, &menu).unwrap();
+        let collections: Vec<_> = prepared
+            .iter()
+            .filter(|def| def.category.as_deref() == Some("Unstable"))
+            .collect();
+        assert_eq!(collections.len(), 1);
+        assert_eq!(collections[0].id, "MyNightlies");
+        assert_eq!(collections[0].name, "My builds");
+        std::fs::remove_dir_all(menu).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collection_symlink_aliases_are_deduplicated() {
+        let menu = temp_dir("collection-symlink");
+        std::fs::create_dir_all(menu.join("_Unstable")).unwrap();
+        std::os::unix::fs::symlink(menu.join("_Unstable"), menu.join("alias")).unwrap();
+        let mut table = prepare_table(vec![one_system(&["NES"])], &menu).unwrap();
+        let mut alias = table.last().unwrap().clone();
+        alias.id = "Alias".into();
+        alias.folders = vec![menu.join("alias").to_string_lossy().into_owned()];
+        table.insert(0, alias);
+        let prepared = prepare_table(table, &menu).unwrap();
+        assert_eq!(
+            prepared
+                .iter()
+                .filter(|def| def.category.as_deref() == Some("Unstable"))
+                .count(),
+            1
+        );
+        assert_eq!(prepared[0].id, "Alias");
+        std::fs::remove_dir_all(menu).unwrap();
+    }
+
+    #[test]
+    fn nightly_and_ra_support_copies_cannot_classify_normal_systems() {
+        for reverse in [false, true] {
+            let menu = temp_dir(if reverse {
+                "collision-reverse"
+            } else {
+                "collision-forward"
+            });
+            let mut files = vec![
+                "_Console/NES.rbf",
+                "_Unstable/NES_20260101.rbf",
+                "_RA_Cores/Cores/NES.rbf",
+            ];
+            if reverse {
+                files.reverse();
+            }
+            for file in files {
+                let path = menu.join(file);
+                std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                std::fs::write(path, b"fixture").unwrap();
+            }
+            let index = CoreIndex::read(&menu);
+            assert_eq!(index.folder_of("_Console/NES"), Some("Console"));
+            assert_eq!(index.folder_of("NES"), Some("Console"));
+            std::fs::remove_file(menu.join("_Console/NES.rbf")).unwrap();
+            assert_eq!(CoreIndex::read(&menu).folder_of("NES"), None);
+            std::fs::remove_dir_all(menu).unwrap();
+        }
+    }
+
+    #[test]
+    fn declared_folder_wins_then_fallback_is_shallow_and_deterministic() {
+        for reverse in [false, true] {
+            let menu = temp_dir(if reverse {
+                "ordering-reverse"
+            } else {
+                "ordering-forward"
+            });
+            let mut files = vec![
+                "_Zeta/NES.rbf",
+                "_Alpha/extra/NES.rbf",
+                "_Console/extra/NES_20260907.rBf",
+            ];
+            if reverse {
+                files.reverse();
+            }
+            for file in files {
+                let path = menu.join(file);
+                std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                std::fs::write(path, b"fixture").unwrap();
+            }
+            let index = CoreIndex::read(&menu);
+            assert_eq!(index.folder_of("_Console/NES"), Some("Console"));
+            assert_eq!(index.folder_of("_Missing/NES"), Some("Zeta"));
+            std::fs::write(menu.join("_Alpha/NES.rbf"), b"fixture").unwrap();
+            assert_eq!(
+                CoreIndex::read(&menu).folder_of("_Missing/NES"),
+                Some("Alpha")
+            );
+            std::fs::remove_dir_all(menu).unwrap();
+        }
+        // Exercise case-only ties even on a case-insensitive host filesystem.
+        let first = CoreCandidate {
+            folder: "lower".into(),
+            depth: 0,
+            relative: b"_alpha/NES.rbf".to_vec(),
+            folded: b"_alpha/nes.rbf".to_vec(),
+        };
+        let second = CoreCandidate {
+            folder: "upper".into(),
+            depth: 0,
+            relative: b"_Alpha/NES.rbf".to_vec(),
+            folded: b"_alpha/nes.rbf".to_vec(),
+        };
+        assert!(second.rank() < first.rank());
+    }
+
+    #[test]
+    fn prepared_table_discovers_collection_added_after_startup() {
+        let menu = temp_dir("collection-added-later");
+        let table =
+            prepare_table(load_table(Path::new("assets/systems.toml")).unwrap(), &menu).unwrap();
+        assert!(!discover_checked(&table, &[], None, &CoreIndex::default())
+            .unwrap()
+            .iter()
+            .any(|system| system.category() == "Unstable"));
+        std::fs::create_dir_all(menu.join("_Unstable")).unwrap();
+        let found: Vec<_> = discover_checked(&table, &[], None, &CoreIndex::read(&menu))
+            .unwrap()
+            .into_iter()
+            .filter(|system| system.category() == "Unstable")
+            .collect();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].category(), "Unstable");
+        // Discovery retains an empty collection; the existing Show Empty
+        // policy owns whether it is displayed after counting its contents.
+        assert_eq!(found[0].path(), menu.join("_Unstable"));
+        std::fs::remove_dir_all(menu).unwrap();
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -19,6 +19,11 @@ use serde::Deserialize;
 use crate::config::LaunchRule;
 use crate::error::{DegaussError, Result};
 
+/// Favorites semantics also apply to custom collection names and category casing.
+pub fn is_favorites(category: &str) -> bool {
+    category.eq_ignore_ascii_case("Favorites")
+}
+
 /// One row of the systems table.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -1,47 +1,58 @@
-//! Listing what is inside a zip, without unpacking any of it.
+//! Read the ZIP central directory without extracting file data.
 //!
-//! Plenty of MiSTer libraries keep games zipped, one game per archive or
-//! several. Indexing the contents rather than the archive is what stops a
-//! folder of zips looking empty to anything that only sees the `.zip`.
-//! MiSTer itself launches a file inside an archive perfectly well: the path
-//! `something.zip/inner.rom` is understood by its own loader.
-//!
-//! So Degauss needs the names inside an archive and nothing else. That is
-//! the central directory, a plain table at the end of the file, and reading
-//! it needs no decompression and therefore no compression library: a listing
-//! is a few seeks and some little-endian integers. Unpacking is MiSTer's job
-//! at launch time, not ours at scan time.
+//! MiSTer opens the native `archive.zip/member` target. Its reader supports
+//! stored and deflated single-disk classic/ZIP64 archives. Names must survive
+//! our UTF-8 state/XML paths and MiSTer's ASCII-insensitive lookup unchanged.
 
+use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::error::{DegaussError, Result};
 
-/// End of central directory record.
 const EOCD_SIGNATURE: [u8; 4] = [0x50, 0x4b, 0x05, 0x06];
-/// Central directory file header.
 const CENTRAL_SIGNATURE: [u8; 4] = [0x50, 0x4b, 0x01, 0x02];
+const MAX_TRAILER: u64 = 22 + u16::MAX as u64;
+/// Bound both Main's central-directory allocation and Degauss's entry table.
+/// Main itself uses 32-bit directory sizes/counts; these lower bounds leave
+/// room for the frontend, metadata and Main on a 512 MiB MiSTer.
+pub const MAX_ENTRIES: u64 = 100_000;
+pub const MAX_DIRECTORY_BYTES: u64 = 16 * 1024 * 1024;
+/// Main's fileTYPE path buffer is 1024 bytes including the terminator.
+pub const MAX_NATIVE_PATH_BYTES: usize = 1023;
 
-/// A zip comment can be 64 KiB, and the record we want sits just before it,
-/// so that is how far back it is worth looking.
-const MAX_TRAILER: usize = 66_000;
-
-/// Refuse absurd archives rather than allocating whatever a corrupt header
-/// claims. No real game archive holds a hundred thousand files.
-const MAX_ENTRIES: usize = 100_000;
-
-fn u16_at(bytes: &[u8], offset: usize) -> Option<usize> {
-    let slice = bytes.get(offset..offset + 2)?;
-    Some(u16::from_le_bytes([slice[0], slice[1]]) as usize)
+fn bad(path: &Path, reason: impl AsRef<str>) -> DegaussError {
+    DegaussError::malformed("zip archive", path, reason.as_ref())
+}
+fn word(bytes: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes(
+        bytes[offset..offset + 2]
+            .try_into()
+            .expect("checked record"),
+    )
+}
+fn dword(bytes: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(
+        bytes[offset..offset + 4]
+            .try_into()
+            .expect("checked record"),
+    )
+}
+fn qword(bytes: &[u8], offset: usize) -> u64 {
+    u64::from_le_bytes(
+        bytes[offset..offset + 8]
+            .try_into()
+            .expect("checked record"),
+    )
+}
+fn read_at(file: &mut std::fs::File, path: &Path, offset: u64, bytes: &mut [u8]) -> Result<()> {
+    file.seek(SeekFrom::Start(offset))
+        .map_err(|e| DegaussError::io("seeking archive", path, e))?;
+    file.read_exact(bytes)
+        .map_err(|e| DegaussError::io("reading archive directory", path, e))
 }
 
-fn u32_at(bytes: &[u8], offset: usize) -> Option<u64> {
-    let slice = bytes.get(offset..offset + 4)?;
-    Some(u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]) as u64)
-}
-
-/// Identity already present in one central-directory record.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Entry {
     pub name: String,
@@ -49,157 +60,594 @@ pub struct Entry {
     pub size: u64,
 }
 
-/// The names of the files inside an archive, in the order the archive lists
-/// them. Directory entries are left out: only files can be launched.
-///
-/// A damaged archive yields an error rather than an empty list, so a corrupt
-/// file is never mistaken for an empty one.
+#[derive(Debug)]
+pub struct Contents {
+    pub entries: Vec<Entry>,
+    pub directories: Vec<String>,
+    // Current Main picks the last signature without checking comment length.
+    main_compatible: bool,
+}
+
+/// A bounded, operation-local archive cache. Opening the file and checking its
+/// identity on every use keeps ordinary browsing responsive to replacement;
+/// launch confirmation deliberately calls `entries` directly instead.
+#[derive(Debug, Default)]
+pub struct ArchiveCache {
+    last: Option<(PathBuf, ArchiveStamp, std::sync::Arc<Contents>)>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ArchiveStamp {
+    size: u64,
+    modified: std::time::SystemTime,
+    #[cfg(unix)]
+    identity: (u64, u64, i64, i64),
+}
+
+impl ArchiveCache {
+    pub fn read(&mut self, path: &Path) -> Result<std::sync::Arc<Contents>> {
+        self.read_controlled(path, &AtomicBool::new(false))?
+            .ok_or_else(|| bad(path, "archive listing cancelled unexpectedly"))
+    }
+
+    pub fn read_controlled(
+        &mut self,
+        path: &Path,
+        cancelled: &AtomicBool,
+    ) -> Result<Option<std::sync::Arc<Contents>>> {
+        if cancelled.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        let file =
+            std::fs::File::open(path).map_err(|e| DegaussError::io("opening archive", path, e))?;
+        let metadata = file
+            .metadata()
+            .map_err(|e| DegaussError::io("reading archive size", path, e))?;
+        #[cfg(unix)]
+        use std::os::unix::fs::MetadataExt;
+        let stamp = ArchiveStamp {
+            size: metadata.len(),
+            modified: metadata
+                .modified()
+                .map_err(|e| DegaussError::io("reading archive modification time", path, e))?,
+            #[cfg(unix)]
+            identity: (
+                metadata.dev(),
+                metadata.ino(),
+                metadata.ctime(),
+                metadata.ctime_nsec(),
+            ),
+        };
+        if let Some((previous, previous_stamp, entries)) = &self.last {
+            if previous == path && previous_stamp == &stamp {
+                return Ok(Some(entries.clone()));
+            }
+        }
+        let Some(contents) = contents_controlled(path, cancelled)? else {
+            return Ok(None);
+        };
+        let entries = std::sync::Arc::new(contents);
+        self.last = Some((path.to_path_buf(), stamp, entries.clone()));
+        Ok(Some(entries))
+    }
+}
+
+/// Split only a native ZIP member target. The member string is not normalized.
+pub fn split_member_path(path: &Path) -> Option<(PathBuf, String)> {
+    let raw = path.to_str()?;
+    let at = raw.to_ascii_lowercase().find(".zip/")? + 4;
+    Some((PathBuf::from(&raw[..at]), raw[at + 1..].to_string()))
+}
+
+/// Re-read the actual archive, including all ambiguity and format checks.
+pub fn validate_member(path: &Path) -> Result<Entry> {
+    let (archive, member) =
+        split_member_path(path).ok_or_else(|| bad(path, "not a native archive/member target"))?;
+    entries(&archive)?
+        .into_iter()
+        .find(|entry| entry.name == member)
+        .ok_or_else(|| {
+            bad(
+                &archive,
+                format!("member {member:?} is missing or was renamed"),
+            )
+        })
+}
+
+/// Validate the selected member and reject a known Main reader limitation
+/// before handoff. Listing can remain correct for these valid containers.
+pub fn validate_member_for_launch(path: &Path) -> Result<Entry> {
+    let (archive, member) =
+        split_member_path(path).ok_or_else(|| bad(path, "not a native archive/member target"))?;
+    let contents = contents_controlled(&archive, &AtomicBool::new(false))?
+        .ok_or_else(|| bad(&archive, "archive listing was cancelled unexpectedly"))?;
+    if !contents.main_compatible {
+        return Err(DegaussError::unsupported("zip launch", format!(
+            "{}: MiSTer Main's ZIP reader selects a different end record inside the archive comment; member {member:?} cannot be launched",
+            archive.display())));
+    }
+    contents
+        .entries
+        .into_iter()
+        .find(|entry| entry.name == member)
+        .ok_or_else(|| {
+            bad(
+                &archive,
+                format!("member {member:?} is missing or was renamed"),
+            )
+        })
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn list(path: &Path) -> Result<Vec<String>> {
     entries(path).map(|entries| entries.into_iter().map(|entry| entry.name).collect())
 }
-
-/// The files inside an archive with their CRC32 and uncompressed byte size.
-/// No member is extracted.
 pub fn entries(path: &Path) -> Result<Vec<Entry>> {
-    let cancelled = AtomicBool::new(false);
-    entries_controlled(path, &cancelled)?.ok_or_else(|| {
-        DegaussError::unsupported("zip archive", "archive listing was cancelled unexpectedly")
-    })
+    entries_controlled(path, &AtomicBool::new(false))?
+        .ok_or_else(|| bad(path, "archive listing was cancelled unexpectedly"))
 }
 
-/// The files inside an archive, with cooperative cancellation between
-/// central-directory entries. `None` is a cancellation, never an empty or
-/// damaged archive.
+#[derive(Clone, Copy)]
+struct Directory {
+    count: u64,
+    offset: u64,
+    size: u64,
+    disk: u32,
+}
+
+fn layout(file: &mut std::fs::File, path: &Path, end: &[u8], end_offset: u64) -> Result<Directory> {
+    let disk = u32::from(word(end, 4));
+    let cd_disk = u32::from(word(end, 6));
+    let on_disk = u64::from(word(end, 8));
+    let count = u64::from(word(end, 10));
+    let size = u64::from(dword(end, 12));
+    let offset = u64::from(dword(end, 16));
+    let needs64 = [on_disk, count].contains(&u64::from(u16::MAX))
+        || [size, offset].contains(&u64::from(u32::MAX));
+    let mut directory = Directory {
+        count,
+        offset,
+        size,
+        disk,
+    };
+    let mut records_start = end_offset;
+    let mut locator = [0u8; 20];
+    let has_locator = if end_offset >= 20 {
+        read_at(file, path, end_offset - 20, &mut locator)?;
+        locator[..4] == [0x50, 0x4b, 0x06, 0x07]
+    } else {
+        false
+    };
+    if needs64 && !has_locator {
+        return Err(bad(path, "missing ZIP64 locator for sentinel fields"));
+    }
+    if has_locator {
+        let record_offset = qword(&locator, 8);
+        if dword(&locator, 4) != 0 || dword(&locator, 16) != 1 {
+            return Err(bad(path, "multi-disk ZIP64 locator is unsupported"));
+        }
+        if record_offset
+            .checked_add(56)
+            .is_none_or(|end| end > end_offset - 20)
+        {
+            return Err(bad(path, "ZIP64 end record is outside the archive"));
+        }
+        let mut record = [0u8; 56];
+        read_at(file, path, record_offset, &mut record)?;
+        if record[..4] != [0x50, 0x4b, 0x06, 0x06]
+            || qword(&record, 4) < 44
+            || record_offset
+                .checked_add(12)
+                .and_then(|v| v.checked_add(qword(&record, 4)))
+                != Some(end_offset - 20)
+        {
+            return Err(bad(
+                path,
+                "invalid ZIP64 end record signature, size or locator chain",
+            ));
+        }
+        let disk64 = dword(&record, 16);
+        if disk64 > 1 || dword(&record, 20) != disk64 || qword(&record, 24) != qword(&record, 32) {
+            return Err(bad(path, "multi-disk or inconsistent ZIP64 counts"));
+        }
+        directory = Directory {
+            count: qword(&record, 32),
+            size: qword(&record, 40),
+            offset: qword(&record, 48),
+            disk: disk64,
+        };
+        for (classic, sentinel, actual) in [
+            (count, u64::from(u16::MAX), directory.count),
+            (on_disk, u64::from(u16::MAX), directory.count),
+            (size, u64::from(u32::MAX), directory.size),
+            (offset, u64::from(u32::MAX), directory.offset),
+        ] {
+            if classic != sentinel && classic != actual {
+                return Err(bad(path, "classic and ZIP64 end records disagree"));
+            }
+        }
+        if (disk != u32::from(u16::MAX) && disk != disk64)
+            || (cd_disk != u32::from(u16::MAX) && cd_disk != disk64)
+        {
+            return Err(bad(path, "classic and ZIP64 disk fields disagree"));
+        }
+        records_start = record_offset;
+    } else if disk > 1 || cd_disk != disk || count != on_disk {
+        return Err(bad(path, "multi-disk archive or inconsistent entry counts"));
+    }
+    if directory.count > MAX_ENTRIES || directory.size > MAX_DIRECTORY_BYTES {
+        return Err(bad(path, format!("resource limit exceeded: at most {MAX_ENTRIES} entries and {MAX_DIRECTORY_BYTES} central-directory bytes")));
+    }
+    if directory
+        .count
+        .checked_mul(46)
+        .is_none_or(|minimum| minimum > directory.size)
+        || directory.offset.checked_add(directory.size) != Some(records_start)
+    {
+        return Err(bad(
+            path,
+            "central-directory size, count or offset is inconsistent with end records",
+        ));
+    }
+    Ok(directory)
+}
+
+/// Enforce a byte-exact path, including Main's first `.zip` split and buffers.
+fn validate_name(path: &Path, name: &str) -> Result<()> {
+    let body = name.strip_suffix('/').unwrap_or(name);
+    if body.is_empty()
+        || body.trim() != body
+        || body.contains('\\')
+        || body.contains(':')
+        || body.chars().any(char::is_control)
+        || body
+            .split('/')
+            .any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        return Err(bad(
+            path,
+            format!("member {name:?} cannot round-trip as a native path"),
+        ));
+    }
+    if body.rsplit('/').next().is_some_and(|part| part.len() > 260) {
+        return Err(bad(
+            path,
+            format!("member {name:?} exceeds Main's 260-byte filename limit"),
+        ));
+    }
+    if body
+        .split('/')
+        .any(|part| part.to_ascii_lowercase().ends_with(".zip"))
+    {
+        return Err(bad(
+            path,
+            format!("nested archive member {name:?} is unsupported"),
+        ));
+    }
+    let outer = path
+        .to_str()
+        .ok_or_else(|| bad(path, "archive path is not UTF-8"))?;
+    let lower = outer.to_ascii_lowercase();
+    if lower.find(".zip") != outer.len().checked_sub(4)
+        || outer.chars().any(char::is_control)
+        || outer
+            .len()
+            .checked_add(1)
+            .and_then(|n| n.checked_add(body.len()))
+            .is_none_or(|n| n > MAX_NATIVE_PATH_BYTES)
+    {
+        return Err(bad(
+            path,
+            format!(
+                "native target for {name:?} is ambiguous or exceeds {MAX_NATIVE_PATH_BYTES} bytes"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Central-directory-only read with cancellation. Payload CRC/decompression
+/// failures remain Main's responsibility; this never reads compressed data.
 pub fn entries_controlled(path: &Path, cancelled: &AtomicBool) -> Result<Option<Vec<Entry>>> {
+    contents_controlled(path, cancelled).map(|contents| contents.map(|contents| contents.entries))
+}
+
+fn contents_controlled(path: &Path, cancelled: &AtomicBool) -> Result<Option<Contents>> {
     if cancelled.load(Ordering::Relaxed) {
         return Ok(None);
     }
     let mut file =
         std::fs::File::open(path).map_err(|e| DegaussError::io("opening archive", path, e))?;
-    let size = file
+    let file_size = file
         .metadata()
         .map_err(|e| DegaussError::io("reading archive size", path, e))?
         .len();
-
-    // Read the tail and find the end-of-directory record inside it.
-    let tail_len = MAX_TRAILER.min(size as usize);
-    let tail_start = size - tail_len as u64;
-    file.seek(SeekFrom::Start(tail_start))
-        .map_err(|e| DegaussError::io("seeking archive", path, e))?;
-    let mut tail = vec![0u8; tail_len];
-    file.read_exact(&mut tail)
-        .map_err(|e| DegaussError::io("reading archive", path, e))?;
-    if cancelled.load(Ordering::Relaxed) {
-        return Ok(None);
-    }
-
-    let eocd = tail
-        .windows(4)
-        .rposition(|w| w == EOCD_SIGNATURE)
-        .ok_or_else(|| {
-            DegaussError::malformed("zip archive", path, "no end-of-directory record")
-        })?;
-
-    let entry_count = u16_at(&tail, eocd + 10).ok_or_else(|| {
-        DegaussError::malformed("zip archive", path, "truncated directory record")
-    })?;
-    let directory_offset = u32_at(&tail, eocd + 16).ok_or_else(|| {
-        DegaussError::malformed("zip archive", path, "truncated directory record")
-    })?;
-
-    if entry_count > MAX_ENTRIES {
-        return Err(DegaussError::unsupported(
-            "zip archive",
-            format!("{} claims {entry_count} entries", path.display()),
-        ));
-    }
-
-    // Both of these are numbers taken straight out of the file, so both are
-    // checked before they are used to index or to allocate. A corrupt one is
-    // a malformed archive, never a panic: this process is the whole menu, and
-    // the release profile aborts rather than unwinding.
-    if directory_offset >= size {
-        return Err(DegaussError::malformed(
-            "zip archive",
-            path,
-            "directory offset past the end of the file",
-        ));
-    }
-    let directory_size = u32_at(&tail, eocd + 12).ok_or_else(|| {
-        DegaussError::malformed("zip archive", path, "truncated directory record")
-    })?;
-    let directory_size = directory_size.min(size - directory_offset);
-
-    // The directory may already be inside the tail we hold; if not, read it.
-    // Reading only as far as the record says stops a wrong offset pulling a
-    // whole archive into memory.
-    let directory = if directory_offset >= tail_start {
-        let start = (directory_offset - tail_start) as usize;
-        tail.get(start..)
-            .ok_or_else(|| {
-                DegaussError::malformed("zip archive", path, "directory offset outside the file")
-            })?
-            .to_vec()
-    } else {
-        file.seek(SeekFrom::Start(directory_offset))
-            .map_err(|e| DegaussError::io("seeking archive directory", path, e))?;
-        let mut buffer = Vec::new();
-        file.take(directory_size)
-            .read_to_end(&mut buffer)
-            .map_err(|e| DegaussError::io("reading archive directory", path, e))?;
-        buffer
-    };
-
-    let mut entries = Vec::with_capacity(entry_count.min(1024));
-    let mut cursor = 0usize;
-    // Counted separately from `names`, which leaves directory entries out: the
-    // record says how many headers there are, and every one of them must be
-    // found or the directory is damaged.
-    let mut seen = 0usize;
-    while seen < entry_count {
+    let tail_len = usize::try_from(file_size.min(MAX_TRAILER))
+        .map_err(|_| bad(path, "archive trailer does not fit this target"))?;
+    let tail_start = file_size - tail_len as u64;
+    let mut tail = vec![0; tail_len];
+    read_at(&mut file, path, tail_start, &mut tail)?;
+    let mut found = None;
+    let mut failure = bad(path, "no valid end-of-directory record");
+    for at in (0..tail.len().saturating_sub(21)).rev() {
         if cancelled.load(Ordering::Relaxed) {
             return Ok(None);
         }
-        if directory.get(cursor..cursor + 4) != Some(&CENTRAL_SIGNATURE) {
-            return Err(DegaussError::malformed(
-                "zip archive",
+        if tail[at..at + 4] != EOCD_SIGNATURE
+            || at + 22 + usize::from(word(&tail, at + 20)) != tail.len()
+        {
+            continue;
+        }
+        match layout(&mut file, path, &tail[at..at + 22], tail_start + at as u64) {
+            Ok(directory) => {
+                found = Some((directory, at));
+                break;
+            }
+            Err(error) => failure = error,
+        }
+    }
+    let (directory, eocd) = found.ok_or(failure)?;
+    let main_eocd = (0..tail.len().saturating_sub(21))
+        .rev()
+        .find(|&at| tail[at..at + 4] == EOCD_SIGNATURE);
+    let main_compatible = main_eocd == Some(eocd);
+    let length = usize::try_from(directory.size)
+        .map_err(|_| bad(path, "central directory does not fit this target"))?;
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(length)
+        .map_err(|_| bad(path, "cannot allocate bounded central directory"))?;
+    bytes.resize(length, 0);
+    read_at(&mut file, path, directory.offset, &mut bytes)?;
+    let count = usize::try_from(directory.count)
+        .map_err(|_| bad(path, "entry count does not fit this target"))?;
+    let mut entries = Vec::new();
+    entries
+        .try_reserve_exact(count)
+        .map_err(|_| bad(path, "cannot allocate bounded entry table"))?;
+    let mut names = HashMap::<String, (String, bool)>::new();
+    names
+        .try_reserve(count)
+        .map_err(|_| bad(path, "cannot allocate archive name table"))?;
+    let mut cursor = 0usize;
+    for _ in 0..count {
+        if cancelled.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        let header = bytes
+            .get(cursor..cursor + 46)
+            .ok_or_else(|| bad(path, "truncated central-directory header"))?;
+        if header[..4] != CENTRAL_SIGNATURE {
+            return Err(bad(path, "invalid central-directory signature"));
+        }
+        let name_len = usize::from(word(header, 28));
+        let extra_len = usize::from(word(header, 30));
+        let comment_len = usize::from(word(header, 32));
+        let end = cursor + 46 + name_len + extra_len + comment_len;
+        if end > length {
+            return Err(bad(
                 path,
-                "directory ends before the entries it claims",
+                "truncated central-directory name, extra field or comment",
             ));
         }
-        seen += 1;
-        let name_len = u16_at(&directory, cursor + 28).ok_or_else(|| {
-            DegaussError::malformed("zip archive", path, "truncated directory entry")
-        })?;
-        let extra_len = u16_at(&directory, cursor + 30).ok_or_else(|| {
-            DegaussError::malformed("zip archive", path, "truncated directory entry")
-        })?;
-        let comment_len = u16_at(&directory, cursor + 32).ok_or_else(|| {
-            DegaussError::malformed("zip archive", path, "truncated directory entry")
-        })?;
-
-        let name_start = cursor + 46;
-        let name = directory
-            .get(name_start..name_start + name_len)
-            .ok_or_else(|| {
-                DegaussError::malformed("zip archive", path, "directory entry runs past the end")
-            })?;
-        let name = String::from_utf8_lossy(name).into_owned();
-        let crc32 = u32_at(&directory, cursor + 16)
-            .ok_or_else(|| DegaussError::malformed("zip archive", path, "truncated CRC field"))?
-            as u32;
-        let size = u32_at(&directory, cursor + 24)
-            .ok_or_else(|| DegaussError::malformed("zip archive", path, "truncated size field"))?;
-
-        // A trailing slash marks a directory, which is not launchable.
-        if !name.ends_with('/') && !name.is_empty() {
-            entries.push(Entry { name, crc32, size });
+        let name = std::str::from_utf8(&bytes[cursor + 46..cursor + 46 + name_len])
+            .map_err(|_| bad(path, "member name is not exact UTF-8"))?;
+        validate_name(path, name)?;
+        let flags = word(header, 8);
+        if flags & (1 | 32 | 64 | 8192) != 0 {
+            return Err(bad(
+                path,
+                format!("encrypted or compressed-patch member {name:?} is unsupported"),
+            ));
         }
-
-        cursor = name_start + name_len + extra_len + comment_len;
+        let method = word(header, 10);
+        if method != 0 && method != 8 {
+            return Err(bad(
+                path,
+                format!("member {name:?} has unsupported compression method {method}"),
+            ));
+        }
+        let mut size = u64::from(dword(header, 24));
+        let mut compressed = u64::from(dword(header, 20));
+        let mut local = u64::from(dword(header, 42));
+        let mut disk = u64::from(word(header, 34));
+        let mut extra = &bytes[cursor + 46 + name_len..cursor + 46 + name_len + extra_len];
+        let mut zip64 = None;
+        while !extra.is_empty() {
+            if extra.len() < 4 {
+                return Err(bad(path, "truncated extra-field header"));
+            }
+            let field_len = usize::from(word(extra, 2));
+            if field_len + 4 > extra.len() {
+                return Err(bad(path, "truncated extra-field value"));
+            }
+            if word(extra, 0) == 1 {
+                if zip64.is_some() {
+                    return Err(bad(path, "duplicate ZIP64 extra field"));
+                }
+                zip64 = Some(&extra[4..4 + field_len]);
+            }
+            extra = &extra[4 + field_len..];
+        }
+        let mut zip64 = zip64.unwrap_or(&[]);
+        for value in [&mut size, &mut compressed, &mut local] {
+            if *value == u64::from(u32::MAX) {
+                if zip64.len() < 8 {
+                    return Err(bad(path, "missing or truncated ZIP64 entry value"));
+                }
+                *value = qword(zip64, 0);
+                zip64 = &zip64[8..];
+            }
+        }
+        if disk == u64::from(u16::MAX) {
+            if zip64.len() < 4 {
+                return Err(bad(path, "missing ZIP64 disk value"));
+            }
+            disk = u64::from(dword(zip64, 0));
+            zip64 = &zip64[4..];
+        }
+        // PKWARE APPNOTE 4.5.3 permits these fields only when the corresponding
+        // central-directory value is its ZIP64 sentinel.
+        if !zip64.is_empty() {
+            return Err(bad(path, "inconsistent ZIP64 extra-field values"));
+        }
+        if disk != u64::from(directory.disk) {
+            return Err(bad(path, "member starts on another disk"));
+        }
+        if (method == 0 && size != compressed)
+            || (size != 0 && compressed == 0)
+            || local
+                .checked_add(30)
+                .and_then(|v| v.checked_add(name_len as u64))
+                .and_then(|v| v.checked_add(compressed))
+                .is_none_or(|v| v > directory.offset)
+        {
+            return Err(bad(
+                path,
+                format!("member {name:?} has inconsistent size or local-header bounds"),
+            ));
+        }
+        let is_dir = name.ends_with('/');
+        let key = name.trim_end_matches('/').to_ascii_lowercase();
+        if let Some((previous, _)) = names.get(&key) {
+            return Err(bad(
+                path,
+                format!("duplicate or case-ambiguous members {previous:?} and {name:?}"),
+            ));
+        }
+        names.insert(key, (name.to_string(), is_dir));
+        if !is_dir {
+            entries.push(Entry {
+                name: name.to_string(),
+                crc32: dword(header, 16),
+                size,
+            });
+        }
+        cursor = end;
     }
+    if cursor != length {
+        return Err(bad(
+            path,
+            "central-directory size does not match its entries",
+        ));
+    }
+    // Check implied directories against explicit files and directory casing.
+    // Sort once rather than retaining every prefix of every long member name.
+    let mut paths: Vec<_> = names.iter().collect();
+    paths.sort_unstable_by_key(|(left, _)| *left);
+    for (_, (name, _)) in &paths {
+        for (slash, _) in name.match_indices('/') {
+            let prefix = &name[..slash];
+            if let Some((existing, directory)) = names.get(&prefix.to_ascii_lowercase()) {
+                if !directory || existing.trim_end_matches('/') != prefix {
+                    return Err(bad(
+                        path,
+                        format!("ambiguous file/directory prefix in member {name:?}"),
+                    ));
+                }
+            }
+        }
+    }
+    for pair in paths.windows(2) {
+        let (_, (left, _)) = pair[0];
+        let (_, (right, _)) = pair[1];
+        for (a, b) in left.split('/').zip(right.split('/')) {
+            if !a.eq_ignore_ascii_case(b) {
+                break;
+            }
+            if a != b {
+                return Err(bad(
+                    path,
+                    format!("case-ambiguous directory names in {left:?} and {right:?}"),
+                ));
+            }
+        }
+    }
+    let mut directories: Vec<String> = names
+        .into_values()
+        .filter_map(|(name, directory)| directory.then(|| name.trim_end_matches('/').to_string()))
+        .collect();
+    // Browse uses a stable case-insensitive sort. Exact Unicode directory names
+    // can share that sort key, so their input order must not come from HashMap.
+    directories.sort_unstable();
+    Ok(Some(Contents {
+        entries,
+        directories,
+        main_compatible,
+    }))
+}
 
-    Ok(Some(entries))
+/// Real stored ZIP bytes shared by boundary/compatibility tests.
+#[cfg(test)]
+pub fn tests_archive(names: &[&str], zip64: bool) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    let mut directory = Vec::new();
+    for name in names {
+        let offset = bytes.len() as u64;
+        let name = name.as_bytes();
+        let mut local = [0u8; 30];
+        local[..4].copy_from_slice(&[0x50, 0x4b, 3, 4]);
+        local[4..6].copy_from_slice(&20u16.to_le_bytes());
+        local[26..28].copy_from_slice(&(name.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(&local);
+        bytes.extend_from_slice(name);
+        let mut central = [0u8; 46];
+        central[..4].copy_from_slice(&CENTRAL_SIGNATURE);
+        central[4..6].copy_from_slice(&20u16.to_le_bytes());
+        central[6..8].copy_from_slice(&(if zip64 { 45u16 } else { 20u16 }).to_le_bytes());
+        central[28..30].copy_from_slice(&(name.len() as u16).to_le_bytes());
+        if zip64 {
+            central[20..28].fill(0xff);
+            central[42..46].fill(0xff);
+            central[30..32].copy_from_slice(&28u16.to_le_bytes());
+        } else {
+            central[42..46].copy_from_slice(&(offset as u32).to_le_bytes());
+        }
+        directory.extend_from_slice(&central);
+        directory.extend_from_slice(name);
+        if zip64 {
+            directory.extend_from_slice(&1u16.to_le_bytes());
+            directory.extend_from_slice(&24u16.to_le_bytes());
+            directory.extend_from_slice(&0u64.to_le_bytes());
+            directory.extend_from_slice(&0u64.to_le_bytes());
+            directory.extend_from_slice(&offset.to_le_bytes());
+        }
+    }
+    let offset = bytes.len() as u64;
+    bytes.extend_from_slice(&directory);
+    if zip64 {
+        let record_offset = bytes.len() as u64;
+        bytes.extend_from_slice(&[0x50, 0x4b, 6, 6]);
+        bytes.extend_from_slice(&44u64.to_le_bytes());
+        bytes.extend_from_slice(&45u16.to_le_bytes());
+        bytes.extend_from_slice(&45u16.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&(names.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&(names.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&(directory.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&offset.to_le_bytes());
+        bytes.extend_from_slice(&[0x50, 0x4b, 6, 7]);
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&record_offset.to_le_bytes());
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+    }
+    bytes.extend_from_slice(&EOCD_SIGNATURE);
+    bytes.extend_from_slice(&0u32.to_le_bytes());
+    let count = if zip64 { u16::MAX } else { names.len() as u16 };
+    bytes.extend_from_slice(&count.to_le_bytes());
+    bytes.extend_from_slice(&count.to_le_bytes());
+    bytes.extend_from_slice(
+        &(if zip64 {
+            u32::MAX
+        } else {
+            directory.len() as u32
+        })
+        .to_le_bytes(),
+    );
+    bytes.extend_from_slice(&(if zip64 { u32::MAX } else { offset as u32 }).to_le_bytes());
+    bytes.extend_from_slice(&0u16.to_le_bytes());
+    bytes
 }
 
 /// The test archive, shared with the catalog's tests so both exercise the
@@ -354,5 +802,268 @@ mod tests {
     fn a_missing_archive_names_the_file_it_could_not_open() {
         let err = list(Path::new("/definitely/not/here.zip")).expect_err("must fail");
         assert!(err.to_string().contains("here.zip"), "got: {err}");
+    }
+    #[test]
+    fn explicit_directory_order_is_stable_when_browse_sort_keys_tie() {
+        let path = write_fixture(
+            "directory-order",
+            &tests_archive(&["ä/", "Ä/", "ö/", "Ö/", "ü/", "Ü/"], false),
+        );
+        for _ in 0..8 {
+            let contents = contents_controlled(&path, &AtomicBool::new(false))
+                .unwrap()
+                .unwrap();
+            let mut names = contents.directories;
+            names.sort_by_key(|name| name.to_lowercase());
+            assert_eq!(names, ["Ä", "ä", "Ö", "ö", "Ü", "ü"]);
+        }
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn zip64_entries_preserve_exact_identity_size_and_crc() {
+        let path = write_fixture(
+            "zip64",
+            &tests_archive(&["root.neo", "folder/nested.neo"], true),
+        );
+        let entries = entries(&path).unwrap();
+        assert_eq!(
+            entries
+                .iter()
+                .map(|e| (e.name.as_str(), e.size, e.crc32))
+                .collect::<Vec<_>>(),
+            vec![("root.neo", 0, 0), ("folder/nested.neo", 0, 0)]
+        );
+        assert_eq!(
+            validate_member(&path.join("folder/nested.neo")).unwrap(),
+            entries[1]
+        );
+        assert!(validate_member(&path.join("missing.neo"))
+            .unwrap_err()
+            .to_string()
+            .contains("missing.neo"));
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn comment_signatures_do_not_hide_the_structural_end_record() {
+        let mut bytes = tests_archive(&["game.neo"], false);
+        let at = bytes.len() - 2;
+        let comment = b"comment PK\x05\x06 with a false signature";
+        bytes[at..].copy_from_slice(&(comment.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(comment);
+        let path = write_fixture("comment", &bytes);
+        assert_eq!(list(&path).unwrap(), ["game.neo"]);
+        assert!(validate_member(&path.join("game.neo")).is_ok());
+        let error = validate_member_for_launch(&path.join("game.neo"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("archive comment"));
+        assert!(error.contains(path.to_str().unwrap()));
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn invalid_names_cannot_change_identity_or_choose_the_wrong_member() {
+        for (index, names) in [
+            vec!["../game.neo"],
+            vec!["/game.neo"],
+            vec!["a//game.neo"],
+            vec!["a/./game.neo"],
+            vec!["a\\game.neo"],
+            vec!["game.neo\n"],
+            vec!["nested.zip/game.neo"],
+            vec!["nested.zip"],
+            vec!["game.neo", "game.neo"],
+            vec!["game.neo", "GAME.neo"],
+            vec!["Folder/a.neo", "folder/b.neo"],
+            vec!["folder", "folder/game.neo"],
+        ]
+        .iter()
+        .enumerate()
+        {
+            let path = write_fixture(&format!("names-{index}"), &tests_archive(names, false));
+            assert!(entries(&path).is_err(), "accepted {names:?}");
+            std::fs::remove_file(path).unwrap();
+        }
+    }
+
+    #[test]
+    fn malformed_zip64_chains_and_entry_fields_fail_explicitly() {
+        let original = tests_archive(&["game.neo"], true);
+        let central = original
+            .windows(4)
+            .position(|b| b == CENTRAL_SIGNATURE)
+            .unwrap();
+        let end64 = original
+            .windows(4)
+            .position(|b| b == [0x50, 0x4b, 6, 6])
+            .unwrap();
+        let locator = end64 + 56;
+        for (index, (offset, value)) in [
+            (end64, 0),
+            (end64 + 4, 43),
+            (end64 + 16, 2),
+            (end64 + 32, 2),
+            (locator, 0),
+            (locator + 16, 2),
+            (central + 46 + "game.neo".len(), 2),
+            (central + 46 + "game.neo".len() + 2, 23),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let mut bytes = original.clone();
+            bytes[offset] = value;
+            let path = write_fixture(&format!("broken64-{index}"), &bytes);
+            assert!(entries(&path).is_err(), "accepted mutation {index}");
+            std::fs::remove_file(path).unwrap();
+        }
+    }
+
+    #[test]
+    fn zip64_values_without_corresponding_sentinels_are_rejected() {
+        let mut bytes = tests_archive(&["game.neo"], true);
+        let central = bytes
+            .windows(4)
+            .position(|header| header == CENTRAL_SIGNATURE)
+            .unwrap();
+        // The empty member fits in the classic compressed-size field. Keeping
+        // its ZIP64 value anyway violates APPNOTE 4.5.3's conditional layout.
+        bytes[central + 20..central + 24].fill(0);
+        let path = write_fixture("surplus64", &bytes);
+        assert!(entries(&path)
+            .unwrap_err()
+            .to_string()
+            .contains("inconsistent ZIP64 extra-field values"));
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn unsupported_methods_flags_and_malformed_directory_lengths_are_errors() {
+        let original = tests_archive(&["game.neo"], false);
+        let central = original
+            .windows(4)
+            .position(|b| b == CENTRAL_SIGNATURE)
+            .unwrap();
+        for (index, (offset, value)) in [(8, 1), (8, 32), (8, 64), (9, 32), (10, 12), (32, 1)]
+            .into_iter()
+            .enumerate()
+        {
+            let mut bytes = original.clone();
+            bytes[central + offset] = value;
+            let path = write_fixture(&format!("unsupported-{index}"), &bytes);
+            assert!(entries(&path).is_err(), "accepted mutation {index}");
+            std::fs::remove_file(path).unwrap();
+        }
+    }
+
+    #[test]
+    fn more_than_65535_entries_are_reachable_within_the_resource_limit() {
+        let names: Vec<_> = (0..65_536).map(|n| format!("{n}.neo")).collect();
+        let refs: Vec<_> = names.iter().map(String::as_str).collect();
+        let path = write_fixture("count64", &tests_archive(&refs, true));
+        assert_eq!(entries(&path).unwrap().len(), 65_536);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn sparse_archive_directory_above_four_gib_uses_real_large_file_seeks() {
+        use std::io::Write;
+        let bytes = tests_archive(&["game.neo"], true);
+        let central = bytes
+            .windows(4)
+            .position(|b| b == CENTRAL_SIGNATURE)
+            .unwrap();
+        let mut ending = bytes[central..].to_vec();
+        let end64 = ending
+            .windows(4)
+            .position(|b| b == [0x50, 0x4b, 6, 6])
+            .unwrap();
+        let offset = u64::from(u32::MAX) + 65;
+        ending[end64 + 48..end64 + 56].copy_from_slice(&offset.to_le_bytes());
+        ending[end64 + 64..end64 + 72].copy_from_slice(&(offset + end64 as u64).to_le_bytes());
+        let path = write_fixture("sparse64", &bytes[..central]);
+        let mut file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+        file.seek(SeekFrom::Start(offset)).unwrap();
+        file.write_all(&ending).unwrap();
+        drop(file);
+        assert_eq!(list(&path).unwrap(), ["game.neo"]);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn archive_cache_observes_replacement_and_never_uses_a_missing_archive() {
+        let path = write_fixture("cache-replace", &tests_archive(&["old.neo"], false));
+        let mut cache = ArchiveCache::default();
+        assert_eq!(cache.read(&path).unwrap().entries[0].name, "old.neo");
+        std::fs::remove_file(&path).unwrap();
+        assert!(cache.read(&path).is_err());
+        std::fs::write(&path, tests_archive(&["new.neo"], false)).unwrap();
+        assert_eq!(cache.read(&path).unwrap().entries[0].name, "new.neo");
+        std::fs::remove_file(path).unwrap();
+    }
+    #[test]
+    fn resource_limits_are_explicit_before_any_large_allocation() {
+        let original = tests_archive(&["game.neo"], true);
+        let at = original
+            .windows(4)
+            .position(|b| b == [0x50, 0x4b, 6, 6])
+            .unwrap();
+        for (tag, offset, value) in [
+            ("count-limit", 32, MAX_ENTRIES + 1),
+            ("directory-limit", 40, MAX_DIRECTORY_BYTES + 1),
+        ] {
+            let mut bytes = original.clone();
+            bytes[at + offset..at + offset + 8].copy_from_slice(&value.to_le_bytes());
+            if offset == 32 {
+                bytes[at + 24..at + 32].copy_from_slice(&value.to_le_bytes());
+            }
+            let path = write_fixture(tag, &bytes);
+            let error = entries(&path).unwrap_err().to_string();
+            assert!(error.contains("resource limit"), "{error}");
+            assert!(error.contains(path.to_str().unwrap()));
+            std::fs::remove_file(path).unwrap();
+        }
+    }
+
+    #[test]
+    fn duplicate_zip64_extra_fields_are_rejected() {
+        let mut bytes = tests_archive(&["game.neo"], true);
+        let central = bytes
+            .windows(4)
+            .position(|b| b == CENTRAL_SIGNATURE)
+            .unwrap();
+        let end64 = bytes
+            .windows(4)
+            .position(|b| b == [0x50, 0x4b, 6, 6])
+            .unwrap();
+        let extra_start = central + 46 + "game.neo".len();
+        let duplicate = bytes[extra_start..extra_start + 28].to_vec();
+        bytes.splice(end64..end64, duplicate);
+        bytes[central + 30..central + 32].copy_from_slice(&56u16.to_le_bytes());
+        let end64 = end64 + 28;
+        let size = qword(&bytes, end64 + 40) + 28;
+        bytes[end64 + 40..end64 + 48].copy_from_slice(&size.to_le_bytes());
+        bytes[end64 + 64..end64 + 72].copy_from_slice(&(end64 as u64).to_le_bytes());
+        let path = write_fixture("duplicate64", &bytes);
+        assert!(entries(&path)
+            .unwrap_err()
+            .to_string()
+            .contains("duplicate ZIP64"));
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn entry_names_are_never_decoded_lossily() {
+        let mut bytes = tests_archive(&["game.neo"], false);
+        let central = bytes
+            .windows(4)
+            .position(|b| b == CENTRAL_SIGNATURE)
+            .unwrap();
+        bytes[central + 46] = 0xff;
+        let path = write_fixture("bad-utf8", &bytes);
+        assert!(entries(&path).unwrap_err().to_string().contains("UTF-8"));
+        std::fs::remove_file(path).unwrap();
     }
 }

--- a/support/ra-main/Dockerfile
+++ b/support/ra-main/Dockerfile
@@ -1,9 +1,11 @@
-# Debian bullseye on purpose: it ships glibc 2.31 and gcc 10, which is what
-# the MiSTer rootfs has (/lib/libc-2.31.so) and what upstream's Makefile says
-# it builds with. A newer Debian links against symbols the device does not
-# have and the binary refuses to start.
-FROM debian:bullseye
-RUN apt-get update \
+# Use a maintained host while retaining MiSTer's glibc 2.31 / GCC 10 target ABI.
+# Bullseye supplies the GCC 10 cross compiler and ARM sysroot only; its other
+# packages have lower priority than the Bookworm host libraries and tools.
+FROM debian:bookworm
+RUN printf 'deb http://deb.debian.org/debian bullseye main\n' > /etc/apt/sources.list.d/bullseye.list \
+ && printf 'Package: *\nPin: release n=bullseye\nPin-Priority: 1\n\nPackage: *-armhf-cross\nPin: release n=bullseye\nPin-Priority: 990\n' > /etc/apt/preferences.d/mister-target \
+ && apt-get update \
  && apt-get install -y --no-install-recommends \
-      crossbuild-essential-armhf make ca-certificates \
+      gcc-10-arm-linux-gnueabihf g++-10-arm-linux-gnueabihf \
+      binutils-arm-linux-gnueabihf make ca-certificates \
  && rm -rf /var/lib/apt/lists/*

--- a/support/ra-main/Dockerfile
+++ b/support/ra-main/Dockerfile
@@ -1,0 +1,9 @@
+# Debian bullseye on purpose: it ships glibc 2.31 and gcc 10, which is what
+# the MiSTer rootfs has (/lib/libc-2.31.so) and what upstream's Makefile says
+# it builds with. A newer Debian links against symbols the device does not
+# have and the binary refuses to start.
+FROM debian:bullseye
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      crossbuild-essential-armhf make ca-certificates \
+ && rm -rf /var/lib/apt/lists/*

--- a/support/ra-main/README.md
+++ b/support/ra-main/README.md
@@ -1,0 +1,150 @@
+# RA Main frontend integration
+
+`../../scripts/build-ra-main.sh NEW_OUTPUT_DIRECTORY` builds RetroAchievements
+Main with the existing Degauss Frontend menu and keyboard shortcut. The output
+directory must not exist. The helper installs nothing on a device. The release
+workflow builds it and includes the binary, CA bundle, and source notice in the
+normal archive and Downloader database. Corresponding source is attached to the
+same release as `MiSTer_RA_Degauss-source.tar.gz`.
+
+## Installation and updates
+
+The release installs these separate files:
+
+```text
+degauss/MiSTer_RA_Degauss
+degauss/MiSTer_RA_Degauss.cacert.pem
+degauss/MiSTer_RA_Degauss.SOURCE.txt
+```
+
+After installing the RA cores with their compatible RA setup, select this Main
+in the existing `[RA_*]` section of `MiSTer.ini`:
+
+```ini
+[RA_*]
+main=degauss/MiSTer_RA_Degauss
+```
+
+Change only that section's `main=` value, preserving its position and other
+settings. If it is absent, add it before any more-specific RA sections. Matching
+sections apply in file order: preserve deliberate per-core Main overrides and
+update an affected override only when that core should use this integration.
+The package and Downloader never rewrite INI files or credentials.
+
+The [upstream RA installer](https://github.com/sage2050/MiSTer_RetroAchievements/blob/bc19dcab7c855dc55bf61e4025a2591cd9a9a5f5/Scripts/MiSTer_RA.sh#L371)
+updates its own root `MiSTer_RA` and leaves an existing `[RA_*]` block untouched. The separate Degauss executable therefore survives that
+update. Degauss's normal Downloader database updates the integrated binary and
+its CA bundle. No executable or updater is renamed or impersonated.
+
+This preserves files from upstream updates; it does not promise that an older
+RA Main understands future core protocols. Degauss releases deliberately pin,
+build and test the RA backend. When upstream cores require a newer Main, update
+the pinned backend and validate it before shipping another Degauss release.
+
+## Sources and compatibility
+
+- RA Main v1.12.2: commit `48e32b43ed85b046c7cd41bce756b7bb1679782b`
+  from https://github.com/odelot/Main_MiSTer/tree/48e32b43ed85b046c7cd41bce756b7bb1679782b.
+- Source archive SHA-256:
+  `77b2f284a675f4217be27b3fb700c06536e07f3600e14149f2231f2dceb95edb`.
+- Degauss integration: commit `0651979d53f570c29f8772e124ae603297830954`
+  relative to `0a8fb44`, from https://github.com/giancarloerra/Degauss-Main.
+  The patch omits its unrelated input.cpp blank-line removal.
+- rcheevos 12.4.0 is already bundled in this exact RA source. Its bytes remain
+  unchanged; the build fails if the dependency or its compiled object is missing.
+- Mozilla CA bundle from https://curl.se/ca/cacert-2026-08-13.pem (MPL-2.0),
+  SHA-256 `f66dff1bdf8f96060b8177976f8b7d9254bc89bc4db933d769f7384d28480bc9`.
+  Its published checksum is available at the same URL with `.sha256` appended.
+
+The patch adds the same helper implementation, input hook, menu actions, and
+host tests used by Degauss Main. It preserves RA achievement code and its build
+configuration. The `controller.patch` sends both joystick words from the first update and
+sends initial controller states even before any button is pressed. This clears
+FPGA input bits retained across a Main restart, including the RA NES input-disable
+bit, while preserving player swaps and suppressing unchanged polling traffic.
+The existing protocol already sends both words after any high-bit button input.
+A separate `tls.patch` changes only the active HTTP transport and
+adds a real-curl host test. It removes certificate-verification bypass, requires
+HTTPS even for redirects, ignores curl startup configuration, and reports
+transport errors without URLs or credential contents. The existing 16-byte version 1 shortcut configuration at
+`config/degauss/frontend_shortcut.bin` is shared unchanged. There is no second
+shortcut setting. Frontend and the configured keyboard key load `menu.rbf`;
+normal Main profile selection determines the executable used after that load.
+
+Unstable cores using Degauss Main already use that integration. This build is
+needed for an RA Main executable selected through an RA profile. It does not
+modify any FPGA core.
+
+## Build and validation
+
+Requires Bash, curl, tar, patch, shasum, Python 3, OpenSSL, a host C++ compiler,
+and Docker. Host TLS tests bind a temporary loopback server. The build
+builds `degauss-ra-main-build:bullseye` from the included Dockerfile, allowing
+Docker to reuse matching layers but never trusting an arbitrary existing tag. It compiles for Cortex-A9 with NEON and the ARM hard-float
+ABI. Container compilation has networking disabled. The source archive is
+checksum-verified and the integration must apply with zero fuzz.
+
+Controller tests compile the actual serialization function and initial polling
+block against the HPS word-update contract, covering stale high bits, zero-input
+startup, Start, release, player swaps and unchanged polls.
+
+Host tests validate persisted shortcut records, disabled and invalid settings,
+key consumption, repeat/release handling, extended Linux keys, runtime gates,
+and placement before keyboard remapping. The build checks that achievement
+support was enabled and that achievement and frontend implementations were
+linked into the final executable. Real host curl tests exercise trusted TLS,
+hostname rejection even with an insecure curlrc, plaintext/redirect rejection,
+missing/invalid CA files, connection errors, quoted POST bodies and paths, long
+quoted content types, and request-log redaction.
+On macOS only the `/proc/self/exe` lookup is adapted to the host executable API;
+actual Linux sidecar discovery and target curl remain device acceptance checks.
+
+The output retains patched source, upstream archive, integration patch,
+Dockerfile, build log, source pins, `MiSTer_RA_Degauss`, and its `.cacert.pem`
+sidecar. To rebuild from the
+output bundle, run `rebuild/scripts/build-ra-main.sh NEW_OUTPUT_DIRECTORY`.
+Before distribution,
+include corresponding source and build instructions: Main and this integration
+are GPL-3.0, separate from the Rust frontend's licence. Upstream bundled
+components retain their own licences and notices.
+
+On-device acceptance must additionally verify the Frontend OSD action and saved
+keyboard shortcut from an RA game, reopening the frontend, another RA launch,
+and subsequent standard and Unstable launches. Preserve the original RA Main
+and restore it when removing the test installation.
+
+## Updating
+
+Pin a new RA release and its archive checksum deliberately. Regenerate the
+Degauss patch from the two recorded integration revisions when that integration
+changes. Check RA input/menu additions before resolving a conflict; never replace
+whole RA files with standard Main files. Run the host tests and full ARM build,
+then repeat the device acceptance flow. A source update is not implicitly
+validated by a previously tested binary.
+
+## TLS installation and CA updates
+
+Return to the menu so RA Main is inactive before replacing its executable.
+Install the binary and CA bundle together, then launch the replacement. The bundle must have the executable's
+full pathname plus `.cacert.pem`. For example, a binary installed as
+`/media/fat/MiSTer_RA` needs `/media/fat/MiSTer_RA.cacert.pem`. The normal release instead
+uses `/media/fat/degauss/MiSTer_RA_Degauss` and the adjacent
+`MiSTer_RA_Degauss.cacert.pem`. Deriving this from
+the running executable preserves custom installation locations. Back up both
+exact destinations, verify staged hashes, and replace each through a temporary
+file in its destination directory followed by an atomic rename. No system CA
+store, credential file, or curl configuration is modified. Missing or invalid
+bundles fail explicitly, with no insecure fallback.
+
+The bundle comes from curl's [Mozilla CA extraction service](https://curl.se/docs/caextract.html).
+For updates, select a dated official bundle, verify its published SHA-256, and
+update the URL and expected digest in the build script together. A verified
+bundle can also replace the sidecar without rebuilding Main. Retain its MPL-2.0
+notice and official source URL when distributing it. Do not pin individual
+server certificates, which would break legitimate certificate rotation.
+
+Before using credentials, verify an anonymous HTTPS request with the target
+curl and this exact bundle. Then verify the new binary's actual RA request path
+and ensure failures identify certificate, CA-file, connection, and timeout
+errors without printing credentials. An HTTP error response still establishes
+TLS transport when curl succeeds; it does not establish authenticated login.

--- a/support/ra-main/README.md
+++ b/support/ra-main/README.md
@@ -66,10 +66,14 @@ The existing protocol already sends both words after any high-bit button input.
 A separate `tls.patch` changes only the active HTTP transport and
 adds a real-curl host test. It removes certificate-verification bypass, requires
 HTTPS even for redirects, ignores curl startup configuration, and reports
-transport errors without URLs or credential contents. The existing 16-byte version 1 shortcut configuration at
+transport errors without URLs or credential contents. Curl is started directly;
+request values pass through an anonymous stdin connection, never shell/process
+arguments or request files. This uses curl 7.43 or newer (`data-raw`). The existing 16-byte version 1 shortcut configuration at
 `config/degauss/frontend_shortcut.bin` is shared unchanged. There is no second
 shortcut setting. Frontend and the configured keyboard key load `menu.rbf`;
 normal Main profile selection determines the executable used after that load.
+When a frontend exits from RA Main Scripts mode, cleanup explicitly returns to
+VT1 before disabling its script framebuffer.
 
 Unstable cores using Degauss Main already use that integration. This build is
 needed for an RA Main executable selected through an RA profile. It does not
@@ -79,10 +83,14 @@ modify any FPGA core.
 
 Requires Bash, curl, tar, patch, shasum, Python 3, OpenSSL, a host C++ compiler,
 and Docker. Host TLS tests bind a temporary loopback server. The build
-builds `degauss-ra-main-build:bullseye` from the included Dockerfile, allowing
-Docker to reuse matching layers but never trusting an arbitrary existing tag. It compiles for Cortex-A9 with NEON and the ARM hard-float
-ABI. Container compilation has networking disabled. The source archive is
-checksum-verified and the integration must apply with zero fuzz.
+builds `degauss-ra-main-build:bookworm-gcc10` from the included Dockerfile,
+allowing Docker to reuse matching layers but never trusting an arbitrary
+existing tag. Debian Bookworm provides the maintained host libraries and tools;
+low-priority Bullseye packages supply GCC 10 and the ARM glibc 2.31 sysroot for
+MiSTer compatibility. It compiles for Cortex-A9 with NEON and the ARM hard-float
+ABI, then rejects GLIBC requirements above 2.31 or GLIBCXX requirements above
+3.4.28 before packaging. Container compilation has networking disabled. The
+source archive is checksum-verified and the integration must apply with zero fuzz.
 
 Controller tests compile the actual serialization function and initial polling
 block against the HPS word-update contract, covering stale high bits, zero-input

--- a/support/ra-main/controller.patch
+++ b/support/ra-main/controller.patch
@@ -1,0 +1,148 @@
+--- a/user_io.cpp
++++ b/user_io.cpp
+@@ -1813,12 +1813,12 @@
+ {
+ 	uint8_t joy = (joystick>1 || !joyswap) ? joystick : joystick ^ 1;
+ 
+-	static int use32 = 0;
+-	use32 |= map >> 16;
++	// Main can restart without resetting the FPGA joystick registers.
++	// Always replace the upper word too, including an old input-disable bit.
+ 
+ 	spi_uio_cmd_cont((joy < 2) ? (UIO_JOYSTICK0 + joy) : (UIO_JOYSTICK2 + joy - 2));
+ 	spi_w(map);
+-	if(use32) spi_w(map >> 16);
++	spi_w(map >> 16);
+ 	DisableIO();
+ 
+ 	if (!is_minimig() && joy_transl == 1 && newdir)
+--- a/input.cpp
++++ b/input.cpp
+@@ -6388,6 +6388,7 @@
+ 	static bool autofire_cfg_parsed = false;
+  	if (!autofire_cfg_parsed) autofire_cfg_parsed = parse_autofire_cfg();
+ 	static uint32_t joy_mask_prev[NUMPLAYERS] = {};
++	static bool joy_mask_initialized = false;
+ 
+ 	add_frame_callback(key_update_frames_held_cb);
+ 
+@@ -6437,13 +6438,15 @@
+ 		for (int i = 0; i < NUMPLAYERS; i++) {
+ 			joy_mask[i] = joy_mask[i] | autofire_mask[i];
+ 			int newdir = (joy_mask[i] & 0xF) | (joy_mask_prev[i] & 0xF);
+-			if (joy_mask[i] != joy_mask_prev[i])
++			if (!joy_mask_initialized || joy_mask[i] != joy_mask_prev[i])
+ 			{
+ 				joy_mask_prev[i] = joy_mask[i];
+ 				user_io_digital_joystick(i, joy_mask[i], newdir);
+ 			}
+ 		}
+ 	}
++
++	if (grabbed) joy_mask_initialized = true;
+ 
+ 	if (!grabbed || user_io_osd_is_visible())
+ 	{
+--- /dev/null
++++ b/tests/run-ra-controller-tests.py
+@@ -0,0 +1,100 @@
++#!/usr/bin/env python3
++"""Exercise actual Main joystick serialization and first-poll state clearing."""
++import pathlib
++import subprocess
++import tempfile
++
++root = pathlib.Path(__file__).resolve().parent.parent
++user_io = (root / 'user_io.cpp').read_text()
++inputs = (root / 'input.cpp').read_text()
++
++
++def block(text, marker):
++    start = text.index(marker)
++    opening = text.index('{', start)
++    depth = 1
++    end = opening + 1
++    while depth:
++        depth += (text[end] == '{') - (text[end] == '}')
++        end += 1
++    return text[start:end]
++
++
++send = block(user_io, 'void user_io_digital_joystick(')
++poll = inputs[inputs.index('int input_poll(int getchar)'):]
++start = poll.index('static uint32_t joy_mask_prev')
++end = poll.index('add_frame_callback(', start)
++declarations = poll[start:end]
++start = poll.index('\n\tif (grabbed)')
++end = poll.index('\n\tif (!grabbed ||', start)
++forward = poll[start:end]
++source = r'''
++#include <cassert>
++#include <cstdint>
++#include <vector>
++#include <unistd.h>
++#define NUMPLAYERS 6
++#define UIO_JOYSTICK0 2
++#define UIO_JOYSTICK2 16
++static int joyswap = 0, joy_transl = 0;
++static unsigned player, word_index, transfers;
++static uint32_t fpga[NUMPLAYERS];
++static std::vector<uint16_t> words;
++void spi_uio_cmd_cont(unsigned cmd) {
++    player = cmd < 16 ? cmd - 2 : cmd - 16 + 2;
++    word_index = 0;
++    ++transfers;
++}
++void spi_w(uint16_t word) {
++    assert(word_index < 2);
++    words.push_back(word);
++    // Exact HPS contract: each received word replaces only its own half.
++    const unsigned shift = word_index++ * 16;
++    fpga[player] = (fpga[player] & ~(uint32_t(0xffff) << shift)) | (uint32_t(word) << shift);
++}
++void DisableIO() { assert(word_index == 2); }
++bool is_minimig() { return false; }
++void user_io_l_analog_joystick(unsigned, int, int) {}
++void register_activity() {}
++''' + send + '\nvoid poll_for_test(bool grabbed, uint32_t* joy_mask, uint32_t* autofire_mask) {\n' + declarations + forward + r'''
++}
++int main(int argc, char** argv) {
++    uint32_t mask[NUMPLAYERS] = {}, autofire[NUMPLAYERS] = {};
++    for (auto &state : fpga) state = 0x00800000; // Stale RA NES input-disable bit.
++    poll_for_test(false, mask, autofire);
++    assert(transfers == 0);
++    poll_for_test(true, mask, autofire);
++    assert(transfers == NUMPLAYERS);
++    for (auto state : fpga) assert(state == 0);
++    poll_for_test(true, mask, autofire);
++    assert(transfers == NUMPLAYERS); // Unchanged polls still avoid SPI traffic.
++    mask[0] = 128; // NES Start, no high-bit button event required.
++    poll_for_test(true, mask, autofire);
++    assert(fpga[0] == 128);
++    mask[0] = 0;
++    poll_for_test(true, mask, autofire);
++    assert(fpga[0] == 0);
++    user_io_digital_joystick(0, 0x00800080, 0);
++    assert(fpga[0] == 0x00800080);
++    user_io_digital_joystick(0, 128, 0);
++    assert(fpga[0] == 128);
++    joyswap = 1;
++    user_io_digital_joystick(0, 0x12345678, 0);
++    assert(fpga[1] == 0x12345678);
++    user_io_digital_joystick(2, 0x87654321, 0);
++    assert(fpga[2] == 0x87654321); // Players above two are not swapped.
++    // Main's app_restart uses exec: the first-poll state must reset in that
++    // new process image, even after this process has already initialized it.
++    if (argc == 1) {
++        execl(argv[0], argv[0], "restarted", static_cast<char*>(nullptr));
++        assert(false && "exec restart failed");
++    }
++    assert(argc == 2);
++}
++'''
++with tempfile.TemporaryDirectory() as temporary:
++    path = pathlib.Path(temporary)
++    (path / 'test.cpp').write_text(source)
++    subprocess.run(['c++', '-std=c++11', '-Wall', '-Wextra', '-Werror', str(path / 'test.cpp'), '-o', str(path / 'test')], check=True)
++    subprocess.run([str(path / 'test')], check=True)
++print('Joystick first-poll clearing, full-word updates, release and swap checks passed')

--- a/support/ra-main/frontend.patch
+++ b/support/ra-main/frontend.patch
@@ -1201,3 +1201,62 @@ index 0000000..64a4e88
 +	echo "Frontend shortcut UI still uses the ambiguous set/capture label" >&2
 +	exit 1
 +fi
+--- a/menu.cpp
++++ b/menu.cpp
+@@ -7489,6 +7489,7 @@
+ 				if (degauss_running)
+ 				{
+ 					degauss_running = false;
++					video_chvt(1);
+ 					video_menu_bg(user_io_status_get("[3:1]"));
+ 					video_fb_enable(0);
+ 					menustate = MENU_SYSTEM1;
+--- a/tests/run-degauss-shortcut-tests.sh
++++ b/tests/run-degauss-shortcut-tests.sh
+@@ -62,3 +62,5 @@
+ 	echo "Frontend shortcut UI still uses the ambiguous set/capture label" >&2
+ 	exit 1
+ fi
++
++python3 tests/run-degauss-vt-test.py
+--- /dev/null
++++ b/tests/run-degauss-vt-test.py
+@@ -0,0 +1,38 @@
++#!/usr/bin/env python3
++"""Compile the actual frontend exit block and verify it leaves the script VT."""
++import pathlib
++import subprocess
++import tempfile
++
++root = pathlib.Path(__file__).resolve().parent.parent
++text = (root / 'menu.cpp').read_text()
++start = text.index('degauss_running = false;', text.index('case MENU_SCRIPTS_FB2:'))
++end = text.index('\n\t\t\t\t}', start)
++body = text[start:end]
++source = r'''
++#include <cassert>
++static bool degauss_running = true;
++static int vt = 2, menustate = 0, menusub = 0;
++static bool osd = false, framebuffer = true;
++enum { MENU_SYSTEM1 = 1, DISABLE_KEYBOARD = 1 };
++void video_chvt(int value) { vt = value; }
++int user_io_status_get(const char*) { return 0; }
++void video_menu_bg(int) {}
++void video_fb_enable(int value) { assert(vt == 1); framebuffer = value; }
++void OsdClear() {}
++void OsdEnable(int) { osd = true; }
++void cleanup() {
++''' + body + r'''
++}
++int main() {
++    cleanup();
++    assert(!degauss_running && vt == 1 && !framebuffer);
++    assert(menustate == MENU_SYSTEM1 && menusub == 3 && osd);
++}
++'''
++with tempfile.TemporaryDirectory() as temporary:
++    path = pathlib.Path(temporary)
++    (path / 'test.cpp').write_text(source)
++    subprocess.run(['c++', '-std=c++11', '-Wall', '-Wextra', '-Werror', str(path / 'test.cpp'), '-o', str(path / 'test')], check=True)
++    subprocess.run([str(path / 'test')], check=True)
++print('Frontend completion restores VT1 before disabling script framebuffer')

--- a/support/ra-main/frontend.patch
+++ b/support/ra-main/frontend.patch
@@ -1,0 +1,1203 @@
+diff --git a/input.cpp b/input.cpp
+index 50f1991..5f251ec 100644
+--- a/input.cpp
++++ b/input.cpp
+@@ -36,10 +36,26 @@
+ #include "frame_timer.h"
+ #include "scaler.h"
+ #include "file_io.h"
++#include "support/degauss/degauss_shortcut.h"
+ 
+ #define NUMDEV 30
+ #define UINPUT_NAME "MiSTer virtual input"
+ 
++static_assert(degauss_shortcut_logic::MAX_KEYBOARD_KEY == KEY_MAX,
++	"Degauss shortcut key range must match Linux KEY_MAX");
++static_assert(degauss_shortcut_logic::PRIMARY_BUTTON_FIRST == BTN_MISC,
++	"Degauss primary-button range must match Linux BTN_MISC");
++static_assert(degauss_shortcut_logic::PRIMARY_BUTTON_LAST == BTN_GEAR_UP,
++	"Degauss primary-button range must match Linux BTN_GEAR_UP");
++static_assert(degauss_shortcut_logic::DPAD_BUTTON_FIRST == BTN_DPAD_UP,
++	"Degauss D-pad range must match Linux BTN_DPAD_UP");
++static_assert(degauss_shortcut_logic::DPAD_BUTTON_LAST == BTN_DPAD_RIGHT,
++	"Degauss D-pad range must match Linux BTN_DPAD_RIGHT");
++static_assert(degauss_shortcut_logic::TRIGGER_BUTTON_FIRST == BTN_TRIGGER_HAPPY1,
++	"Degauss trigger-button range must match Linux BTN_TRIGGER_HAPPY1");
++static_assert(degauss_shortcut_logic::TRIGGER_BUTTON_LAST == BTN_TRIGGER_HAPPY40,
++	"Degauss trigger-button range must match Linux BTN_TRIGGER_HAPPY40");
++
+ bool update_advanced_state(int devnum, uint16_t evcode, int evstate);
+ 
+ char joy_bnames[NUMBUTTONS][32] = {};
+@@ -2971,6 +2987,20 @@ static void input_cb(struct input_event *ev, struct input_absinfo *absinfo, int
+ 		}
+ 	}
+ 
++	// Degauss accepts the complete Linux keyboard-key range before MiSTer's
++	// legacy 256-entry keyboard remap. Linux button ranges and keyboards that
++	// are deliberately configured as joysticks cannot become the shortcut.
++	const bool degauss_keyboard_event = ev->type == EV_KEY
++		&& ev->code
++		&& degauss_shortcut_logic::valid_keyboard_key(ev->code)
++		&& !(mapping && mapping_type == 2)
++		&& !input[dev].force_joy;
++	if (degauss_keyboard_event
++		&& degauss_shortcut_handle_keyboard_event(ev->code, ev->value, menu_event))
++	{
++		return;
++	}
++
+ 	if (ev->type == EV_KEY && ev->code < 256 && !(mapping && mapping_type == 2) && !input[dev].force_joy)
+ 	{
+ 		if (!input[dev].has_kbdmap)
+diff --git a/menu.cpp b/menu.cpp
+index 0c74e21..879f4a8 100644
+--- a/menu.cpp
++++ b/menu.cpp
+@@ -50,6 +50,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include "osd.h"
+ #include "hardware.h"
+ #include "menu.h"
++#include "support/degauss/degauss_launcher.h"
++#include "support/degauss/degauss_shortcut.h"
++
++// Degauss: true while the frontend, rather than an ordinary script, owns
++// the framebuffer terminal.
++static bool degauss_running = false;
++static bool degauss_shortcut_save_failed = false;
+ #include "user_io.h"
+ #include "debug.h"
+ #include "fpga_io.h"
+@@ -80,6 +87,10 @@ enum MENU
+ 	MENU_SYSTEM2,
+ 	MENU_COMMON1,
+ 	MENU_COMMON2,
++	MENU_DEGAUSS_SHORTCUT1,
++	MENU_DEGAUSS_SHORTCUT2,
++	MENU_DEGAUSS_SHORTCUT_CAPTURE1,
++	MENU_DEGAUSS_SHORTCUT_CAPTURE2,
+ 	MENU_MISC1,
+ 	MENU_MISC2,
+ 
+@@ -567,6 +578,11 @@ void menu_key_set(unsigned int c)
+ 	menu_key = c;
+ }
+ 
++bool menu_osd_is_unlocked(void)
++{
++	return osd_unlocked;
++}
++
+ // get key status
+ static int hold_cnt = 0;
+ static uint32_t menu_key_get(void)
+@@ -1107,6 +1123,17 @@ void HandleUI(void)
+ {
+ 	PROFILE_FUNCTION();
+ 
++	// Degauss: when the menu core comes up, hand the screen to the
++	// frontend instead of showing the stock menu. Done by entering the
++	// Scripts state the OSD itself uses, which is what sets the console to
++	// VT 2 and so makes Main hold its own hotkeys back while the frontend
++	// owns the screen. Exiting the frontend returns here with the stock
++	// menu, and it is not started again until the next core load.
++	if (menustate == MENU_NONE1 && degauss_should_take_menu(selPath, sizeof(selPath)))
++	{
++		menustate = MENU_SCRIPTS_FB;
++	}
++
+ 	if (bt_timer >= 0)
+ 	{
+ 		if (!bt_timer) bt_timer = (int32_t)GetTimer(6000);
+@@ -1582,6 +1609,12 @@ void HandleUI(void)
+ 		break;
+ 	}
+ 
++	if (degauss_shortcut_take_request())
++	{
++		fpga_load_rbf("menu.rbf");
++		return;
++	}
++
+ 	// Switch to current menu screen
+ 	switch (menustate)
+ 	{
+@@ -2862,6 +2895,14 @@ void HandleUI(void)
+ 			helptext_idx = 0;
+ 			reboot_req = 0;
+ 
++			// Degauss: arriving here fresh, start on Frontend. It is the
++			// reason most people open this menu from inside a game, and it
++			// saves walking to it.
++			if (parentstate != MENU_COMMON1 && !menusub && degauss_installed())
++			{
++				menusub = DEGAUSS_MENUSUB;
++			}
++
+ 			OsdSetTitle("System", 0);
+ 			menustate = MENU_COMMON2;
+ 			parentstate = MENU_COMMON1;
+@@ -2875,6 +2916,19 @@ void HandleUI(void)
+ 				if (!menusub) firstmenu = 0;
+ 				adjvisible = 0;
+ 
++				// Degauss: the way back. Inside a game there is otherwise
++				// no route to the frontend short of a reboot, because
++				// leaving a core means loading the menu core and only the
++				// OSD can ask for that.
++				if (degauss_installed())
++				{
++					MenuWrite(n++, " Frontend                  \x16", menusub == DEGAUSS_MENUSUB, 0);
++					MenuWrite(n++, " Frontend shortcut         \x16", menusub == DEGAUSS_SHORTCUT_MENUSUB, 0);
++					MenuWrite(n++);
++					menumask |= (1ULL << DEGAUSS_MENUSUB);
++					menumask |= (1ULL << DEGAUSS_SHORTCUT_MENUSUB);
++				}
++
+ 				MenuWrite(n++, " Core                      \x16", menusub == 0, 0);
+ 				MenuWrite(n++);
+ 
+@@ -3104,6 +3158,18 @@ void HandleUI(void)
+ 				menusub = 0;
+ 				break;
+ 
++			case DEGAUSS_MENUSUB:
++				// Loading the menu core is what makes Main re-execute
++				// itself, and that is where the frontend is started from.
++				// No hold handling: this is not the cold reboot item.
++				reboot_req = 1;
++				break;
++
++			case DEGAUSS_SHORTCUT_MENUSUB:
++				menustate = MENU_DEGAUSS_SHORTCUT1;
++				menusub = 0;
++				break;
++
+ 			case 17:
+ 				{
+ 					reboot_req = 1;
+@@ -3168,6 +3234,126 @@ void HandleUI(void)
+ 		if(!hold_cnt && reboot_req) fpga_load_rbf("menu.rbf");
+ 		break;
+ 
++	case MENU_DEGAUSS_SHORTCUT1:
++		{
++			helptext_idx = 0;
++			firstmenu = 0;
++			adjvisible = 0;
++			OsdSetSize(16);
++			OsdSetTitle("Frontend shortcut", 0);
++			parentstate = MENU_DEGAUSS_SHORTCUT1;
++			menustate = MENU_DEGAUSS_SHORTCUT2;
++
++			int n = 0;
++			const bool invalid = degauss_shortcut_load_state() == DEGAUSS_SHORTCUT_INVALID;
++			if (invalid)
++			{
++				menumask = 0x3;
++				MenuWrite(n++, " Invalid shortcut config", 0, 1);
++				MenuWrite(n++);
++				MenuWrite(n++, " Reset shortcut", menusub == 0);
++				if (degauss_shortcut_save_failed) MenuWrite(n++, " Reset failed", 0, 1);
++				while (n < OsdGetSize() - 1) MenuWrite(n++);
++				MenuWrite(n++, STD_BACK, menusub == 1, 0, OSD_ARROW_LEFT);
++			}
++			else
++			{
++				menumask = 0x3;
++				const uint16_t key = degauss_shortcut_keyboard_key();
++				if (key) snprintf(s, sizeof(s), " Keyboard: key code %u", key);
++				else snprintf(s, sizeof(s), " Keyboard: Off");
++				MenuWrite(n++, s, menusub == 0);
++
++				MenuWrite(n++);
++				MenuWrite(n++, " A: Capture   X: Disable", 0, 1);
++				if (degauss_shortcut_save_failed)
++				{
++					MenuWrite(n++, " Save failed", 0, 1);
++				}
++				while (n < OsdGetSize() - 1) MenuWrite(n++);
++				MenuWrite(n++, STD_BACK, menusub == 1, 0, OSD_ARROW_LEFT);
++			}
++		}
++		break;
++
++	case MENU_DEGAUSS_SHORTCUT2:
++		{
++			const bool invalid = degauss_shortcut_load_state() == DEGAUSS_SHORTCUT_INVALID;
++			if (menu || back || left)
++			{
++				degauss_shortcut_cancel_keyboard_capture();
++				menustate = MENU_COMMON1;
++				menusub = DEGAUSS_SHORTCUT_MENUSUB;
++				break;
++			}
++
++			if (invalid)
++			{
++				if (select && menusub == 0)
++				{
++					degauss_shortcut_save_failed = !degauss_shortcut_reset();
++					menustate = MENU_DEGAUSS_SHORTCUT1;
++				}
++				else if (select && menusub == 1)
++				{
++					menustate = MENU_COMMON1;
++					menusub = DEGAUSS_SHORTCUT_MENUSUB;
++				}
++				break;
++			}
++
++			if (c == KEY_TAB && menusub == 0)
++			{
++				degauss_shortcut_save_failed = !degauss_shortcut_set_keyboard(0);
++				menustate = MENU_DEGAUSS_SHORTCUT1;
++			}
++			else if (select && menusub == 0)
++			{
++				degauss_shortcut_begin_keyboard_capture();
++				menustate = MENU_DEGAUSS_SHORTCUT_CAPTURE1;
++			}
++			else if (select && menusub == 1)
++			{
++				menustate = MENU_COMMON1;
++				menusub = DEGAUSS_SHORTCUT_MENUSUB;
++			}
++		}
++		break;
++
++	case MENU_DEGAUSS_SHORTCUT_CAPTURE1:
++		{
++			firstmenu = 0;
++			menumask = 0;
++			OsdSetSize(16);
++			OsdSetTitle("Keyboard shortcut", 0);
++			MenuWrite(0, "");
++			MenuWrite(1, " Press one keyboard key");
++			MenuWrite(2, "");
++			MenuWrite(3, " Pad Menu/B: cancel", 0, 1);
++			for (int n = 4; n < OsdGetSize(); n++) MenuWrite(n, "");
++			menustate = MENU_DEGAUSS_SHORTCUT_CAPTURE2;
++		}
++		break;
++
++	case MENU_DEGAUSS_SHORTCUT_CAPTURE2:
++		if (menu || back)
++		{
++			degauss_shortcut_cancel_keyboard_capture();
++			menustate = MENU_DEGAUSS_SHORTCUT1;
++			menusub = 0;
++		}
++		else
++		{
++			uint16_t key = 0;
++			if (degauss_shortcut_take_keyboard_capture(&key))
++			{
++				degauss_shortcut_save_failed = !degauss_shortcut_set_keyboard(key);
++				menustate = MENU_DEGAUSS_SHORTCUT1;
++				menusub = 0;
++			}
++		}
++		break;
++
+ 	case MENU_VIDEOPROC1:
+ 		helptext_idx = 0;
+ 		menumask = 0x7FFF;
+@@ -7412,10 +7598,21 @@ void HandleUI(void)
+ 			static char cmd[1024 * 2];
+ 			const char *path = getFullPath(selPath);
+ 			menustate = MENU_SCRIPTS_FB2;
++			// Degauss: a frontend is not a script whose output anyone
++			// reads. Remembered here because the state that ends the run
++			// no longer knows which path started it.
++			degauss_running = degauss_is_frontend_script(selPath);
+ 			video_chvt(2);
+ 			video_fb_enable(1);
+ 			vga_nag();
+-			sprintf(cmd, "#!/bin/bash\nexport LC_ALL=en_US.UTF-8\nexport HOME=/root\ncd $(dirname %s)\n%s\necho \"Press any key to continue\"\n", path, path);
++			if (degauss_running)
++			{
++				sprintf(cmd, "#!/bin/bash\nexport LC_ALL=en_US.UTF-8\nexport HOME=/root\ncd $(dirname %s)\n%s\n", path, path);
++			}
++			else
++			{
++				sprintf(cmd, "#!/bin/bash\nexport LC_ALL=en_US.UTF-8\nexport HOME=/root\ncd $(dirname %s)\n%s\necho \"Press any key to continue\"\n", path, path);
++			}
+ 
+ 			unlink("/tmp/script");
+ 			FileSave("/tmp/script", cmd, strlen(cmd));
+@@ -7423,6 +7620,14 @@ void HandleUI(void)
+ 			ttypid = fork();
+ 			if (!ttypid)
+ 			{
++				if (degauss_running)
++				{
++					// -i drops the issue file, -n the login prompt: between
++					// them they are the "Welcome to MiSTer" and "login: root
++					// (automatic login)" that would otherwise flash up
++					// before the frontend has drawn anything.
++					execl("/sbin/agetty", "/sbin/agetty", "-n", "-i", "-a", "root", "-l", "/tmp/script", "--nohostname", "-L", "tty2", "linux", NULL);
++				}
+ 				execl("/sbin/agetty", "/sbin/agetty", "-a", "root", "-l", "/tmp/script", "--nohostname", "-L", "tty2", "linux", NULL);
+ 				exit(0); //should never be reached
+ 			}
+@@ -7440,6 +7645,19 @@ void HandleUI(void)
+ 			{
+ 				ttypid = 0;
+ 				user_io_osd_key_enable(1);
++				// Degauss: nothing was printed for anyone to read, and the
++				// user already chose to leave, so go straight back rather
++				// than asking them to press something first.
++				if (degauss_running)
++				{
++					degauss_running = false;
++					video_menu_bg(user_io_status_get("[3:1]"));
++					video_fb_enable(0);
++					menustate = MENU_SYSTEM1;
++					menusub = 3;
++					OsdClear();
++					OsdEnable(DISABLE_KEYBOARD);
++				}
+ 			}
+ 		}
+ 		else
+diff --git a/menu.h b/menu.h
+index d85deb4..ce8767c 100644
+--- a/menu.h
++++ b/menu.h
+@@ -7,6 +7,7 @@ void SelectFile(const char* path, const char* pFileExt, int Options, unsigned ch
+ 
+ void HandleUI(void);
+ void menu_key_set(unsigned int c);
++bool menu_osd_is_unlocked(void);
+ void menu_process_save();
+ void PrintDirectory(int expand = 0);
+ void ScrollLongName(void);
+diff --git a/support/degauss/README.md b/support/degauss/README.md
+new file mode 100644
+index 0000000..d601ce1
+--- /dev/null
++++ b/support/degauss/README.md
+@@ -0,0 +1,74 @@
++# Degauss integration in MiSTer Main
++
++This directory contains the Degauss-specific integration maintained by the
++Degauss fork of MiSTer Main. A stock Main build ignores Degauss and does not
++read its shortcut configuration.
++
++## Existing frontend handoff
++
++`degauss_launcher.cpp` retains the existing paths:
++
++- A menu-core start hands the framebuffer terminal to
++  `Scripts/degauss.sh` once per Main process.
++- The System menu contains **Frontend** when `fb_terminal=1` and that script
++  exists.
++- A on **Frontend** loads `menu.rbf`. Main then restarts and uses the same
++  handoff path.
++- Starting `degauss.sh` from the Scripts menu uses the same framebuffer
++  execution path without the console banner or final key prompt.
++- Cards without functional Degauss support keep the stock Main behaviour.
++
++## Optional return shortcut
++
++The System menu's **Frontend shortcut** row, directly below **Frontend**, opens
++the shortcut settings with A. The keyboard assignment defaults to Off.
++
++- **Keyboard** captures one physical Linux key code. A starts capture and X
++  clears it.
++- Menu or B cancels keyboard capture.
++- A malformed or unsupported record is displayed as invalid and can only be
++  replaced by explicitly resetting the shortcut to Off.
++
++The runtime shortcut is accepted only when all of these conditions hold:
++
++- Degauss and the framebuffer terminal are available.
++- A non-menu core is running.
++- OSD lock is unlocked.
++- No framebuffer script owns VT 2.
++- A keyboard trigger occurs while the OSD is hidden.
++
++The configured keyboard make, repeat and break events are consumed.
++
++Input processing records one request. `HandleUI` consumes it and loads
++`menu.rbf`; the input path never starts Degauss or loads a core directly.
++
++## Configuration format
++
++The settings are stored at:
++
++```text
++/media/fat/config/degauss/frontend_shortcut.bin
++```
++
++The version 1 record remains a 16-byte little-endian structure containing
++magic, version, record size, keyboard key, a legacy controller byte, a reserved
++byte and a sentinel. The legacy byte keeps files written by pre-release test
++builds readable, but it is ignored and every new save writes it as zero. A
++missing file means the keyboard shortcut is Off. Wrong size, version, field
++range, reserved value, magic or sentinel is invalid. Deleting the file restores
++the missing-file Off default on the next Main start.
++
++## Local verification
++
++The pure configuration and input-state logic is independent of Main's ARM
++dependencies and can be checked on the host:
++
++```bash
++./tests/run-degauss-shortcut-tests.sh
++```
++
++The complete fork build uses the existing containerised ARM toolchain:
++
++```bash
++./build-degauss-main.sh
++```
+diff --git a/support/degauss/degauss_launcher.cpp b/support/degauss/degauss_launcher.cpp
+new file mode 100644
+index 0000000..e850d41
+--- /dev/null
++++ b/support/degauss/degauss_launcher.cpp
+@@ -0,0 +1,53 @@
++// Degauss: hand the menu core to the Degauss frontend.
++//
++// Copyright (C) 2026 Giancarlo Erra
++// SPDX-License-Identifier: GPL-3.0-or-later
++
++#include <stdio.h>
++#include <string.h>
++
++#include "degauss_launcher.h"
++#include "../../cfg.h"
++#include "../../file_io.h"
++#include "../../user_io.h"
++
++// Where the frontend is installed. The same path the Scripts menu would
++// show, so a card that has Degauss already has this and a card that does
++// not is left alone.
++#define DEGAUSS_SCRIPT "Scripts/degauss.sh"
++
++bool degauss_is_frontend_script(const char *path)
++{
++	if (!path) return false;
++	const char *slash = strrchr(path, '/');
++	const char *name = slash ? slash + 1 : path;
++	return !strcmp(name, "degauss.sh");
++}
++
++bool degauss_installed(void)
++{
++	return cfg.fb_terminal && FileExists(DEGAUSS_SCRIPT);
++}
++
++bool degauss_should_take_menu(char *path, int size)
++{
++	// Once per Main process. Main re-executes itself on every core load
++	// (fpga_io.cpp, app_restart), so this static is fresh every time the
++	// menu core comes back, and stays set if the user quits the frontend
++	// to the stock menu. Quitting therefore means quitting, rather than
++	// the frontend reappearing on top of itself.
++	static bool taken = false;
++	if (taken) return false;
++
++	// Only the menu core. A game core must never have its screen taken.
++	if (!is_menu()) return false;
++
++	// Without the framebuffer terminal there is no way to give a program
++	// the screen at all, and the Scripts menu is equally dead. Leaving the
++	// stock menu up is the honest outcome.
++	if (!degauss_installed()) return false;
++
++	taken = true;
++	snprintf(path, size, "%s", DEGAUSS_SCRIPT);
++	return true;
++}
+diff --git a/support/degauss/degauss_launcher.h b/support/degauss/degauss_launcher.h
+new file mode 100644
+index 0000000..5fe1dd8
+--- /dev/null
++++ b/support/degauss/degauss_launcher.h
+@@ -0,0 +1,45 @@
++// Degauss: hand the menu core to the Degauss frontend.
++//
++// Copyright (C) 2026 Giancarlo Erra
++// SPDX-License-Identifier: GPL-3.0-or-later
++//
++// This file is part of a fork of MiSTer Main and is therefore GPL-3.0, the
++// same as Main itself. The Degauss frontend is a separate program under a
++// different licence; nothing here links against it. All this does is start
++// it the same way the Scripts menu starts any other script.
++
++#ifndef DEGAUSS_LAUNCHER_H
++#define DEGAUSS_LAUNCHER_H
++
++// True when the menu core has just come up and the frontend should be given
++// the screen. Answers true at most once per Main process, and Main re-execs
++// itself on every core load, so that is once per return to the menu.
++//
++// Writes the script path into `path`, in the form the Scripts menu uses:
++// relative to the root directory.
++bool degauss_should_take_menu(char *path, int size);
++
++// Which entries of the core's System menu the Degauss items occupy.
++//
++// menumask bits are menusub values, not line positions, so an item can be
++// drawn anywhere and numbered anything free. The number still decides the
++// order the stick walks through them. These two are deliberately above every
++// upstream entry and consecutive: Frontend walks down to Frontend shortcut,
++// then wraps to Core. Up walks through the same visible order in reverse.
++#define DEGAUSS_MENUSUB 30
++#define DEGAUSS_SHORTCUT_MENUSUB 31
++
++// True when `path` names the frontend's own script.
++//
++// The frontend draws its own screen and leaves on purpose, so it wants
++// neither the console banner on the way in nor the "press any key" on the
++// way out that an ordinary shell script needs. Asking about the path
++// rather than about how it was started covers both routes to it: the
++// automatic handover above, and picking it from the Scripts menu by hand.
++bool degauss_is_frontend_script(const char *path);
++
++// True when the frontend script and framebuffer terminal are available, so
++// the Frontend entry can work. Other cards get the stock menu untouched.
++bool degauss_installed(void);
++
++#endif
+diff --git a/support/degauss/degauss_shortcut.cpp b/support/degauss/degauss_shortcut.cpp
+new file mode 100644
+index 0000000..3615922
+--- /dev/null
++++ b/support/degauss/degauss_shortcut.cpp
+@@ -0,0 +1,188 @@
++// Degauss frontend shortcut integration for MiSTer Main.
++//
++// Copyright (C) 2026 Giancarlo Erra
++// SPDX-License-Identifier: GPL-3.0-or-later
++
++#include <stdio.h>
++#include <string.h>
++
++#include "degauss_shortcut.h"
++#include "degauss_launcher.h"
++#include "../../file_io.h"
++#include "../../menu.h"
++#include "../../user_io.h"
++#include "../../video.h"
++
++namespace
++{
++
++constexpr const char *CONFIG_NAME = "degauss/frontend_shortcut.bin";
++constexpr const char *CONFIG_PATH = CONFIG_DIR "/degauss/frontend_shortcut.bin";
++
++using degauss_shortcut_logic::ConfigV1;
++using degauss_shortcut_logic::KeyboardRuntimeState;
++using degauss_shortcut_logic::RequestState;
++
++ConfigV1 config = degauss_shortcut_logic::make_config(0);
++DegaussShortcutLoadState load_state = DEGAUSS_SHORTCUT_MISSING;
++bool loaded = false;
++RequestState request_state;
++
++bool capture_active = false;
++bool capture_ready = false;
++uint16_t capture_key = 0;
++uint16_t capture_release_key = 0;
++
++KeyboardRuntimeState keyboard_state;
++
++void ensure_loaded()
++{
++	if (loaded) return;
++	loaded = true;
++
++	const bool exists = FileExists(CONFIG_PATH);
++	const int size = FileLoadConfig(CONFIG_NAME, nullptr, 0);
++	ConfigV1 candidate = {};
++	const bool read = size == static_cast<int>(sizeof(candidate))
++		&& FileLoadConfig(CONFIG_NAME, &candidate, sizeof(candidate))
++			== static_cast<int>(sizeof(candidate));
++	const degauss_shortcut_logic::ConfigLoadResult result =
++		degauss_shortcut_logic::classify_config(exists, size,
++			read ? &candidate : nullptr);
++
++	if (result == degauss_shortcut_logic::CONFIG_MISSING) return;
++	if (result == degauss_shortcut_logic::CONFIG_INVALID)
++	{
++		load_state = DEGAUSS_SHORTCUT_INVALID;
++		printf("Degauss shortcut config is invalid or unsupported (size %d): %s\n",
++			size, CONFIG_PATH);
++		return;
++	}
++
++	config = candidate;
++	load_state = DEGAUSS_SHORTCUT_VALID;
++}
++
++bool save_config(const ConfigV1 &candidate)
++{
++	if (!degauss_shortcut_logic::config_valid(candidate)) return false;
++
++	ConfigV1 stored = candidate;
++	if (FileSaveConfig(CONFIG_NAME, &stored, sizeof(stored))
++		!= static_cast<int>(sizeof(stored)))
++	{
++		printf("Degauss shortcut config save failed: %s\n", CONFIG_PATH);
++		return false;
++	}
++
++	config = candidate;
++	load_state = DEGAUSS_SHORTCUT_VALID;
++	loaded = true;
++	return true;
++}
++
++bool runtime_eligible(bool require_hidden_osd)
++{
++	const degauss_shortcut_logic::RuntimeConditions conditions = {
++		degauss_installed(),
++		is_menu() != 0,
++		menu_osd_is_unlocked(),
++		video_fb_state() && video_chvt(0) == 2,
++		user_io_osd_is_visible() != 0
++	};
++	return degauss_shortcut_logic::runtime_eligible(conditions, require_hidden_osd);
++}
++
++} // namespace
++
++DegaussShortcutLoadState degauss_shortcut_load_state(void)
++{
++	ensure_loaded();
++	return load_state;
++}
++
++uint16_t degauss_shortcut_keyboard_key(void)
++{
++	ensure_loaded();
++	return load_state == DEGAUSS_SHORTCUT_INVALID ? 0 : config.keyboard_key;
++}
++
++bool degauss_shortcut_set_keyboard(uint16_t key)
++{
++	ensure_loaded();
++	if (load_state == DEGAUSS_SHORTCUT_INVALID
++		|| !degauss_shortcut_logic::valid_keyboard_key(key))
++	{
++		return false;
++	}
++
++	return save_config(degauss_shortcut_logic::make_config(key));
++}
++
++bool degauss_shortcut_reset(void)
++{
++	return save_config(degauss_shortcut_logic::make_config(0));
++}
++
++void degauss_shortcut_begin_keyboard_capture(void)
++{
++	capture_active = true;
++	capture_ready = false;
++	capture_key = 0;
++}
++
++void degauss_shortcut_cancel_keyboard_capture(void)
++{
++	capture_active = false;
++	capture_ready = false;
++	capture_key = 0;
++}
++
++bool degauss_shortcut_take_keyboard_capture(uint16_t *key)
++{
++	if (!capture_ready) return false;
++	if (key) *key = capture_key;
++	capture_ready = false;
++	return true;
++}
++
++bool degauss_shortcut_handle_keyboard_event(uint16_t key, int value, bool menu_event)
++{
++	ensure_loaded();
++
++	if (!menu_event && capture_active)
++	{
++		if (value == 1 && key)
++		{
++			capture_active = false;
++			capture_ready = true;
++			capture_key = key;
++			capture_release_key = key;
++		}
++		return true;
++	}
++
++	if (!menu_event && capture_release_key && key == capture_release_key)
++	{
++		if (!value) capture_release_key = 0;
++		return true;
++	}
++
++	if (menu_event || load_state == DEGAUSS_SHORTCUT_INVALID) return false;
++
++	const bool needs_eligibility = !keyboard_state.consumed_key
++		&& config.keyboard_key
++		&& key == config.keyboard_key
++		&& value == 1;
++	bool triggered = false;
++	const bool consumed = keyboard_state.event(config.keyboard_key, key, value,
++		needs_eligibility && runtime_eligible(true), triggered);
++	if (triggered) request_state.request();
++	return consumed;
++}
++
++bool degauss_shortcut_take_request(void)
++{
++	if (!request_state.pending) return false;
++	return request_state.take(runtime_eligible(false));
++}
+diff --git a/support/degauss/degauss_shortcut.h b/support/degauss/degauss_shortcut.h
+new file mode 100644
+index 0000000..7dde22f
+--- /dev/null
++++ b/support/degauss/degauss_shortcut.h
+@@ -0,0 +1,38 @@
++// Degauss frontend shortcut integration for MiSTer Main.
++//
++// Copyright (C) 2026 Giancarlo Erra
++// SPDX-License-Identifier: GPL-3.0-or-later
++
++#ifndef DEGAUSS_SHORTCUT_H
++#define DEGAUSS_SHORTCUT_H
++
++#include <stdint.h>
++
++#include "degauss_shortcut_logic.h"
++
++enum DegaussShortcutLoadState
++{
++	DEGAUSS_SHORTCUT_MISSING,
++	DEGAUSS_SHORTCUT_VALID,
++	DEGAUSS_SHORTCUT_INVALID
++};
++
++// Configuration access. A missing file is the documented Off default.
++DegaussShortcutLoadState degauss_shortcut_load_state(void);
++uint16_t degauss_shortcut_keyboard_key(void);
++bool degauss_shortcut_set_keyboard(uint16_t key);
++bool degauss_shortcut_reset(void);
++
++// Keyboard capture is initiated by the OSD and completed by a physical Linux
++// keyboard event. Controller-generated menu events are excluded by the caller.
++void degauss_shortcut_begin_keyboard_capture(void);
++void degauss_shortcut_cancel_keyboard_capture(void);
++bool degauss_shortcut_take_keyboard_capture(uint16_t *key);
++
++// The input hook returns true when the current event must not reach the core.
++bool degauss_shortcut_handle_keyboard_event(uint16_t key, int value, bool menu_event);
++
++// The input path only records a request. HandleUI performs the core load.
++bool degauss_shortcut_take_request(void);
++
++#endif
+diff --git a/support/degauss/degauss_shortcut_logic.h b/support/degauss/degauss_shortcut_logic.h
+new file mode 100644
+index 0000000..bc47972
+--- /dev/null
++++ b/support/degauss/degauss_shortcut_logic.h
+@@ -0,0 +1,173 @@
++// Pure state and file-format logic for the Degauss frontend shortcut.
++//
++// Copyright (C) 2026 Giancarlo Erra
++// SPDX-License-Identifier: GPL-3.0-or-later
++
++#ifndef DEGAUSS_SHORTCUT_LOGIC_H
++#define DEGAUSS_SHORTCUT_LOGIC_H
++
++#include <stddef.h>
++#include <stdint.h>
++
++namespace degauss_shortcut_logic
++{
++
++// Version 1 briefly exposed a controller shortcut before release. Keep its
++// byte range readable so test cards do not need their configuration deleted,
++// but every keyboard-only save writes the field back to zero.
++constexpr uint8_t LEGACY_CONTROLLER_OFF = 0;
++constexpr uint8_t LEGACY_CONTROLLER_COUNT = 9;
++
++enum ConfigLoadResult : uint8_t
++{
++	CONFIG_MISSING,
++	CONFIG_VALID,
++	CONFIG_INVALID
++};
++
++// Stored separately from MiSTer.ini so a stock Main build ignores the feature.
++// Fixed-width fields, size, version, and sentinels make truncated, future, and
++// corrupt records distinguishable from a deliberately disabled configuration.
++struct ConfigV1
++{
++	uint32_t magic;
++	uint16_t version;
++	uint16_t size;
++	uint16_t keyboard_key;
++	uint8_t legacy_controller_button;
++	uint8_t reserved;
++	uint32_t sentinel;
++};
++
++static_assert(sizeof(ConfigV1) == 16, "Degauss shortcut config must remain stable");
++static_assert(offsetof(ConfigV1, magic) == 0, "Config magic offset changed");
++static_assert(offsetof(ConfigV1, version) == 4, "Config version offset changed");
++static_assert(offsetof(ConfigV1, size) == 6, "Config size offset changed");
++static_assert(offsetof(ConfigV1, keyboard_key) == 8, "Config key offset changed");
++static_assert(offsetof(ConfigV1, legacy_controller_button) == 10,
++	"Config legacy controller offset changed");
++static_assert(offsetof(ConfigV1, reserved) == 11, "Config reserved offset changed");
++static_assert(offsetof(ConfigV1, sentinel) == 12, "Config sentinel offset changed");
++
++constexpr uint32_t CONFIG_MAGIC = 0x43534744; // "DGSC" on little-endian ARM
++constexpr uint16_t CONFIG_VERSION = 1;
++constexpr uint32_t CONFIG_SENTINEL = 0xA55A5AA5;
++// Linux input-event-codes.h defines KEY_MAX as 0x2ff. Keep the pure logic
++// header independent of Linux headers so its tests also compile on the host;
++// input.cpp asserts this value against the target toolchain's KEY_MAX.
++constexpr uint16_t MAX_KEYBOARD_KEY = 0x02ff;
++constexpr uint16_t PRIMARY_BUTTON_FIRST = 0x0100;
++constexpr uint16_t PRIMARY_BUTTON_LAST = 0x0151;
++constexpr uint16_t DPAD_BUTTON_FIRST = 0x0220;
++constexpr uint16_t DPAD_BUTTON_LAST = 0x0223;
++constexpr uint16_t TRIGGER_BUTTON_FIRST = 0x02c0;
++constexpr uint16_t TRIGGER_BUTTON_LAST = 0x02e7;
++
++inline bool valid_keyboard_key(uint16_t key)
++{
++	if (key > MAX_KEYBOARD_KEY) return false;
++	return !(key >= PRIMARY_BUTTON_FIRST && key <= PRIMARY_BUTTON_LAST)
++		&& !(key >= DPAD_BUTTON_FIRST && key <= DPAD_BUTTON_LAST)
++		&& !(key >= TRIGGER_BUTTON_FIRST && key <= TRIGGER_BUTTON_LAST);
++}
++
++inline ConfigV1 make_config(uint16_t keyboard_key)
++{
++	return {
++		CONFIG_MAGIC,
++		CONFIG_VERSION,
++		static_cast<uint16_t>(sizeof(ConfigV1)),
++		keyboard_key,
++		LEGACY_CONTROLLER_OFF,
++		0,
++		CONFIG_SENTINEL
++	};
++}
++
++inline bool config_valid(const ConfigV1 &config)
++{
++	return config.magic == CONFIG_MAGIC
++		&& config.version == CONFIG_VERSION
++		&& config.size == sizeof(ConfigV1)
++		&& valid_keyboard_key(config.keyboard_key)
++		&& config.legacy_controller_button < LEGACY_CONTROLLER_COUNT
++		&& config.reserved == 0
++		&& config.sentinel == CONFIG_SENTINEL;
++}
++
++inline ConfigLoadResult classify_config(bool file_exists, uint32_t file_size,
++	const ConfigV1 *record)
++{
++	if (!file_exists) return CONFIG_MISSING;
++	if (file_size != sizeof(ConfigV1) || !record || !config_valid(*record))
++	{
++		return CONFIG_INVALID;
++	}
++	return CONFIG_VALID;
++}
++
++struct RuntimeConditions
++{
++	bool frontend_available;
++	bool menu_core;
++	bool osd_unlocked;
++	bool framebuffer_script;
++	bool osd_visible;
++};
++
++inline bool runtime_eligible(const RuntimeConditions &conditions,
++	bool require_hidden_osd)
++{
++	return conditions.frontend_available
++		&& !conditions.menu_core
++		&& conditions.osd_unlocked
++		&& !conditions.framebuffer_script
++		&& (!require_hidden_osd || !conditions.osd_visible);
++}
++
++struct RequestState
++{
++	bool pending = false;
++
++	void request()
++	{
++		pending = true;
++	}
++
++	bool take(bool eligible)
++	{
++		const bool result = pending && eligible;
++		pending = false;
++		return result;
++	}
++};
++
++struct KeyboardRuntimeState
++{
++	uint16_t consumed_key = 0;
++
++	bool event(uint16_t configured_key, uint16_t key, int value,
++		bool eligible, bool &triggered)
++	{
++		triggered = false;
++
++		if (consumed_key && key == consumed_key)
++		{
++			if (!value) consumed_key = 0;
++			return true;
++		}
++
++		if (!configured_key || key != configured_key || value != 1 || !eligible)
++		{
++			return false;
++		}
++
++		consumed_key = key;
++		triggered = true;
++		return true;
++	}
++};
++
++} // namespace degauss_shortcut_logic
++
++#endif
+diff --git a/tests/degauss_shortcut_logic_test.cpp b/tests/degauss_shortcut_logic_test.cpp
+new file mode 100644
+index 0000000..e627958
+--- /dev/null
++++ b/tests/degauss_shortcut_logic_test.cpp
+@@ -0,0 +1,145 @@
++#include <assert.h>
++#include <stdint.h>
++#include <string.h>
++
++#include "../support/degauss/degauss_shortcut_logic.h"
++
++using namespace degauss_shortcut_logic;
++
++static void test_config_validation()
++{
++	const uint16_t braille_dot_1 = 0x01f1;
++	assert(MAX_KEYBOARD_KEY == 0x02ff);
++	assert(config_valid(make_config(braille_dot_1)));
++	assert(config_valid(make_config(0x02bb)));
++	assert(!config_valid(make_config(PRIMARY_BUTTON_FIRST)));
++	assert(!config_valid(make_config(PRIMARY_BUTTON_LAST)));
++	assert(!config_valid(make_config(DPAD_BUTTON_FIRST)));
++	assert(!config_valid(make_config(DPAD_BUTTON_LAST)));
++	assert(!config_valid(make_config(TRIGGER_BUTTON_FIRST)));
++	assert(!config_valid(make_config(TRIGGER_BUTTON_LAST)));
++
++	ConfigV1 config = make_config(87);
++	assert(config_valid(config));
++
++	config.magic = 0;
++	assert(!config_valid(config));
++	config = make_config(87);
++	config.version++;
++	assert(!config_valid(config));
++	config = make_config(87);
++	config.size--;
++	assert(!config_valid(config));
++	config = make_config(87);
++	config.keyboard_key = MAX_KEYBOARD_KEY + 1;
++	assert(!config_valid(config));
++	config = make_config(87);
++	config.legacy_controller_button = LEGACY_CONTROLLER_COUNT;
++	assert(!config_valid(config));
++	config = make_config(87);
++	config.reserved = 1;
++	assert(!config_valid(config));
++	config = make_config(87);
++	config.sentinel = 0;
++	assert(!config_valid(config));
++
++	config = make_config(87);
++	ConfigV1 reloaded = {};
++	memcpy(&reloaded, &config, sizeof(config));
++	assert(config_valid(reloaded));
++	assert(!memcmp(&config, &reloaded, sizeof(config)));
++	const uint8_t expected_bytes[] = {
++		0x44, 0x47, 0x53, 0x43,
++		0x01, 0x00,
++		0x10, 0x00,
++		0x57, 0x00,
++		LEGACY_CONTROLLER_OFF, 0x00,
++		0xA5, 0x5A, 0x5A, 0xA5
++	};
++	assert(sizeof(expected_bytes) == sizeof(config));
++	assert(!memcmp(&config, expected_bytes, sizeof(config)));
++
++	const ConfigV1 cleared = make_config(0);
++	assert(config_valid(cleared));
++	assert(cleared.keyboard_key == 0);
++	assert(cleared.legacy_controller_button == LEGACY_CONTROLLER_OFF);
++
++	// A file written by the unreleased controller-capable build remains valid,
++	// but every new keyboard-only save clears its legacy controller byte.
++	ConfigV1 legacy = make_config(87);
++	legacy.legacy_controller_button = LEGACY_CONTROLLER_COUNT - 1;
++	assert(config_valid(legacy));
++	const ConfigV1 next_save = make_config(legacy.keyboard_key);
++	assert(next_save.keyboard_key == legacy.keyboard_key);
++	assert(next_save.legacy_controller_button == LEGACY_CONTROLLER_OFF);
++
++	assert(classify_config(false, 0, nullptr) == CONFIG_MISSING);
++	assert(classify_config(true, 0, nullptr) == CONFIG_INVALID);
++	assert(classify_config(true, sizeof(config) - 1, &config) == CONFIG_INVALID);
++	assert(classify_config(true, sizeof(config), nullptr) == CONFIG_INVALID);
++	assert(classify_config(true, sizeof(config), &config) == CONFIG_VALID);
++}
++
++static void test_runtime_conditions_and_request()
++{
++	RuntimeConditions conditions = { true, false, true, false, false };
++	assert(runtime_eligible(conditions, true));
++
++	conditions.frontend_available = false;
++	assert(!runtime_eligible(conditions, false));
++	conditions = { true, true, true, false, false };
++	assert(!runtime_eligible(conditions, false));
++	conditions = { true, false, false, false, false };
++	assert(!runtime_eligible(conditions, false));
++	conditions = { true, false, true, true, false };
++	assert(!runtime_eligible(conditions, false));
++	conditions = { true, false, true, false, true };
++	assert(runtime_eligible(conditions, false));
++	assert(!runtime_eligible(conditions, true));
++
++	RequestState request;
++	assert(!request.take(true));
++	request.request();
++	request.request();
++	assert(request.take(true));
++	assert(!request.take(true));
++	request.request();
++	assert(!request.take(false));
++	assert(!request.take(true));
++}
++
++static void test_keyboard_runtime()
++{
++	KeyboardRuntimeState state;
++	bool triggered = false;
++
++	assert(!state.event(0, 87, 1, true, triggered));
++	assert(!triggered);
++	assert(!state.event(87, 86, 1, true, triggered));
++	assert(!state.event(87, 87, 1, false, triggered));
++
++	assert(state.event(87, 87, 1, true, triggered));
++	assert(triggered);
++	assert(state.event(87, 87, 2, false, triggered));
++	assert(!triggered);
++	assert(state.event(87, 87, 0, false, triggered));
++	assert(!state.event(87, 87, 0, true, triggered));
++
++	// Linux keyboard codes above MiSTer's legacy 256-entry keyboard map remain
++	// valid shortcut keys and retain the same make, repeat and break behavior.
++	const uint16_t braille_dot_1 = 0x01f1;
++	KeyboardRuntimeState high_key_state;
++	assert(high_key_state.event(braille_dot_1, braille_dot_1, 1, true, triggered));
++	assert(triggered);
++	assert(high_key_state.event(braille_dot_1, braille_dot_1, 2, false, triggered));
++	assert(!triggered);
++	assert(high_key_state.event(braille_dot_1, braille_dot_1, 0, false, triggered));
++}
++
++int main()
++{
++	test_config_validation();
++	test_runtime_conditions_and_request();
++	test_keyboard_runtime();
++	return 0;
++}
+diff --git a/tests/run-degauss-shortcut-tests.sh b/tests/run-degauss-shortcut-tests.sh
+new file mode 100755
+index 0000000..64a4e88
+--- /dev/null
++++ b/tests/run-degauss-shortcut-tests.sh
+@@ -0,0 +1,64 @@
++#!/usr/bin/env bash
++set -euo pipefail
++
++cd "$(dirname "$0")/.."
++
++test_binary="$(mktemp -t degauss-shortcut-test.XXXXXX)"
++trap 'rm -f "$test_binary"' EXIT
++
++${CXX:-c++} -std=c++14 -Wall -Wextra -Werror \
++	-I. tests/degauss_shortcut_logic_test.cpp -o "$test_binary"
++"$test_binary"
++
++# The shortcut must use the physical Linux key. Moving its hook below either
++# transformation makes a saved assignment depend on the active keyboard map.
++shortcut_hook_line="$(grep -n 'degauss_shortcut_handle_keyboard_event' input.cpp | cut -d: -f1)"
++keyboard_map_guard_line="$(grep -n 'if (ev->type == EV_KEY && ev->code < 256' input.cpp | head -1 | cut -d: -f1)"
++keyboard_map_line="$(grep -n 'kbdmap\[ev->code\]' input.cpp | cut -d: -f1)"
++keyrah_line="$(grep -n 'ev->code = keyrah_trans' input.cpp | cut -d: -f1)"
++
++test -n "$shortcut_hook_line"
++test "$shortcut_hook_line" -lt "$keyboard_map_guard_line"
++test "$shortcut_hook_line" -lt "$keyboard_map_line"
++test "$shortcut_hook_line" -lt "$keyrah_line"
++grep -B8 'degauss_shortcut_handle_keyboard_event' input.cpp | grep -q 'valid_keyboard_key(ev->code)'
++grep -B8 'degauss_shortcut_handle_keyboard_event' input.cpp | grep -q '!input\[dev\]\.force_joy'
++grep -q 'uint8_t  kbdmap\[256\]' input.cpp
++
++# The two Degauss rows must follow their visible order when Up or Down changes
++# menusub. They stay above every stock System-menu index, with no controller
++# direction required to open the shortcut settings.
++frontend_menusub="$(awk '$2 == "DEGAUSS_MENUSUB" { print $3 }' support/degauss/degauss_launcher.h)"
++shortcut_menusub="$(awk '$2 == "DEGAUSS_SHORTCUT_MENUSUB" { print $3 }' support/degauss/degauss_launcher.h)"
++test "$frontend_menusub" -eq 30
++test "$shortcut_menusub" -eq 31
++
++frontend_row_line="$(grep -n 'MenuWrite(n++, " Frontend ' menu.cpp | head -1 | cut -d: -f1)"
++shortcut_row_line="$(grep -n 'MenuWrite(n++, " Frontend shortcut' menu.cpp | cut -d: -f1)"
++core_row_line="$(grep -n 'MenuWrite(n++, " Core ' menu.cpp | head -1 | cut -d: -f1)"
++test "$frontend_row_line" -lt "$shortcut_row_line"
++test "$shortcut_row_line" -lt "$core_row_line"
++
++if grep -q 'right && menusub == DEGAUSS_MENUSUB' menu.cpp; then
++	echo "Frontend shortcut still depends on Right from the Frontend row" >&2
++	exit 1
++fi
++grep -A4 'case DEGAUSS_SHORTCUT_MENUSUB:' menu.cpp \
++	| grep -q 'menustate = MENU_DEGAUSS_SHORTCUT1'
++
++# The release UI and input path are keyboard-only. Version 1 keeps a legacy
++# byte solely so files written by local pre-release builds remain readable.
++if grep -q ' Controller:' menu.cpp; then
++	echo "Frontend shortcut UI still exposes a controller assignment" >&2
++	exit 1
++fi
++if grep -q 'degauss_shortcut_handle_controller_event' input.cpp; then
++	echo "Frontend shortcut input still handles controller events" >&2
++	exit 1
++fi
++grep -q 'legacy_controller_button' support/degauss/degauss_shortcut_logic.h
++grep -q ' A: Capture   X: Disable' menu.cpp
++if grep -q 'set/capture' menu.cpp; then
++	echo "Frontend shortcut UI still uses the ambiguous set/capture label" >&2
++	exit 1
++fi

--- a/support/ra-main/tls.patch
+++ b/support/ra-main/tls.patch
@@ -1,18 +1,38 @@
-diff --git a/ra_http.cpp b/ra_http.cpp
-index 4ff5bb8..0daa303 100644
 --- a/ra_http.cpp
 +++ b/ra_http.cpp
-@@ -13,6 +13,9 @@
+@@ -1,6 +1,6 @@
+ // ra_http.cpp — Asynchronous HTTP for RetroAchievements on MiSTer
+ //
+-// Worker thread executes curl via popen(), responses are queued back to the
++// Worker thread executes curl via posix_spawnp(), responses are queued back to the
+ // main thread for safe rc_client callback dispatch.
+ 
+ #include "ra_http.h"
+@@ -13,6 +13,14 @@
  #include <sched.h>
  #include <errno.h>
  #include <unistd.h>
 +#include <limits.h>
 +#include <sys/wait.h>
 +#include <string>
++#include <spawn.h>
++#include <sys/socket.h>
++#include <fcntl.h>
++
++extern char **environ;
  
  // ---------------------------------------------------------------------------
  // Debug (uses same style as achievements.cpp)
-@@ -100,49 +103,38 @@ static void buf_append(struct buf *b, const char *chunk, size_t n)
+@@ -68,7 +76,7 @@
+ }
+ 
+ // ---------------------------------------------------------------------------
+-// curl execution via popen()
++// curl execution via posix_spawnp()
+ // ---------------------------------------------------------------------------
+ 
+ // Grow-able buffer for reading curl output
+@@ -100,49 +108,56 @@
  	b->data[b->len] = '\0';
  }
  
@@ -20,8 +40,7 @@ index 4ff5bb8..0daa303 100644
 -// We write status code on a separate last line using -w '\n%{http_code}'.
 -static char *build_curl_cmd(const char *url, const char *post_data,
 -	const char *content_type)
-+static std::string shell_quote(const char *value)
- {
+-{
 -	// Estimate command length
 -	size_t len = 256 + strlen(url);
 -	if (post_data) len += strlen(post_data) + 32;
@@ -55,17 +74,39 @@ index 4ff5bb8..0daa303 100644
 -		} else {
 -			cmd[off++] = *p;
 -		}
-+	std::string quoted = "'";
-+	for (const char *p = value; *p; ++p) {
-+		if (*p == '\'') quoted += "'\\''";
-+		else quoted += *p;
- 	}
+-	}
 -	off += snprintf(cmd + off, len - off, "'");
 -	cmd[off] = '\0';
-+	return quoted + "'";
-+}
- 
+-
 -	return cmd;
++// curl config values are quoted separately from shell syntax. No shell runs.
++static std::string config_quote(const char *value)
++{
++ std::string quoted = "\"";
++ for (const char *p = value; *p; ++p) {
++  switch (*p) {
++  case '\\': quoted += "\\\\"; break;
++  case '"': quoted += "\\\""; break;
++  case '\n': quoted += "\\n"; break;
++  case '\r': quoted += "\\r"; break;
++  case '\t': quoted += "\\t"; break;
++  case '\v': quoted += "\\v"; break;
++  default: quoted += *p;
++  }
++ }
++ return quoted + "\"\n";
++}
++
++static void process_error(ra_http_resp *resp, const char *operation, int error)
++{
++ resp->http_status = -1;
++ char message[192];
++ snprintf(message, sizeof(message), "curl %s failed: %s", operation, strerror(error));
++ resp->body = strdup(message);
++ resp->body_len = resp->body ? strlen(resp->body) : 0;
++ HTTP_LOG("ERROR: %s", message);
++}
++
 +// Report transport failures without copying URLs, POST bodies, or credentials.
 +static void transport_error(ra_http_resp *resp, int code)
 +{
@@ -91,7 +132,7 @@ index 4ff5bb8..0daa303 100644
  }
  
  static void execute_request(ra_http_req *req, ra_http_resp *resp)
-@@ -153,84 +145,38 @@ static void execute_request(ra_http_req *req, ra_http_resp *resp)
+@@ -153,104 +168,151 @@
  	resp->body = NULL;
  	resp->body_len = 0;
  
@@ -116,13 +157,10 @@ index 4ff5bb8..0daa303 100644
 +		transport_error(resp, 77);
  		return;
  	}
-+	memcpy(ca_path + ca_length, ".cacert.pem", sizeof(".cacert.pem"));
- 
+-
 -	int off = 0;
 -
-+	// One quoting path and dynamically sized storage cover every shell argument.
-+	std::string cmd;
- 	if (req->post_data && req->post_data[0]) {
+-	if (req->post_data && req->post_data[0]) {
 -		// Use printf to feed POST body into curl's stdin.
 -		// Shell-escape the post_data using single-quote wrapping
 -		// (replace each ' with '\'' ).
@@ -135,30 +173,20 @@ index 4ff5bb8..0daa303 100644
 -			}
 -		}
 -		off += snprintf(cmd + off, cmd_len - off, "' | ");
-+		cmd = "printf '%s' " + shell_quote(req->post_data) + " | ";
- 	}
+-	}
 -
 -	// curl base flags (-k: skip SSL cert verification — MiSTer CA bundle is outdated)
 -	off += snprintf(cmd + off, cmd_len - off,
 -		"curl -s -k -L --max-time 30 -w '\\n%%{http_code}' -A '%s'", s_user_agent);
 -
-+	// -q must be first: a curlrc must not disable verification or add requests.
-+	cmd += "curl -q -s -L --proto '=https' --proto-redir '=https' --max-time 30"
-+		" -w '\\n%{http_code}' -A " + shell_quote(s_user_agent);
-+	cmd += " --cacert " + shell_quote(ca_path);
- 	if (req->post_data && req->post_data[0]) {
+-	if (req->post_data && req->post_data[0]) {
 -		const char *ct = (req->content_type && req->content_type[0])
 -			? req->content_type
 -			: "application/x-www-form-urlencoded";
 -		off += snprintf(cmd + off, cmd_len - off,
 -			" -X POST -H 'Content-Type: %s' --data-binary @-", ct);
-+		const char *ct = req->content_type && req->content_type[0]
-+			? req->content_type : "application/x-www-form-urlencoded";
-+		cmd += " -X POST -H " + shell_quote((std::string("Content-Type: ") + ct).c_str());
-+		cmd += " --data-binary @-";
- 	}
-+	cmd += " " + shell_quote(req->url);
- 
+-	}
+-
 -	// URL: single-quote wrapped with ' escaped as '\''
 -	off += snprintf(cmd + off, cmd_len - off, " '");
 -	for (const char *p = req->url; *p && (size_t)off < cmd_len - 10; p++) {
@@ -190,19 +218,145 @@ index 4ff5bb8..0daa303 100644
 -			free(masked);
 -		}
 -	}
-+	// Never log the command: its POST body can contain login credentials.
-+	HTTP_LOG("Request: HTTPS %s", req->post_data && req->post_data[0] ? "POST" : "GET");
- 
+-
 -	FILE *fp = popen(cmd, "r");
 -	free(cmd);
-+	FILE *fp = popen(cmd.c_str(), "r");
+-
+-	if (!fp) {
+-		HTTP_LOG("ERROR: popen() failed: %s", strerror(errno));
+-		resp->body = strdup("popen() failed");
+-		resp->body_len = resp->body ? strlen(resp->body) : 0;
+-		return;
+-	}
++	memcpy(ca_path + ca_length, ".cacert.pem", sizeof(".cacert.pem"));
++
++ // All request values travel through stdin, never process arguments or disk.
++ std::string config = "url = " + config_quote(req->url);
++ config += "user-agent = " + config_quote(s_user_agent);
++ config += "cacert = " + config_quote(ca_path);
++ if (req->post_data && req->post_data[0]) {
++  const char *ct = req->content_type && req->content_type[0]
++   ? req->content_type : "application/x-www-form-urlencoded";
++  config += "request = POST\nheader = " + config_quote((std::string("Content-Type: ") + ct).c_str());
++  config += "data-raw = " + config_quote(req->post_data);
++ }
++ HTTP_LOG("Request: HTTPS %s", req->post_data && req->post_data[0] ? "POST" : "GET");
++
++ int input[2] = {-1, -1}, output_fd[2] = {-1, -1};
++ auto close_pipes = [&]() {
++  for (int fd : {input[0], input[1], output_fd[0], output_fd[1]})
++   if (fd >= 0) close(fd);
++ };
++ if (socketpair(AF_UNIX, SOCK_STREAM, 0, input) || pipe(output_fd)) {
++  int error = errno;
++  close_pipes();
++  process_error(resp, "pipe creation", error);
++  return;
++ }
++ // A launcher may leave a standard stream closed. Keep owned descriptors
++ // above stderr so spawn cleanup cannot close a redirected standard stream.
++ for (int *fd : {&input[0], &input[1], &output_fd[0], &output_fd[1]}) {
++  if (*fd < 3) {
++   int promoted = fcntl(*fd, F_DUPFD_CLOEXEC, 3);
++   if (promoted < 0) {
++    int error = errno;
++    close_pipes();
++    process_error(resp, "pipe setup", error);
++    return;
++   }
++   close(*fd);
++   *fd = promoted;
++  }
++  if (fcntl(*fd, F_SETFD, FD_CLOEXEC) < 0) {
++   int error = errno;
++   close_pipes();
++   process_error(resp, "pipe setup", error);
++   return;
++  }
++ }
++#ifdef SO_NOSIGPIPE
++ int no_sigpipe = 1;
++ if (setsockopt(input[0], SOL_SOCKET, SO_NOSIGPIPE, &no_sigpipe, sizeof(no_sigpipe))) {
++  int error = errno;
++  close_pipes();
++  process_error(resp, "pipe setup", error);
++  return;
++ }
++#endif
++ posix_spawn_file_actions_t actions;
++ int error = posix_spawn_file_actions_init(&actions);
++ if (error) {
++  close_pipes();
++  process_error(resp, "spawn setup", error);
++  return;
++ }
++ error = posix_spawn_file_actions_adddup2(&actions, input[1], STDIN_FILENO);
++ if (!error) error = posix_spawn_file_actions_adddup2(&actions, output_fd[1], STDOUT_FILENO);
++ // curl config errors can quote request values; expose only its safe exit cause.
++ if (!error) error = posix_spawn_file_actions_addopen(&actions, STDERR_FILENO, "/dev/null", O_WRONLY, 0);
++ for (int fd : {input[0], input[1], output_fd[0], output_fd[1]})
++  if (!error) error = posix_spawn_file_actions_addclose(&actions, fd);
++ const char *args[] = {"curl", "-q", "-s", "-L", "--proto", "=https",
++  "--proto-redir", "=https", "--max-time", "30", "-w", "\n%{http_code}", "--config", "-", nullptr};
++ pid_t child = -1;
++ if (!error) error = posix_spawnp(&child, "curl", &actions, nullptr,
++  const_cast<char **>(args), environ);
++ posix_spawn_file_actions_destroy(&actions);
++ if (error) {
++  close_pipes();
++  if (error == ENOENT) transport_error(resp, 127);
++  else process_error(resp, "spawn", error);
++  return;
++ }
++ close(input[1]); input[1] = -1;
++ close(output_fd[1]); output_fd[1] = -1;
++ // curl consumes its complete config before issuing a request. It cannot fill
++ // the response pipe while waiting for more config, including large POST data.
++ size_t written = 0;
++ int write_error = 0;
++ while (written < config.size()) {
++#ifdef MSG_NOSIGNAL
++  ssize_t count = send(input[0], config.data() + written, config.size() - written, MSG_NOSIGNAL);
++#else
++  ssize_t count = send(input[0], config.data() + written, config.size() - written, 0);
++#endif
++  if (count < 0 && errno == EINTR) continue;
++  if (count <= 0) { write_error = count < 0 ? errno : EIO; break; }
++  written += (size_t)count;
++ }
++ close(input[0]); input[0] = -1;
  
- 	if (!fp) {
- 		HTTP_LOG("ERROR: popen() failed: %s", strerror(errno));
-@@ -252,6 +198,14 @@ static void execute_request(ra_http_req *req, ra_http_resp *resp)
- 	int exit_code = pclose(fp);
- 	HTTP_LOG("pclose exit_code=%d output_len=%zu", exit_code, output.len);
- 
+ 	// Read all output
+ 	struct buf output;
+ 	buf_init(&output);
+ 	char chunk[4096];
++	int read_error = 0;
+ 	while (1) {
+-		size_t n = fread(chunk, 1, sizeof(chunk), fp);
++		ssize_t n = read(output_fd[0], chunk, sizeof(chunk));
++		if (n < 0 && errno == EINTR) continue;
++		if (n < 0) { read_error = errno; break; }
+ 		if (n == 0) break;
+-		buf_append(&output, chunk, n);
+-	}
+-
+-	int exit_code = pclose(fp);
+-	HTTP_LOG("pclose exit_code=%d output_len=%zu", exit_code, output.len);
++		buf_append(&output, chunk, (size_t)n);
++	}
++
++	close(output_fd[0]); output_fd[0] = -1;
++ int exit_code = 0;
++ pid_t waited;
++ do { waited = waitpid(child, &exit_code, 0); } while (waited < 0 && errno == EINTR);
++ if (waited < 0) {
++  int error = errno;
++  free(output.data);
++  process_error(resp, "wait", error);
++  return;
++ }
++ HTTP_LOG("curl exit_code=%d output_len=%zu", exit_code, output.len);
++
 +	if (exit_code == -1 || !WIFEXITED(exit_code) || WEXITSTATUS(exit_code)) {
 +		const int code = exit_code != -1 && WIFEXITED(exit_code)
 +			? WEXITSTATUS(exit_code) : -1;
@@ -211,15 +365,17 @@ index 4ff5bb8..0daa303 100644
 +		return;
 +	}
 +
++ if (write_error || read_error) {
++  free(output.data);
++  process_error(resp, write_error ? "stdin write" : "stdout read", write_error ? write_error : read_error);
++  return;
++ }
+ 
  	if (!output.data || output.len == 0) {
  		HTTP_LOG("ERROR: curl returned no output (exit=%d)", exit_code);
- 		resp->body = strdup("curl returned no output");
-diff --git a/tests/run-ra-http-tests.py b/tests/run-ra-http-tests.py
-new file mode 100644
-index 0000000..6f2e3c9
 --- /dev/null
 +++ b/tests/run-ra-http-tests.py
-@@ -0,0 +1,108 @@
+@@ -0,0 +1,153 @@
 +#!/usr/bin/env python3
 +"""Exercise the production curl request executor against a real local TLS server."""
 +import http.server
@@ -259,6 +415,8 @@ index 0000000..6f2e3c9
 +    cpp = d / 'request.cpp'
 +    cpp.write_text(source + '''
 +#include <stdarg.h>
++#include <signal.h>
++#include <cassert>
 +static std::string captured_logs;
 +void ra_log_write(const char *format, ...) {
 + char text[4096]; va_list args; va_start(args, format);
@@ -269,10 +427,32 @@ index 0000000..6f2e3c9
 + if (argc < 2) return 2;
 + ra_http_req request = {};
 + request.url = argv[1];
-+ request.post_data = argc > 2 ? argv[2] : nullptr;
++ std::string post;
++ if (argc > 2) { char block[4096]; ssize_t count; while ((count = read(0, block, sizeof(block))) > 0) post.append(block, count); }
++ request.post_data = argc > 2 ? const_cast<char*>(post.c_str()) : nullptr;
 + request.content_type = argc > 3 ? argv[3] : nullptr;
 + ra_http_resp response = {};
++ struct sigaction before, after;
++ sigaction(SIGPIPE, nullptr, &before);
++ int saved[3] = {-1, -1, -1};
++ const char *closed = getenv("TEST_CLOSED_STREAMS");
++ int closed_mask = closed ? atoi(closed) : 0;
++ for (int fd = 0; fd < 3; ++fd) {
++  if (closed_mask & (1 << fd)) {
++   saved[fd] = fcntl(fd, F_DUPFD_CLOEXEC, 3);
++   assert(saved[fd] >= 3);
++   assert(close(fd) == 0);
++  }
++ }
 + execute_request(&request, &response);
++ for (int fd = 0; fd < 3; ++fd) {
++  if (saved[fd] >= 0) {
++   assert(dup2(saved[fd], fd) == fd);
++   close(saved[fd]);
++  }
++ }
++ sigaction(SIGPIPE, nullptr, &after);
++ assert(before.sa_handler == after.sa_handler);
 + printf("%d\\n%s", response.http_status, response.body ? response.body : "");
 + free(response.body);
 + fprintf(stderr, "%s", captured_logs.c_str());
@@ -305,20 +485,41 @@ index 0000000..6f2e3c9
 +    base = 'https://localhost:%d' % server.server_port
 +    (d / '.curlrc').write_text('insecure\n')
 +    sidecar = pathlib.Path(str(exe) + '.cacert.pem')
-+    def request(url, body=None, content_type=None):
-+        args = [str(exe), url] + ([body] if body is not None else [])
++    def request(url, body=None, content_type=None, search_path=None, closed_streams=0):
++        args = [str(exe), url] + (['stdin-body'] if body is not None else [])
 +        if content_type is not None: args.append(content_type)
-+        result = subprocess.run(args, text=True, capture_output=True, timeout=35, check=True,
-+            env={"PATH": os.environ["PATH"], "NO_PROXY": "localhost,127.0.0.1", "CURL_HOME": str(d)})
-+        assert url not in result.stderr and "synthetic=" not in result.stderr, 'Request details must not be logged'
-+        return result.stdout
++        result = subprocess.run(args, input=body.encode() if body is not None else None, capture_output=True, timeout=35, check=True,
++            env={"PATH": search_path or os.environ["PATH"], "NO_PROXY": "localhost,127.0.0.1", "CURL_HOME": str(d), "TEST_CLOSED_STREAMS": str(closed_streams)})
++        assert url.encode() not in result.stderr and b"synthetic=" not in result.stderr, 'Request details must not be logged'
++        return result.stdout.decode()
 +    try:
 +        missing = request(base)
 +        assert missing.startswith('-1\n') and 'exit 77' in missing, 'Missing CA must retain its client error'
 +        shutil.copyfile(cert, sidecar)
 +        assert request(base) == '200\ntls verified'
++        for closed_streams in (1, 2, 4, 7):
++            assert request(base, 'synthetic=closed-streams', closed_streams=closed_streams) == '200\nsynthetic=closed-streams'
 +        assert request(base, "synthetic=a'b&value=two") == "200\nsynthetic=a'b&value=two"
 +        assert request(base, "body", "application/" + "x" * 8192 + "'quoted") == "200\nbody"
++        for body in ("@literal-not-a-file", "quotes='\" slash=\\ newline=\n carriage=\r tab=\t vertical=\v", "synthetic=" + "long\n\\\"" * 100000):
++            assert request(base, body) == "200\n" + body
++        # Inspect the exact arguments handed to real curl, then exec it normally.
++        probe = d / 'probe'
++        probe.mkdir()
++        argv_file = d / 'curl-argv.txt'
++        real_curl = shutil.which('curl')
++        wrapper = probe / 'curl'
++        wrapper.write_text("#!" + os.sys.executable + "\nimport os,sys\nopen(" + repr(str(argv_file)) + ", 'w').write(repr(sys.argv[1:]))\nos.execv(" + repr(real_curl) + ", [" + repr(real_curl) + "] + sys.argv[1:])\n")
++        wrapper.chmod(0o755)
++        probe_path = str(probe) + os.pathsep + os.environ['PATH']
++        assert request(base + '/?synthetic=url-secret', 'synthetic=post-secret', search_path=probe_path) == '200\nsynthetic=post-secret'
++        assert 'synthetic' not in argv_file.read_text()
++        # Early child termination must not SIGPIPE Main or change its policy.
++        wrapper.write_text('#!/bin/sh\nexit 23\n')
++        assert 'exit 23' in request(base, 'synthetic=' + 'x' * 2000000, search_path=probe_path)
++        empty_path = d / 'empty-path'
++        empty_path.mkdir()
++        assert 'exit 127' in request(base, search_path=str(empty_path))
 +        assert 'exit 60' in request(base.replace('localhost', '127.0.0.1')), 'Hostname validation must remain enabled'
 +        assert 'exit 1' in request('http://localhost:1/plain'), 'Plain HTTP must be rejected'
 +        assert 'exit 1' in request(base + '/redirect'), 'HTTPS-to-HTTP redirect must fail'

--- a/support/ra-main/tls.patch
+++ b/support/ra-main/tls.patch
@@ -1,0 +1,330 @@
+diff --git a/ra_http.cpp b/ra_http.cpp
+index 4ff5bb8..0daa303 100644
+--- a/ra_http.cpp
++++ b/ra_http.cpp
+@@ -13,6 +13,9 @@
+ #include <sched.h>
+ #include <errno.h>
+ #include <unistd.h>
++#include <limits.h>
++#include <sys/wait.h>
++#include <string>
+ 
+ // ---------------------------------------------------------------------------
+ // Debug (uses same style as achievements.cpp)
+@@ -100,49 +103,38 @@ static void buf_append(struct buf *b, const char *chunk, size_t n)
+ 	b->data[b->len] = '\0';
+ }
+ 
+-// Build a shell command string for curl.
+-// We write status code on a separate last line using -w '\n%{http_code}'.
+-static char *build_curl_cmd(const char *url, const char *post_data,
+-	const char *content_type)
++static std::string shell_quote(const char *value)
+ {
+-	// Estimate command length
+-	size_t len = 256 + strlen(url);
+-	if (post_data) len += strlen(post_data) + 32;
+-	if (content_type) len += strlen(content_type) + 32;
+-
+-	char *cmd = (char *)malloc(len);
+-	if (!cmd) return NULL;
+-
+-	// Base: silent, follow redirects, 30s timeout, output body then HTTP code
+-	int off = snprintf(cmd, len,
+-		"curl -s -L --max-time 30 -w '\\n%%{http_code}' -A '%s'", s_user_agent);
+-
+-	if (post_data && post_data[0]) {
+-		// Use --data-binary with stdin to avoid shell injection from post_data
+-		off += snprintf(cmd + off, len - off, " -X POST");
+-		if (content_type && content_type[0]) {
+-			off += snprintf(cmd + off, len - off, " -H 'Content-Type: %s'", content_type);
+-		} else {
+-			off += snprintf(cmd + off, len - off,
+-				" -H 'Content-Type: application/x-www-form-urlencoded'");
+-		}
+-		off += snprintf(cmd + off, len - off, " --data-binary @-");
+-	}
+-
+-	// URL: use single quotes to prevent shell interpretation, escaping any
+-	// embedded single quotes.
+-	off += snprintf(cmd + off, len - off, " '");
+-	for (const char *p = url; *p; p++) {
+-		if (*p == '\'') {
+-			off += snprintf(cmd + off, len - off, "'\\''");
+-		} else {
+-			cmd[off++] = *p;
+-		}
++	std::string quoted = "'";
++	for (const char *p = value; *p; ++p) {
++		if (*p == '\'') quoted += "'\\''";
++		else quoted += *p;
+ 	}
+-	off += snprintf(cmd + off, len - off, "'");
+-	cmd[off] = '\0';
++	return quoted + "'";
++}
+ 
+-	return cmd;
++// Report transport failures without copying URLs, POST bodies, or credentials.
++static void transport_error(ra_http_resp *resp, int code)
++{
++ // rcheevos RC_API_SERVER_RESPONSE_CLIENT_ERROR passes this safe body to callers.
++ resp->http_status = -1;
++ const char *cause = "transport failed";
++ switch (code) {
++ case 1: cause = "only HTTPS is permitted"; break;
++ case 2: cause = "curl options or initialization failed"; break;
++ case 6: cause = "DNS resolution failed"; break;
++ case 7: cause = "connection failed"; break;
++ case 28: cause = "request timed out"; break;
++ case 35: cause = "TLS negotiation failed"; break;
++ case 60: cause = "TLS certificate verification failed"; break;
++ case 77: cause = "CA bundle missing or unreadable"; break;
++ case 127: cause = "curl executable unavailable"; break;
++ }
++ char message[160];
++ snprintf(message, sizeof(message), "curl failed (exit %d): %s", code, cause);
++ resp->body = strdup(message);
++ resp->body_len = resp->body ? strlen(resp->body) : 0;
++ HTTP_LOG("ERROR: %s", message);
+ }
+ 
+ static void execute_request(ra_http_req *req, ra_http_resp *resp)
+@@ -153,84 +145,38 @@ static void execute_request(ra_http_req *req, ra_http_resp *resp)
+ 	resp->body = NULL;
+ 	resp->body_len = 0;
+ 
+-	// Build final shell command.
+-	// For POST: printf '%s' '<data>' | curl ... --data-binary @-
+-	// This avoids temp files and double-popen.
+-	size_t url_len  = strlen(req->url);
+-	size_t post_len = req->post_data ? strlen(req->post_data) : 0;
+-	size_t ua_len   = strlen(s_user_agent);
+-	size_t cmd_len  = 512 + url_len + post_len * 4 + ua_len; // *4: worst-case shell escaping
+-	char *cmd = (char *)malloc(cmd_len);
+-	if (!cmd) {
+-		HTTP_LOG("ERROR: malloc failed for command buffer");
+-		resp->body = strdup("malloc failed");
+-		resp->body_len = resp->body ? strlen(resp->body) : 0;
++	// An explicit sidecar avoids the obsolete system CA store without changing it.
++	// Its name follows the executable, including custom installation locations.
++	char ca_path[PATH_MAX];
++	ssize_t ca_length = readlink("/proc/self/exe", ca_path,
++		sizeof(ca_path) - sizeof(".cacert.pem"));
++	if (ca_length < 0 || ca_length >= (ssize_t)(sizeof(ca_path) - sizeof(".cacert.pem"))) {
++		transport_error(resp, 77);
+ 		return;
+ 	}
++	memcpy(ca_path + ca_length, ".cacert.pem", sizeof(".cacert.pem"));
+ 
+-	int off = 0;
+-
++	// One quoting path and dynamically sized storage cover every shell argument.
++	std::string cmd;
+ 	if (req->post_data && req->post_data[0]) {
+-		// Use printf to feed POST body into curl's stdin.
+-		// Shell-escape the post_data using single-quote wrapping
+-		// (replace each ' with '\'' ).
+-		off += snprintf(cmd + off, cmd_len - off, "printf '%%s' '");
+-		for (const char *p = req->post_data; *p && (size_t)off < cmd_len - 10; p++) {
+-			if (*p == '\'') {
+-				off += snprintf(cmd + off, cmd_len - off, "'\\''");
+-			} else {
+-				cmd[off++] = *p;
+-			}
+-		}
+-		off += snprintf(cmd + off, cmd_len - off, "' | ");
++		cmd = "printf '%s' " + shell_quote(req->post_data) + " | ";
+ 	}
+-
+-	// curl base flags (-k: skip SSL cert verification — MiSTer CA bundle is outdated)
+-	off += snprintf(cmd + off, cmd_len - off,
+-		"curl -s -k -L --max-time 30 -w '\\n%%{http_code}' -A '%s'", s_user_agent);
+-
++	// -q must be first: a curlrc must not disable verification or add requests.
++	cmd += "curl -q -s -L --proto '=https' --proto-redir '=https' --max-time 30"
++		" -w '\\n%{http_code}' -A " + shell_quote(s_user_agent);
++	cmd += " --cacert " + shell_quote(ca_path);
+ 	if (req->post_data && req->post_data[0]) {
+-		const char *ct = (req->content_type && req->content_type[0])
+-			? req->content_type
+-			: "application/x-www-form-urlencoded";
+-		off += snprintf(cmd + off, cmd_len - off,
+-			" -X POST -H 'Content-Type: %s' --data-binary @-", ct);
++		const char *ct = req->content_type && req->content_type[0]
++			? req->content_type : "application/x-www-form-urlencoded";
++		cmd += " -X POST -H " + shell_quote((std::string("Content-Type: ") + ct).c_str());
++		cmd += " --data-binary @-";
+ 	}
++	cmd += " " + shell_quote(req->url);
+ 
+-	// URL: single-quote wrapped with ' escaped as '\''
+-	off += snprintf(cmd + off, cmd_len - off, " '");
+-	for (const char *p = req->url; *p && (size_t)off < cmd_len - 10; p++) {
+-		if (*p == '\'') {
+-			off += snprintf(cmd + off, cmd_len - off, "'\\''");
+-		} else {
+-			cmd[off++] = *p;
+-		}
+-	}
+-	off += snprintf(cmd + off, cmd_len - off, "'");
+-	cmd[off] = '\0';
+-
+-	// Log the command with sensitive params masked: &t= (token) and &p= (password)
+-	{
+-		char *masked = strdup(cmd);
+-		if (masked) {
+-			static const char *keys[] = { "&t=", "&p=", NULL };
+-			for (int k = 0; keys[k]; k++) {
+-				char *pos = strstr(masked, keys[k]);
+-				if (pos) {
+-					char *val = pos + 3;
+-					char *end = val;
+-					while (*end && *end != '&' && *end != '\'') end++;
+-					memmove(val + 3, end, strlen(end) + 1);
+-					memcpy(val, "***", 3);
+-				}
+-			}
+-			HTTP_LOG("CMD: %s", masked);
+-			free(masked);
+-		}
+-	}
++	// Never log the command: its POST body can contain login credentials.
++	HTTP_LOG("Request: HTTPS %s", req->post_data && req->post_data[0] ? "POST" : "GET");
+ 
+-	FILE *fp = popen(cmd, "r");
+-	free(cmd);
++	FILE *fp = popen(cmd.c_str(), "r");
+ 
+ 	if (!fp) {
+ 		HTTP_LOG("ERROR: popen() failed: %s", strerror(errno));
+@@ -252,6 +198,14 @@ static void execute_request(ra_http_req *req, ra_http_resp *resp)
+ 	int exit_code = pclose(fp);
+ 	HTTP_LOG("pclose exit_code=%d output_len=%zu", exit_code, output.len);
+ 
++	if (exit_code == -1 || !WIFEXITED(exit_code) || WEXITSTATUS(exit_code)) {
++		const int code = exit_code != -1 && WIFEXITED(exit_code)
++			? WEXITSTATUS(exit_code) : -1;
++		free(output.data);
++		transport_error(resp, code);
++		return;
++	}
++
+ 	if (!output.data || output.len == 0) {
+ 		HTTP_LOG("ERROR: curl returned no output (exit=%d)", exit_code);
+ 		resp->body = strdup("curl returned no output");
+diff --git a/tests/run-ra-http-tests.py b/tests/run-ra-http-tests.py
+new file mode 100644
+index 0000000..6f2e3c9
+--- /dev/null
++++ b/tests/run-ra-http-tests.py
+@@ -0,0 +1,108 @@
++#!/usr/bin/env python3
++"""Exercise the production curl request executor against a real local TLS server."""
++import http.server
++import pathlib
++import os
++import platform
++import shutil
++import ssl
++import subprocess
++import tempfile
++import threading
++
++root = pathlib.Path(__file__).resolve().parent.parent
++source = (root / 'ra_http.cpp').read_text()
++# Compile the actual request implementation without the unrelated main-loop
++# worker. No replacement HTTP implementation or fake curl participates.
++source = source[:source.index('// Worker thread\n')]
++source = source.replace('#include "achievements.h"', 'void ra_log_write(const char*, ...);')
++# macOS has no /proc/self/exe. Adapt only this OS lookup to the real host
++# executable; curl, request construction, TLS, and response handling are unchanged.
++if platform.system() == 'Darwin':
++    source = source.replace('#include <unistd.h>', r'''#include <unistd.h>
++#include <mach-o/dyld.h>
++#include <limits.h>
++static ssize_t test_executable_readlink(const char *path, char *out, size_t size) {
++ if (strcmp(path, "/proc/self/exe")) return readlink(path, out, size);
++ char executable[PATH_MAX]; uint32_t count = sizeof(executable);
++ if (_NSGetExecutablePath(executable, &count)) return -1;
++ size_t length = strlen(executable);
++ if (length > size) length = size;
++ memcpy(out, executable, length); return length;
++}
++#define readlink test_executable_readlink
++''')
++with tempfile.TemporaryDirectory(prefix='ra-http-') as tmp:
++    d = pathlib.Path(tmp)
++    cpp = d / 'request.cpp'
++    cpp.write_text(source + '''
++#include <stdarg.h>
++static std::string captured_logs;
++void ra_log_write(const char *format, ...) {
++ char text[4096]; va_list args; va_start(args, format);
++ vsnprintf(text, sizeof(text), format, args); va_end(args);
++ captured_logs += text;
++}
++int main(int argc, char **argv) {
++ if (argc < 2) return 2;
++ ra_http_req request = {};
++ request.url = argv[1];
++ request.post_data = argc > 2 ? argv[2] : nullptr;
++ request.content_type = argc > 3 ? argv[3] : nullptr;
++ ra_http_resp response = {};
++ execute_request(&request, &response);
++ printf("%d\\n%s", response.http_status, response.body ? response.body : "");
++ free(response.body);
++ fprintf(stderr, "%s", captured_logs.c_str());
++}
++''')
++    exe = d / "request's client"
++    subprocess.run([os.environ.get('CXX', 'c++'), '-std=c++14', '-I', str(root), str(cpp), '-o', str(exe), '-pthread'], check=True)
++    cert, key = d / 'cert.pem', d / 'key.pem'
++    subprocess.run(['openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
++                    '-keyout', str(key), '-out', str(cert), '-days', '1',
++                    '-subj', '/CN=localhost', '-addext', 'subjectAltName=DNS:localhost'],
++                   check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
++    class Handler(http.server.BaseHTTPRequestHandler):
++        def log_message(self, *args): pass
++        def do_GET(self):
++            if self.path == '/redirect':
++                self.send_response(302)
++                self.send_header('Location', 'http://localhost:1/blocked')
++                self.end_headers()
++            else:
++                self.send_response(200); self.end_headers(); self.wfile.write(b'tls verified')
++        def do_POST(self):
++            body = self.rfile.read(int(self.headers['Content-Length']))
++            self.send_response(200); self.end_headers(); self.wfile.write(body)
++    server = http.server.HTTPServer(('127.0.0.1', 0), Handler)
++    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
++    context.load_cert_chain(cert, key)
++    server.socket = context.wrap_socket(server.socket, server_side=True)
++    thread = threading.Thread(target=server.serve_forever, daemon=True); thread.start()
++    base = 'https://localhost:%d' % server.server_port
++    (d / '.curlrc').write_text('insecure\n')
++    sidecar = pathlib.Path(str(exe) + '.cacert.pem')
++    def request(url, body=None, content_type=None):
++        args = [str(exe), url] + ([body] if body is not None else [])
++        if content_type is not None: args.append(content_type)
++        result = subprocess.run(args, text=True, capture_output=True, timeout=35, check=True,
++            env={"PATH": os.environ["PATH"], "NO_PROXY": "localhost,127.0.0.1", "CURL_HOME": str(d)})
++        assert url not in result.stderr and "synthetic=" not in result.stderr, 'Request details must not be logged'
++        return result.stdout
++    try:
++        missing = request(base)
++        assert missing.startswith('-1\n') and 'exit 77' in missing, 'Missing CA must retain its client error'
++        shutil.copyfile(cert, sidecar)
++        assert request(base) == '200\ntls verified'
++        assert request(base, "synthetic=a'b&value=two") == "200\nsynthetic=a'b&value=two"
++        assert request(base, "body", "application/" + "x" * 8192 + "'quoted") == "200\nbody"
++        assert 'exit 60' in request(base.replace('localhost', '127.0.0.1')), 'Hostname validation must remain enabled'
++        assert 'exit 1' in request('http://localhost:1/plain'), 'Plain HTTP must be rejected'
++        assert 'exit 1' in request(base + '/redirect'), 'HTTPS-to-HTTP redirect must fail'
++        assert 'exit 7' in request('https://localhost:1/refused'), 'Connection failure must retain cause'
++        sidecar.write_text('invalid CA bundle')
++        assert 'exit 77' in request(base), 'Unreadable CA must fail explicitly'
++    finally:
++        server.shutdown(); server.server_close(); thread.join()
++print('Real curl TLS/POST/hostname/redirect/CA/connection checks passed')


### PR DESCRIPTION
## What this changes

Restore Degauss startup on MiSTer Linux 6.18, where the framebuffer driver no longer provides native mmap. Keep the existing `/dev/fb0` mapping first; only `ENODEV` selects a mapping of the driver-reported physical framebuffer through `/dev/mem`. Kernels with working native mmap retain their existing path automatically. Physical mapping defaults to staged rendering, while native mapping retains the direct default. Saved drawing modes and explicit command-line choices take precedence; the runtime default is not saved as a user setting.

The same change set adds ZIP libraries, selectable installed core versions and large MRA artwork metadata support.

- Preserve framebuffer geometry, stride, RGB565/XRGB8888 validation and the original fbdev descriptor for vsync. Align physical mappings safely, retain the correct unmap range and report the mapping source in startup and selftest logs. Other native mmap errors remain errors; fallback failures identify both device boundaries. No new configuration or data migration is required.
- Browse ZIP and bounded ZIP64 libraries by internal folder and launch exact game members. Preserve single-game archive metadata; use complete member paths for multi-game metadata. Successful rebuilds reflect current files; read failures and cancellation preserve the previous complete list.
- Select installed Standard, RetroAchievements and Unstable cores per system, with explicit errors for unavailable selected versions. Preserve existing settings, caches and favourites.
- Read large MRA ROM, patch and cheat payloads without applying the metadata limit to the whole descriptor.
- Deliver a separately installed RA Main with the existing Frontend menu and shortcut, verified HTTPS transport, initial controller-state synchronization and corresponding source. Preserve existing Downloader invocation and configuration ownership.
- Document installation, archive limits, framebuffer diagnostics and hardware acceptance procedures.

## Why

The MiSTer 6.18 framebuffer driver lacks the mapping callback required by the kernel, causing startup to fail. The bounded physical mapping restores access to the same framebuffer while retaining native mapping on existing installations. The library changes address the linked discovery, metadata and archive issues.

Closes #28
Closes #31
Closes #32
Closes #37

## How it was checked

The configured check workflow runs:

- `cargo fmt --check`
- `python3 scripts/test-ra-release.py`
- `cargo test`
- `./scripts/rehearse-migration.sh`
- `cargo clippy --target armv7-unknown-linux-musleabihf --all-targets -j 1 -- -D warnings`

Linux framebuffer regression cases cover native-success bypass, ENODEV-only fallback, other errno propagation, physical range validation and page alignment, overflow, fallback diagnostics, both pixel formats, and separate pixel/unmap addresses. The mapping lifetime test exercises real Linux mmap and verifies that dropping the framebuffer releases its original mapped range.

Existing regression coverage includes persisted data, core discovery and selection, archive members, cache recovery, large MRA identity parsing and RA release delivery compatibility. Documented hardware acceptance covers both kernel paths, ordinary and Scripts startup, rendering, input, launch/return and fallback failure diagnostics. Host tests and CI do not substitute for those hardware checks.

## Licensing

The Rust frontend remains under the [PolyForm Noncommercial License 1.0.0](https://github.com/giancarloerra/Degauss/blob/b6ef151f9e798c74b669c0d4f6f5edd53943e1b2/LICENSE). The separately built RA Main source and its integration patches are GPL-3.0; bundled components retain their own licences and notices, as documented in the [RA Main source and licensing guidance](https://github.com/giancarloerra/Degauss/blob/b6ef151f9e798c74b669c0d4f6f5edd53943e1b2/support/ra-main/README.md#build-and-validation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added browsing and launching for Unstable and RetroAchievements cores.
  - Added per-system core preferences, including Standard-first and RetroAchievements-first choices.
  - ZIP and ZIP64 archives can now be browsed as folders, including nested directories and metadata.
  - Added Degauss frontend integration, shortcuts and System-menu access through the RA Main release.
  - Added framebuffer fallback support for compatible Linux/MiSTer setups.

- **Bug Fixes**
  - Improved handling of missing cores, malformed archives, artwork packs and launch errors.
  - Improved cache, favourite and metadata recovery while preserving existing data during failures.

- **Documentation**
  - Added guidance for ZIP libraries, framebuffer compatibility, RA Main integration and hardware testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->