### PR TITLE
Restore lightweight indexing and responsive progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "degauss"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytemuck",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "degauss"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.96"
 description = "A fast, software-rendered frontend for MiSTer FPGA"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1669,20 +1669,21 @@ fn shortened_label(value: &str, room: usize) -> String {
     format!("{}...", kept.trim_end())
 }
 
-/// Reading the card into the cache, one system per frame.
-///
-/// One per frame rather than all at once: reading a system takes seconds,
-/// and a screen that says what it is doing and moves while it does it is
-/// the difference between waiting and wondering.
+/// Reading the card into the cache with one owned worker at a time.
+/// The UI keeps rendering and accepting cancellation during a large system.
 struct Building {
     /// Indices into `all_systems`, in reverse so the next one is popped.
     left: Vec<usize>,
     done: usize,
     total: usize,
     index: crate::cache::Index,
-    /// True when the whole cache was thrown away first, so a system whose
-    /// file is still on the card is read again rather than skipped.
+    /// Re-read existing systems while retaining their last complete caches.
     forced: bool,
+    job: Option<crate::index_job::Job>,
+    current_id: String,
+    current_name: String,
+    cancelling: bool,
+    started: Instant,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -3438,6 +3439,23 @@ impl App {
         self.settings.screensaver_after.unwrap_or(120)
     }
 
+    fn should_start_screensaver(&self, now: Instant) -> bool {
+        let idle = self.screensaver_after();
+        idle > 0
+            && self.build.is_none()
+            && !matches!(
+                self.screen,
+                Screen::Screensaver
+                    | Screen::Splash
+                    | Screen::ScraperProgress
+                    | Screen::ScraperMatches
+                    | Screen::SourceProgress
+            )
+            && !(self.screen == Screen::ScraperKeyboard
+                && self.scraper_keyboard_field == ScraperField::SearchTerm)
+            && now.duration_since(self.last_input) >= Duration::from_secs(idle)
+    }
+
     /// Show something, or stay browsing if there is nothing to show.
     ///
     /// A screensaver that draws a blank screen is worse than none: it looks
@@ -4070,6 +4088,7 @@ impl App {
     /// field, so a message set here would be wiped before it was drawn.
     /// The caller shows it after its redraw.
     fn refresh_system(&mut self, id: &str) -> Option<String> {
+        let started = Instant::now();
         // A system is in the table only when its folder existed at
         // discovery. With no folder there is no cache to refresh and
         // nothing is listed, so doing nothing is correct.
@@ -4129,18 +4148,17 @@ impl App {
             Ok(cache) => cache,
             Err(error) => return Some(format!("{name}: {error}")),
         };
-        let mut next_index = self.index.clone().unwrap_or_default();
-        next_index
+        if let Err(error) = crate::cache::save_system(&self.cache_dir, id, &cache) {
+            return Some(format!("{name}: {error}"));
+        }
+        let index = self.index.get_or_insert_with(crate::cache::Index::new);
+        index
             .systems
             .insert(id.to_string(), cache.summary(&browse::start_for(&config)));
-        let warnings =
-            match crate::cache::save_system_with_index(&self.cache_dir, id, &cache, &next_index) {
-                Ok(warnings) => warnings,
-                Err(error) => return Some(format!("{name}: {error}")),
-            };
-        self.index = Some(next_index);
+        let error = crate::cache::save_index(&self.cache_dir, index)
+            .err()
+            .map(|error| format!("{name}: cache index not written: {error}"));
         self.apply_index();
-        let error = (!warnings.is_empty()).then(|| warnings.join("\n"));
         if let Some(build) = self.build.as_mut() {
             // A build runs a system per frame with the controls still
             // live, and what it finishes with replaces the index outright.
@@ -4166,6 +4184,10 @@ impl App {
         // nothing when nothing is hidden.
         self.correct_system_counts();
         self.rebuild_system_list();
+        crate::note(&format!(
+            "index refresh {id}: {}ms",
+            started.elapsed().as_millis()
+        ));
         error
     }
 
@@ -5323,7 +5345,12 @@ impl App {
     fn start_build(&mut self, forced: bool) {
         // One at a time. Replacing a build in flight would lose its progress;
         // the existing progress message already explains the active work.
-        if self.build.is_some() || self.source_job.is_some() || self.refreshing.is_some() {
+        if self.build.is_some()
+            || self.source_job.is_some()
+            || self.refreshing.is_some()
+            || self.scraper_job.is_some()
+            || self.scraper_cache_refresh_active
+        {
             return;
         }
         if self.provider_job.is_some() {
@@ -5365,20 +5392,94 @@ impl App {
             total,
             index,
             forced,
+            job: None,
+            current_id: String::new(),
+            current_name: String::new(),
+            cancelling: false,
+            started: Instant::now(),
         });
+        crate::note(&format!(
+            "index all    starting {total} systems, forced={forced}"
+        ));
         // Not shown yet: it goes up when the reading starts, which is
         // after the wordmark has had its moment.
         self.dirty = true;
     }
 
-    /// Read one system into the cache, and say so on screen.
+    /// Poll the active system, or dispatch the next one without blocking UI.
     fn build_one_system(&mut self) {
+        for _ in 0..4 {
+            let event = self
+                .build
+                .as_mut()
+                .and_then(|build| build.job.as_mut())
+                .and_then(crate::index_job::Job::try_recv);
+            let Some(event) = event else {
+                break;
+            };
+            let build = self.build.as_mut().expect("active index worker");
+            if let crate::index_job::Event::Progress { folders, games } = event {
+                if !build.cancelling {
+                    self.message = Some(format!(
+                        "Indexing all systems\n{}   {} of {}\n{folders} folders, {games} games\nB Cancel",
+                        build.current_name, build.done, build.total,
+                    ));
+                    self.dirty = true;
+                }
+                continue;
+            }
+            build.job = None;
+            let result = match event {
+                crate::index_job::Event::Ready { summary } => {
+                    // A completed write wins a cancellation that arrived
+                    // during publication: retain its matching summary.
+                    if let Some(summary) = summary {
+                        build
+                            .index
+                            .systems
+                            .insert(build.current_id.clone(), summary);
+                    }
+                    Ok(())
+                }
+                crate::index_job::Event::Failed(error) => Err(error),
+                crate::index_job::Event::Cancelled => {
+                    build.cancelling = true;
+                    build.left.clear();
+                    self.source_recovery_queue.clear();
+                    Ok(())
+                }
+                crate::index_job::Event::Progress { .. } => unreachable!(),
+            };
+            let message = match result {
+                Ok(()) => None,
+                Err(error) => Some(format!("{}: {error}", build.current_name)),
+            };
+            if let Some(message) = message {
+                crate::note(&message);
+                self.message_after_build = Some(match self.message_after_build.take() {
+                    Some(previous) => format!("{previous}\n{message}"),
+                    None => message,
+                });
+            }
+            break;
+        }
         let Some(build) = self.build.as_mut() else {
             return;
         };
+        if build.job.is_some() {
+            return;
+        }
         let Some(index) = build.left.pop() else {
             // Done: write the index down and use it.
             let finished = self.build.take().expect("just checked");
+            let cancelled = finished.cancelling;
+            crate::note(&format!(
+                "index all    {} after {}ms, {} of {} systems visited",
+                if cancelled { "cancelled" } else { "finished" },
+                finished.started.elapsed().as_millis(),
+                finished.done,
+                finished.total,
+            ));
             let index = finished.index;
             if let Err(e) = crate::cache::save_index(&self.cache_dir, &index) {
                 let message = format!("cache index not written: {e}");
@@ -5398,7 +5499,7 @@ impl App {
             // build goes up in its place. Only set when the open system
             // vanished, in which case the re-listing below has nothing
             // to do, so the two never fight over the field.
-            self.message = self.message_after_build.take();
+            self.last_input = Instant::now();
             // The folder on screen was listed from the cache as it was
             // before the build, and its rows keep answering from the
             // copy in memory. Both are behind the card now.
@@ -5413,7 +5514,23 @@ impl App {
                     self.relist_here();
                 }
             }
-            if self.start_next_source_recovery() {
+            self.message = self.message_after_build.take();
+            if cancelled {
+                let stopped = "Indexing cancelled. Completed systems kept.";
+                self.message = Some(match self.message.take() {
+                    Some(message) => format!("{stopped}\n{message}"),
+                    None => stopped.to_string(),
+                });
+            }
+            // Pack progress replaces the modal below. Carry earlier scan or
+            // index-write errors into its final warning state so a successful
+            // Pack group cannot turn a partial rebuild into apparent success.
+            if !cancelled && !self.source_recovery_queue.is_empty() {
+                if let Some(message) = &self.message {
+                    self.source_recovery_warnings.push(message.clone());
+                }
+            }
+            if !cancelled && self.start_next_source_recovery() {
                 self.dirty = true;
                 return;
             }
@@ -5433,69 +5550,46 @@ impl App {
         let config = system.to_config();
 
         self.message = Some(format!(
-            "Indexing all systems\n\n{name}   {done} of {total}"
+            "Indexing all systems\n{name}   {done} of {total}\nReading folders\nB Cancel"
         ));
-
-        // Already written down and not being forced: nothing to read.
-        let start = browse::start_for(&config);
         let pack = self.pack_selected(&id);
-        let summary = if pack {
-            // A Pack rebuild is completed by the cancellable group worker
-            // queued above. Keep using the previous complete cache meanwhile;
-            // never overwrite it with a partial synchronous rebuild.
-            crate::cache::load_artwork_pack_system(&self.cache_dir, &id)
-                .map(|cache| cache.summary(&start))
-        } else if !forced {
-            crate::cache::load_system(&self.cache_dir, &id).map(|cache| cache.summary(&start))
-        } else {
-            None
-        };
-        let summary = match summary {
-            Some(summary) => Some(summary),
-            None if pack => None,
-            None => {
-                let built = (|| -> Result<(crate::cache::Summary, Vec<String>)> {
-                    let library = Library::open_with_names(&config, self.names.clone())?;
-                    let cache = crate::cache::build_system_checked(&library)?;
-                    let summary = cache.summary(&start);
-                    let mut next_index = self.build.as_ref().expect("active build").index.clone();
-                    next_index.systems.insert(id.clone(), summary);
-                    let warnings = crate::cache::save_system_with_index(
-                        &self.cache_dir,
-                        &id,
-                        &cache,
-                        &next_index,
-                    )?;
-                    Ok((summary, warnings))
-                })();
-                match built {
-                    Ok((summary, warnings)) => {
-                        if !warnings.is_empty() {
-                            let message = warnings.join("\n");
-                            self.message_after_build =
-                                Some(match self.message_after_build.take() {
-                                    Some(previous) => format!("{previous}\n{message}"),
-                                    None => message,
-                                });
-                        }
-                        Some(summary)
-                    }
-                    Err(error) => {
-                        let message = format!("{name}: {error}");
-                        crate::note(&message);
-                        self.message_after_build = Some(match self.message_after_build.take() {
-                            Some(previous) => format!("{previous}\n{message}"),
-                            None => message,
-                        });
-                        None
-                    }
-                }
+        let build = self.build.as_mut().expect("active build");
+        build.current_id = id.clone();
+        build.current_name = name.clone();
+        match crate::index_job::start(crate::index_job::Request {
+            id,
+            config,
+            names: self.names.clone(),
+            cache_dir: self.cache_dir.clone(),
+            forced,
+            artwork_pack: pack,
+        }) {
+            Ok(job) => build.job = Some(job),
+            Err(error) => {
+                let message = format!("{name}: {error}");
+                crate::note(&message);
+                self.message_after_build = Some(match self.message_after_build.take() {
+                    Some(previous) => format!("{previous}\n{message}"),
+                    None => message,
+                });
             }
-        };
-        if let (Some(build), Some(summary)) = (self.build.as_mut(), summary) {
-            build.index.systems.insert(id, summary);
         }
 
+        self.dirty = true;
+    }
+
+    fn cancel_build(&mut self) {
+        let Some(build) = self.build.as_mut() else {
+            return;
+        };
+        build.cancelling = true;
+        build.left.clear();
+        self.source_recovery_queue.clear();
+        if let Some(job) = &build.job {
+            job.cancel();
+        }
+        self.message =
+            Some("Stopping indexing safely...\nCompleted systems will be kept.".to_string());
         self.dirty = true;
     }
 
@@ -7869,13 +7963,14 @@ impl App {
                     if cancelled {
                         self.source_recovery_queue.clear();
                         self.message = Some(format!(
-                            "System-list rebuild finished, but the Artwork Pack cache refresh for {name} was cancelled. The previous complete cache remains in use."
+                            "Artwork Pack cache refresh for {name} was cancelled. The previous complete cache remains in use.{}",
+                            if self.source_recovery_warnings.is_empty() { "" } else { "\nEarlier indexing warnings: see degauss.log." },
                         ));
                     } else if error.is_some() {
                         self.source_recovery_warnings.push(name.clone());
                         if !self.start_next_source_recovery() {
                             self.message = Some(
-                                "Library rebuilt; some Pack caches were kept.\nSee degauss.log for details."
+                                "Library rebuild has warnings; previous caches were kept where needed.\nSee degauss.log for details."
                                     .to_string(),
                             );
                         }
@@ -8050,7 +8145,7 @@ impl App {
                     self.message = Some(if self.source_recovery_warnings.is_empty() {
                         "Library rebuild complete.".to_string()
                     } else {
-                        "Library rebuild complete with storage warnings.\nSee degauss.log for details."
+                        "Library rebuild finished with warnings.\nSee degauss.log for details."
                             .to_string()
                     });
                 }
@@ -9350,6 +9445,14 @@ impl App {
             self.leave_splash();
             return None;
         }
+        // Indexing owns the cache writer until its worker stops. Keep input
+        // responsive without allowing a launch or another writer to race it.
+        if self.build.is_some() {
+            if action == Action::Quit {
+                self.cancel_build();
+            }
+            return None;
+        }
         if self.screen == Screen::ThemeEditor {
             self.handle_theme_editor(action);
             return None;
@@ -10641,20 +10744,7 @@ impl App {
             }
 
             // Left alone for long enough, show pictures instead.
-            let idle = self.screensaver_after();
-            if idle > 0
-                && !matches!(
-                    self.screen,
-                    Screen::Screensaver
-                        | Screen::Splash
-                        | Screen::ScraperProgress
-                        | Screen::ScraperMatches
-                        | Screen::SourceProgress
-                )
-                && !(self.screen == Screen::ScraperKeyboard
-                    && self.scraper_keyboard_field == ScraperField::SearchTerm)
-                && now.duration_since(self.last_input) >= Duration::from_secs(idle)
-            {
+            if self.should_start_screensaver(now) {
                 self.enter_screensaver();
             }
             if self.screen == Screen::Screensaver {
@@ -10753,7 +10843,7 @@ impl App {
                 }
                 self.dirty = true;
             }
-            // One system per frame, so the count on screen keeps moving.
+            // Poll the system worker after presenting the current progress.
             // After the wordmark, not over it: the first thing anybody sees
             // should be the thing they started, not a progress message.
             if self.build.is_some() && first_frame_done && self.screen != Screen::Splash {
@@ -11039,6 +11129,7 @@ impl App {
         loop {
             if self.build.is_some() {
                 self.build_one_system();
+                std::thread::sleep(Duration::from_millis(1));
                 continue;
             }
             self.poll_source_cache();
@@ -11480,6 +11571,74 @@ pub(crate) fn test_library_launch_flow(window: Rc<MinimalSoftwareWindow>) {
     let ui = DegaussWindow::new().unwrap();
     let mut app = App::new(loaded, window, ui, StartupTimings::default(), 352, 240);
     app.open_system_by_index(0);
+    assert!(
+        app.build.is_none(),
+        "headless entry waits for initial indexing"
+    );
+    app.set_screen(Screen::Browse);
+    app.settings.screensaver_after = Some(1);
+    app.last_input = Instant::now() - Duration::from_secs(3);
+    assert!(app.should_start_screensaver(Instant::now()));
+    app.start_build(true);
+    assert!(
+        !app.should_start_screensaver(Instant::now()),
+        "indexing must suppress the screensaver even after its idle deadline"
+    );
+    app.build_one_system();
+    assert!(
+        app.build.as_ref().unwrap().job.is_some(),
+        "a system read must be dispatched instead of blocking the UI"
+    );
+    let previous_screen = app.screen;
+    assert!(
+        app.handle(Action::Accept).is_none(),
+        "launch input cannot race the index writer"
+    );
+    assert_eq!(app.screen, previous_screen);
+    app.handle(Action::Quit);
+    assert!(
+        app.build.as_ref().unwrap().cancelling,
+        "B reaches cancellation while the worker is running"
+    );
+    app.finish_background_work_for_headless();
+    assert!(app.build.is_none());
+    assert!(app.message.as_ref().unwrap().contains("Indexing cancelled"));
+    assert!(
+        !app.should_start_screensaver(Instant::now()),
+        "completion resets the idle deadline"
+    );
+    app.start_build(true);
+    app.finish_background_work_for_headless();
+    assert_eq!(app.index.as_ref().unwrap().systems["NES"].games, 2);
+    assert_eq!(
+        crate::cache::load_index(&app.cache_dir).unwrap().systems["NES"].games,
+        2
+    );
+    let previous_cache = std::fs::read(crate::cache::system_path(&app.cache_dir, "NES")).unwrap();
+    let previous_index = std::fs::read(crate::cache::index_path(&app.cache_dir)).unwrap();
+    let valid_archive = std::fs::read(&archive).unwrap();
+    std::fs::write(&archive, b"invalid ZIP fixture").unwrap();
+    app.start_build(true);
+    app.finish_background_work_for_headless();
+    assert_eq!(
+        std::fs::read(crate::cache::system_path(&app.cache_dir, "NES")).unwrap(),
+        previous_cache,
+        "a failed ZIP scan must not replace the last complete system cache"
+    );
+    assert_eq!(
+        std::fs::read(crate::cache::index_path(&app.cache_dir)).unwrap(),
+        previous_index,
+        "a failed system must retain its old summary in the final index"
+    );
+    assert!(
+        app.message
+            .as_ref()
+            .is_some_and(|message| message.to_ascii_lowercase().contains("zip")),
+        "a failed scan must remain visible after relisting the open system"
+    );
+    std::fs::write(&archive, valid_archive).unwrap();
+    app.settings.screensaver_after = None;
+    app.message = None;
     let rules = std::mem::take(&mut app.all_systems[0].def.launch);
     assert_eq!(
         app.core_system_id().as_deref(),
@@ -11514,6 +11673,41 @@ pub(crate) fn test_library_launch_flow(window: Rc<MinimalSoftwareWindow>) {
         _ => panic!("expected launch outcome"),
     };
     assert!(mgl(&mut app).contains("<rbf>_Console/NES</rbf>"));
+    let favorites_root = app.favorites_root();
+    std::fs::create_dir_all(&favorites_root).unwrap();
+    let mut favorites_def = table
+        .iter()
+        .find(|system| system.id == "Favorites")
+        .unwrap()
+        .clone();
+    favorites_def.folders = vec![favorites_root.to_string_lossy().into_owned()];
+    app.all_systems.push(FoundSystem {
+        def: favorites_def,
+        paths: vec![favorites_root],
+        logo_dir: None,
+        menu_folder: None,
+    });
+    let ordinary_cache = std::fs::read(crate::cache::system_path(&app.cache_dir, "NES")).unwrap();
+    app.add_favorite_in("Test");
+    assert_eq!(app.favorites.len(), 1);
+    assert_eq!(
+        crate::cache::load_index(&app.cache_dir).unwrap().systems["Favorites"].games,
+        1,
+        "adding a favourite must refresh its persisted summary immediately"
+    );
+    assert!(crate::cache::load_system(&app.cache_dir, "Favorites").is_some());
+    app.remove_favorite();
+    assert_eq!(app.favorites.len(), 0);
+    assert_eq!(
+        crate::cache::load_index(&app.cache_dir).unwrap().systems["Favorites"].games,
+        0,
+        "removing a favourite must refresh its persisted summary immediately"
+    );
+    assert_eq!(
+        std::fs::read(crate::cache::system_path(&app.cache_dir, "NES")).unwrap(),
+        ordinary_cache,
+        "favourite changes must not rebuild the source system cache"
+    );
     app.open_context();
     assert!(app.menu.iter().any(|row| row == CORE_VERSION));
     app.menu_list

--- a/src/app.rs
+++ b/src/app.rs
@@ -12404,11 +12404,11 @@ mod tests {
     }
 
     #[test]
-    fn build_progress_never_consumes_controls_under_the_message() {
+    fn build_progress_is_not_dismissed_as_an_ordinary_message() {
         assert!(message_consumes_input(true, false));
         assert!(
             !message_consumes_input(true, true),
-            "index progress repaints every frame while all screens remain interactive"
+            "index progress remains visible; build controls are handled separately"
         );
         assert!(!message_consumes_input(false, false));
         assert!(!message_consumes_input(false, true));

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -240,7 +240,6 @@ pub fn save_index(dir: &Path, index: &Index) -> Result<()> {
     write(&index_path(dir), &bytes)
 }
 
-#[cfg(test)]
 pub fn save_system(dir: &Path, id: &str, cache: &SystemCache) -> Result<()> {
     let bytes = postcard::to_stdvec(cache)
         .map_err(|e| DegaussError::unsupported("cache", format!("writing {id}: {e}")))?;
@@ -751,6 +750,7 @@ pub fn install_transactional(
 }
 
 /// Commit a complete system scan and its summary together.
+#[cfg(test)]
 pub fn save_system_with_index(
     dir: &Path,
     id: &str,

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -27,6 +27,11 @@ pub const FAVORITES_DIR: &str = "_@Favorites";
 const MAX_MGL_BYTES: u64 = 1024 * 1024;
 const MAX_MGL_VALUE_BYTES: usize = 4096;
 
+#[cfg(test)]
+thread_local! {
+    static MGL_READS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 /// What a Favorite points at, plus optional descriptor evidence that can
 /// distinguish systems sharing one folder and file extension. `cache_target`
 /// preserves the exact target used by MiSTer's Favorites representation;
@@ -43,6 +48,7 @@ pub struct FavoriteReference {
 #[derive(Debug, Default)]
 struct DescriptorReference {
     target: Option<PathBuf>,
+    raw_target: Option<String>,
     rbf: Option<String>,
     setname: Option<String>,
 }
@@ -110,13 +116,9 @@ impl Favorites {
                 .extension()
                 .is_some_and(|e| e.eq_ignore_ascii_case("mgl"))
             {
-                // A title rather than a path: AmigaVision keeps its
-                // library inside one image, so a favourite for one names
-                // the title and there is no file to point at.
-                if let Some((install, title)) = crate::launch::amiga_marker(&path) {
-                    self.by_target.insert(amiga_key(&install, &title), path);
-                    continue;
-                }
+                // The resolver handles AmigaVision markers too. Checking
+                // here as well would read every ordinary MGL twice for the
+                // same absent marker on each favourite add/remove.
                 if let Some(reference) = reference_of_with_systems(&path, systems) {
                     self.by_target.insert(reference.cache_target, path);
                 }
@@ -152,7 +154,14 @@ pub fn target_of(path: &Path) -> Option<PathBuf> {
 /// Resolve the Favorite target while retaining core/set evidence for callers
 /// that need to identify the owning system. This reads only the same symlink,
 /// MGL or MRA that represents the Favorite and never changes it.
+#[cfg(test)]
 pub fn reference_of(path: &Path) -> Option<FavoriteReference> {
+    reference_with_raw_target(path).map(|(reference, _)| reference)
+}
+
+/// Keep the last raw file attribute from the descriptor parse so system-root
+/// resolution does not reopen and reparse every favourite just to find it.
+fn reference_with_raw_target(path: &Path) -> Option<(FavoriteReference, Option<String>)> {
     if let Ok(target) = std::fs::read_link(path) {
         let cache_target = resolve_link_target(path, target);
         let extension = cache_target
@@ -177,17 +186,23 @@ pub fn reference_of(path: &Path) -> Option<FavoriteReference> {
             .as_ref()
             .and_then(|descriptor| descriptor.target.clone())
             .unwrap_or_else(|| cache_target.clone());
-        return Some(FavoriteReference {
-            cache_target,
-            owner_target,
-            rbf: descriptor
-                .as_ref()
-                .and_then(|descriptor| descriptor.rbf.clone()),
-            setname: descriptor
-                .as_ref()
-                .and_then(|descriptor| descriptor.setname.clone()),
-            mgl: extension == "mgl",
-        });
+        let raw_target = descriptor
+            .as_ref()
+            .and_then(|descriptor| descriptor.raw_target.clone());
+        return Some((
+            FavoriteReference {
+                cache_target,
+                owner_target,
+                rbf: descriptor
+                    .as_ref()
+                    .and_then(|descriptor| descriptor.rbf.clone()),
+                setname: descriptor
+                    .as_ref()
+                    .and_then(|descriptor| descriptor.setname.clone()),
+                mgl: extension == "mgl",
+            },
+            raw_target,
+        ));
     }
     if path
         .extension()
@@ -195,23 +210,29 @@ pub fn reference_of(path: &Path) -> Option<FavoriteReference> {
     {
         if let Some((install, title)) = crate::launch::amiga_marker(path) {
             let target = amiga_key(&install, &title);
-            return Some(FavoriteReference {
-                cache_target: target.clone(),
-                owner_target: target,
-                rbf: None,
-                setname: None,
-                mgl: true,
-            });
+            return Some((
+                FavoriteReference {
+                    cache_target: target.clone(),
+                    owner_target: target,
+                    rbf: None,
+                    setname: None,
+                    mgl: true,
+                },
+                None,
+            ));
         }
         let descriptor = descriptor_reference(path, "favourite MGL").ok()?;
         let target = descriptor.target?;
-        return Some(FavoriteReference {
-            cache_target: target.clone(),
-            owner_target: target,
-            rbf: descriptor.rbf,
-            setname: descriptor.setname,
-            mgl: true,
-        });
+        return Some((
+            FavoriteReference {
+                cache_target: target.clone(),
+                owner_target: target,
+                rbf: descriptor.rbf,
+                setname: descriptor.setname,
+                mgl: true,
+            },
+            descriptor.raw_target,
+        ));
     }
     None
 }
@@ -223,36 +244,9 @@ pub fn reference_of_with_systems(
     path: &Path,
     systems: &[crate::systems::FoundSystem],
 ) -> Option<FavoriteReference> {
-    let mut reference = reference_of(path)?;
+    let (mut reference, raw) = reference_with_raw_target(path)?;
     if !reference.mgl || is_amiga_key(&reference.owner_target) {
         return Some(reference);
-    }
-    let descriptor_path = std::fs::read_link(path)
-        .map(|target| resolve_link_target(path, target))
-        .unwrap_or_else(|_| path.to_path_buf());
-    let text = read_mgl_text(&descriptor_path, "favourite MGL").ok()?;
-    let mut reader = Reader::from_str(&text);
-    let mut raw = None;
-    loop {
-        match reader.read_event() {
-            Ok(Event::Start(e) | Event::Empty(e))
-                if e.name().as_ref().eq_ignore_ascii_case("file") =>
-            {
-                for a in e.attributes() {
-                    let a = a.ok()?;
-                    if a.key.as_ref().eq_ignore_ascii_case("path") {
-                        raw = Some(
-                            a.normalized_value(XmlVersion::Implicit1_0)
-                                .ok()?
-                                .into_owned(),
-                        );
-                    }
-                }
-            }
-            Ok(Event::Eof) => break,
-            Err(_) => return None,
-            _ => {}
-        }
     }
     let raw = raw?;
     if raw.starts_with('/') || raw.starts_with("../") || raw.starts_with("./") {
@@ -438,6 +432,8 @@ pub fn mgl_target(path: &Path) -> Result<Option<PathBuf>> {
 /// Bound the bytes actually consumed, rather than relying on metadata from an
 /// earlier instant. A growing file or symlink target cannot bypass this limit.
 pub(crate) fn read_mgl_text(path: &Path, what: &'static str) -> Result<String> {
+    #[cfg(test)]
+    MGL_READS.with(|reads| reads.set(reads.get() + 1));
     let file = File::open(path).map_err(|error| DegaussError::io(what, path, error))?;
     let mut bytes = Vec::new();
     file.take(MAX_MGL_BYTES + 1)
@@ -462,6 +458,7 @@ fn descriptor_reference(path: &Path, what: &'static str) -> Result<DescriptorRef
     let text = read_mgl_text(path, what)?;
     let mut reader = Reader::from_str(&text);
     let mut target = None;
+    let mut raw_target = None;
     let mut active = None;
     let mut value = String::new();
     let mut rbf = None;
@@ -476,7 +473,10 @@ fn descriptor_reference(path: &Path, what: &'static str) -> Result<DescriptorRef
             Ok(Event::Eof) => break,
             Ok(Event::Start(event)) => {
                 if event.name().as_ref().eq_ignore_ascii_case("file") {
-                    target = file_target(path, what, &event)?.or(target);
+                    if let Some((resolved, raw)) = file_target(path, what, &event)? {
+                        target = Some(resolved);
+                        raw_target = Some(raw);
+                    }
                 } else if event.name().as_ref().eq_ignore_ascii_case("rbf") {
                     active = Some(DescriptorField::Rbf);
                     value.clear();
@@ -486,7 +486,10 @@ fn descriptor_reference(path: &Path, what: &'static str) -> Result<DescriptorRef
                 }
             }
             Ok(Event::Empty(event)) if event.name().as_ref().eq_ignore_ascii_case("file") => {
-                target = file_target(path, what, &event)?.or(target);
+                if let Some((resolved, raw)) = file_target(path, what, &event)? {
+                    target = Some(resolved);
+                    raw_target = Some(raw);
+                }
             }
             Ok(Event::Text(text)) if active.is_some() => {
                 value.push_str(&text.xml10_content());
@@ -545,6 +548,7 @@ fn descriptor_reference(path: &Path, what: &'static str) -> Result<DescriptorRef
     }
     Ok(DescriptorReference {
         target,
+        raw_target,
         rbf: (!rbf_ambiguous).then_some(rbf).flatten(),
         setname: (!setname_ambiguous).then_some(setname).flatten(),
     })
@@ -554,7 +558,7 @@ fn file_target(
     path: &Path,
     what: &'static str,
     event: &quick_xml::events::BytesStart<'_>,
-) -> Result<Option<PathBuf>> {
+) -> Result<Option<(PathBuf, String)>> {
     let mut target = None;
     for attribute in event.attributes() {
         let attribute = attribute.map_err(|error| {
@@ -566,7 +570,7 @@ fn file_target(
                 .map_err(|error| {
                     DegaussError::malformed(what, path, format!("bad path attribute: {error}"))
                 })?;
-            target = Some(resolve_mgl_path(path, &raw));
+            target = Some((resolve_mgl_path(path, &raw), raw.into_owned()));
         }
     }
     Ok(target)
@@ -770,6 +774,29 @@ pub fn remove(path: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn rereading_favorites_preserves_targets_without_redundant_descriptor_reads() {
+        let root = temp("rescan-read-budget");
+        let normal = root.join("Normal.mgl");
+        let amiga = root.join("Amiga.mgl");
+        std::fs::write(&normal, "<mistergamedescription><rbf>_Console/NES</rbf><file path=\"/games/Normal.nes\"/></mistergamedescription>").unwrap();
+        std::fs::write(&amiga, "<mistergamedescription><degauss kind=\"amigavision\" install=\"/games/Amiga\" title=\"Alien &amp; Space\"/></mistergamedescription>").unwrap();
+        MGL_READS.with(|reads| reads.set(0));
+        let found = Favorites::read_with_systems(&root, &[]);
+        let reads = MGL_READS.with(std::cell::Cell::get);
+        assert_eq!(
+            found.file_for(Path::new("/games/Normal.nes")),
+            Some(normal.as_path())
+        );
+        assert_eq!(
+            found.file_for(&amiga_key(Path::new("/games/Amiga"), "Alien & Space")),
+            Some(amiga.as_path())
+        );
+        assert!(reads <= 3,
+            "a whole-tree favourite reread must preserve the released read budget: at most two reads for an ordinary MGL and one for an Amiga marker, got {reads}");
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
     /// A folder name has to be a name. "." and ".." pass every character
     /// test and then resolve to the favourites root or above it.
     #[test]

--- a/src/index_job.rs
+++ b/src/index_job.rs
@@ -1,0 +1,282 @@
+//! One system's Index All work, owned by the running frontend process.
+//! Reads and complete cache replacement stay off the rendering thread.
+//! The UI owns the final summary index and prevents concurrent cache writers.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use crate::browse::{DisplayNames, Library};
+use crate::cache::Summary;
+use crate::config::SystemConfig;
+use crate::error::{DegaussError, Result};
+
+pub struct Request {
+    pub id: String,
+    pub config: SystemConfig,
+    pub names: DisplayNames,
+    pub cache_dir: PathBuf,
+    pub forced: bool,
+    pub artwork_pack: bool,
+}
+
+#[derive(Debug)]
+pub enum Event {
+    Progress { folders: usize, games: usize },
+    Ready { summary: Option<Summary> },
+    Cancelled,
+    Failed(DegaussError),
+}
+
+pub struct Job {
+    events: Receiver<Event>,
+    cancelled: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Job {
+    pub fn try_recv(&mut self) -> Option<Event> {
+        match self.events.try_recv() {
+            Ok(event) => {
+                if !matches!(event, Event::Progress { .. }) {
+                    if let Some(handle) = self.handle.take() {
+                        let _ = handle.join();
+                    }
+                }
+                Some(event)
+            }
+            Err(TryRecvError::Empty) => None,
+            Err(TryRecvError::Disconnected) => self.handle.take().map(|handle| {
+                let _ = handle.join();
+                Event::Failed(DegaussError::unsupported(
+                    "indexing",
+                    "the index worker stopped without a result",
+                ))
+            }),
+        }
+    }
+
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Relaxed);
+    }
+}
+
+impl Drop for Job {
+    fn drop(&mut self) {
+        self.cancel();
+    }
+}
+
+pub fn start(request: Request) -> Result<Job> {
+    let (sender, events) = mpsc::sync_channel(4);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let worker_cancelled = Arc::clone(&cancelled);
+    let handle = std::thread::Builder::new()
+        .name("degauss-index".to_string())
+        .spawn(move || {
+            let result = run(request, &sender, &worker_cancelled);
+            let event = match result {
+                Ok(event) => event,
+                Err(error) => Event::Failed(error),
+            };
+            let _ = sender.send(event);
+        })
+        .map_err(|error| {
+            DegaussError::unsupported("indexing", format!("could not start index worker: {error}"))
+        })?;
+    Ok(Job {
+        events,
+        cancelled,
+        handle: Some(handle),
+    })
+}
+
+fn run(request: Request, events: &SyncSender<Event>, cancelled: &AtomicBool) -> Result<Event> {
+    let began = Instant::now();
+    if cancelled.load(Ordering::Relaxed) {
+        return Ok(Event::Cancelled);
+    }
+    let start = crate::browse::start_for(&request.config);
+    // Pack rebuilding remains the responsibility of the existing group
+    // worker, queued after this pass. Never replace it with gamelist data.
+    let cached = if request.artwork_pack {
+        crate::cache::load_artwork_pack_system(&request.cache_dir, &request.id)
+    } else if !request.forced {
+        crate::cache::load_system(&request.cache_dir, &request.id)
+    } else {
+        None
+    };
+    if cancelled.load(Ordering::Relaxed) {
+        return Ok(Event::Cancelled);
+    }
+    if cached.is_some() || request.artwork_pack {
+        return Ok(Event::Ready {
+            summary: cached.map(|cache| cache.summary(&start)),
+        });
+    }
+    let library = Library::open_with_names(&request.config, request.names)?;
+    let open_ms = began.elapsed().as_millis();
+    let walking = Instant::now();
+    let mut last_progress = Instant::now();
+    let Some(cache) =
+        crate::cache::build_system_controlled(&library, cancelled, &mut |folders, games| {
+            if last_progress.elapsed() >= Duration::from_millis(100) {
+                let _ = events.try_send(Event::Progress { folders, games });
+                last_progress = Instant::now();
+            }
+        })?
+    else {
+        return Ok(Event::Cancelled);
+    };
+    let walk_ms = walking.elapsed().as_millis();
+    let summary = cache.summary(&start);
+    if cancelled.load(Ordering::Relaxed) {
+        return Ok(Event::Cancelled);
+    }
+    // Once this complete cache is installed, return its summary even if
+    // cancellation arrives during the write. The UI retains completed work
+    // and writes the matching final index before releasing the writer.
+    let saving = Instant::now();
+    crate::cache::save_system(&request.cache_dir, &request.id, &cache)?;
+    crate::note(&format!(
+        "index        {}: open={}ms walk={}ms save={}ms total={}ms folders={} games={}",
+        request.id,
+        open_ms,
+        walk_ms,
+        saving.elapsed().as_millis(),
+        began.elapsed().as_millis(),
+        cache.folders.len(),
+        summary.games,
+    ));
+    Ok(Event::Ready {
+        summary: Some(summary),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    fn fixture() -> (PathBuf, Request) {
+        let root = (0..)
+            .find_map(|serial| {
+                let path = std::env::temp_dir()
+                    .join(format!("degauss-index-{}-{serial}", std::process::id()));
+                match std::fs::create_dir(&path) {
+                    Ok(()) => Some(path),
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => None,
+                    Err(error) => panic!("fixture: {error}"),
+                }
+            })
+            .unwrap();
+        let games = root.join("games");
+        std::fs::create_dir(&games).unwrap();
+        std::fs::write(games.join("one.rom"), b"fixture").unwrap();
+        let request = Request {
+            id: "Test".into(),
+            config: SystemConfig {
+                preserve_rbf_stem: false,
+                name: "Test".into(),
+                path: games.to_string_lossy().into_owned(),
+                extensions: vec!["rom".into()],
+                rbf: "Test".into(),
+                launch: vec![],
+                setname: None,
+                skip_folders: vec![],
+                extra_paths: vec![],
+            },
+            names: Default::default(),
+            cache_dir: root.join("cache"),
+            forced: true,
+            artwork_pack: false,
+        };
+        (root, request)
+    }
+
+    fn terminal(job: &mut Job) -> Event {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Some(event) = job.try_recv() {
+                if !matches!(event, Event::Progress { .. }) {
+                    return event;
+                }
+            }
+            assert!(Instant::now() < deadline, "index worker did not finish");
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    #[test]
+    fn worker_installs_complete_cache_and_leaves_summary_index_to_ui() {
+        let (root, request) = fixture();
+        let cache_dir = request.cache_dir.clone();
+        let mut job = start(request).unwrap();
+        let Event::Ready {
+            summary: Some(summary),
+        } = terminal(&mut job)
+        else {
+            panic!("complete scan must be saved");
+        };
+        assert_eq!(summary.games, 1);
+        assert!(crate::cache::load_index(&cache_dir).is_none());
+        assert!(crate::cache::load_system(&cache_dir, "Test").is_some());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn cancelled_scan_preserves_previous_cache() {
+        let (root, request) = fixture();
+        let cache_dir = request.cache_dir.clone();
+        let mut first = start(Request {
+            config: request.config.clone(),
+            names: request.names.clone(),
+            id: request.id.clone(),
+            cache_dir: cache_dir.clone(),
+            forced: true,
+            artwork_pack: false,
+        })
+        .unwrap();
+        assert!(matches!(terminal(&mut first), Event::Ready { .. }));
+        let before = std::fs::read(crate::cache::system_path(&cache_dir, "Test")).unwrap();
+        std::fs::write(root.join("games/two.rom"), b"fixture").unwrap();
+        let (sender, _) = mpsc::sync_channel(4);
+        assert!(matches!(
+            run(request, &sender, &AtomicBool::new(true)).unwrap(),
+            Event::Cancelled
+        ));
+        assert_eq!(
+            std::fs::read(crate::cache::system_path(&cache_dir, "Test")).unwrap(),
+            before
+        );
+        assert_eq!(std::fs::read_dir(&cache_dir).unwrap().count(), 1);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn a_pack_pass_never_scans_or_installs_gamelist_data() {
+        let (root, mut request) = fixture();
+        let cache_dir = request.cache_dir.clone();
+        request.artwork_pack = true;
+        let mut job = start(request).unwrap();
+        assert!(matches!(terminal(&mut job), Event::Ready { summary: None }));
+        assert!(!cache_dir.exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn pre_cancelled_scan_does_not_touch_the_cache() {
+        let (root, request) = fixture();
+        let cache_dir = request.cache_dir.clone();
+        let (sender, _) = mpsc::sync_channel(4);
+        assert!(matches!(
+            run(request, &sender, &AtomicBool::new(true)).unwrap(),
+            Event::Cancelled
+        ));
+        assert!(!cache_dir.exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod error;
 mod favorites;
 mod font;
 mod gamelist;
+mod index_job;
 mod input;
 mod launch;
 mod list_state;

--- a/src/options.rs
+++ b/src/options.rs
@@ -208,7 +208,7 @@ impl OptionId {
                 "Whether a random pick starts the game, or only moves to it so you can look first."
             }
             OptionId::RebuildCache => {
-                "Press A to read the card again after adding games, cores or artwork."
+                "Press A to read the card again after adding games, cores or artwork. B cancels; completed systems are kept."
             }
             OptionId::ScrapeAll => {
                 "Press A to open ScreenScraper settings for every supported system."


### PR DESCRIPTION
## Summary

Fixes #43.

- Restore lightweight cache writes for ordinary system indexing and favourites refreshes. Full indexing writes the summary index once at completion instead of publishing a transaction for each system.
- Remove repeated MGL reads when refreshing favourites while preserving ZIP, AmigaVision and relative-path resolution.
- Run each system's indexing in a worker owned by the frontend process, keeping progress and B cancellation responsive. No persistent service is introduced.
- Prevent the screensaver from starting during indexing and reset the idle timer afterwards.
- Retain ZIP parser validation and reject an incomplete scan before replacing its previous complete cache. Keep scan errors visible when Artwork Pack work follows.
- Preserve existing cache formats, configuration and installation paths. Prepare version 0.5.1.

## Regression coverage

Tests cover completed and cancelled worker jobs, malformed ZIP cache preservation, progress input isolation, screensaver suppression, repeated indexing, favourites add/remove persistence, and separation between ordinary and Artwork Pack caches.

## Release gate

Final target-device validation and CI must pass before merge and release. This is not a performance or release-readiness claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Indexing now runs in the background with progress updates and can be cancelled using **B**.
  - Completed system caches are retained when indexing is cancelled or encounters an error.
  - Conflicting actions are prevented while indexing is in progress.
  - Artwork Pack recovery and screensaver startup now handle active indexing safely.

- **Bug Fixes**
  - Improved individual system refreshes, cache updates and launch behaviour.
  - Favourite rescans avoid unnecessary file reads, improving refresh efficiency.
  - Headless processing waits for background work to finish without blocking interface operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->