### PR TITLE
Allow favourites to be saved directly in the main Favourites shelf

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,17 +180,16 @@ its short, flat Actions menu for images and views.
 **Game** contains Game Information, separate **Random Game** and **Random
 Favourite** actions, and adding/removing favourites. Adding one opens a
 chooser that lists **Main Favourites** (the `_@Favorites` folder itself)
-first, then the folders already inside it, then **New folder**. Choosing Main
-Favourites writes the `.mgl`, or the link for a core file, directly under
-`_@Favorites`; no folder of that name is made, and a folder somebody has
-really called Main Favourites is listed after it as a folder of its own. On a
-card that had no `_@Favorites` when Degauss started, the first favourite
-makes it, but the Favourites shelf is only listed after **Rebuild All System
-Lists**; until then every favourite kept or dropped says so. Both random
-choices use the currently open folder and **Random Game Behaviour**.
-**Find** contains jump, search and hiding controls; **Library** contains
-scraping, core choice, data source and rebuilding; **Appearance** contains
-view and image controls.
+first, then the folders already inside it, then **New folder...**. Choosing
+Main Favourites writes the `.mgl`, or the link for a core file, directly
+under `_@Favorites`; no folder of that name is made, and a folder somebody
+has really called Main Favourites is listed after it as a folder of its own.
+On a card that had no `_@Favorites` when Degauss started, the first
+favourite makes it, but the Favourites shelf is only listed after **Rebuild
+All System Lists**. Both random choices use the currently open folder and
+**Random Game Behaviour**. **Find** contains jump, search and hiding
+controls; **Library** contains scraping, core choice, data source and
+rebuilding; **Appearance** contains view and image controls.
 
 A gamepad needs no extra setup and browsing and settings need no keyboard. While Degauss
 owns the screen, MiSTer sends the d-pad as arrows and the face buttons as

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Click the image to watch Degauss 0.4.0 on YouTube.
 | **left / right** | scroll speed, 0.5x to 12x, or what **Left and Right Behaviour** says: letter jumps, page jumps, or plain movement. Inside an Options page, left chooses the previous ordered value and right chooses the next; either direction toggles two-choice values |
 | **A** (enter) | open a folder, launch a game; in Options, choose the next value or run an action |
 | **B** (escape) | back, out of the folder |
-| **X** (tab) | **Actions** for the current selection and location: Game Information, random game, random favourite, keep or drop a favourite, jump to letter, search, hide a row, rebuild this system, change view, etc. With **Hold X (1s) to Add/Remove Fav** enabled, hold X for one second over a game to use the favourite shortcut |
+| **X** (tab) | **Actions** for the current selection and location: Game Information, random game, random favourite, keep a favourite in Main Favourites or in a folder, drop a favourite, jump to letter, search, hide a row, rebuild this system, change view, etc. With **Hold X (1s) to Add/Remove Fav** enabled, hold X for one second over a game to use the favourite shortcut |
 | **Y** (space) | **Menu**: Options, Scripts, Help, About, Exit to MiSTer. Optional **Hold Y (1s) for Random Game** uses Random Game Behaviour while browsing inside a system; a short press still opens Menu |
 
 **Actions** groups the available controls into **Game**, **Find**, **Library**
@@ -178,8 +178,14 @@ control has an explanation below the list. The Categories home screen keeps
 its short, flat Actions menu for images and views.
 
 **Game** contains Game Information, separate **Random Game** and **Random
-Favourite** actions, and adding/removing favourites. Both random choices use
-the currently open folder and **Random Game Behaviour**. **Find** contains
+Favourite** actions, and adding/removing favourites. Adding one opens a
+chooser that lists **Main Favourites** (the `_@Favorites` folder itself)
+first, then the folders already inside it, then **New folder**. Choosing Main
+Favourites writes the `.mgl`, or the link for a core file, directly under
+`_@Favorites`; no folder of that name is made, and a folder somebody has
+really called Main Favourites is listed after it as a folder of its own. Both
+random choices use the currently open folder and **Random Game
+Behaviour**. **Find** contains
 jump, search and hiding controls; **Library** contains scraping, core choice,
 data source and rebuilding; **Appearance** contains view and image controls.
 
@@ -248,9 +254,9 @@ scripts report their underlying error.
 - **Full metadata.** Read the complete description and available publisher,
   developer, release date, players, language and genre in Game Information,
   from the system's selected Gamelist or Artwork Pack source.
-- **Favourites are MiSTer's favourites**, written into `_@Favorites` in
-  MiSTer's own format. One made here works in the stock menu; one made
-  anywhere else appears here.
+- **Favourites are MiSTer's favourites**, written directly into
+  `_@Favorites` or into one of its folders, in MiSTer's own format. One made
+  here works in the stock menu; one made anywhere else appears here.
 - **Awkward systems handled** without hassle: AmigaVision, DOS,
   Neo Geo, Arcade, X68000, and cores that are several machines.
 
@@ -552,7 +558,7 @@ require **A** and confirmation, never a sideways press.
 | Navigation | Scroll Speed | How fast a held direction moves through the list. 3x out of the box |
 | Navigation | Skip Artwork Faster Than | Above this speed, pictures wait until the list stops. 6x out of the box |
 | Navigation | Left and Right Behaviour | What left and right do while browsing: Scroll Speed Change (the default), Letter, Page or Direction. Letter and Page repeat while held; in Direction, left and right move one entry and up and down move a whole row in Tiled, Multi List and Gallery |
-| Navigation | Hold X (1s) to Add/Remove Fav | Off by default. Hold X for one second over a game to open the normal favourite-folder chooser, or to remove it when it is already a favourite. The shortcut does nothing in the master Favourites system |
+| Navigation | Hold X (1s) to Add/Remove Fav | Off by default. Hold X for one second over a game to open the normal favourite-folder chooser, Main Favourites first, or to remove it when it is already a favourite. The shortcut does nothing in the master Favourites system |
 | Navigation | Hold Y (1s) for Random Game | Off by default. Hold Y for one second while browsing inside a system to use Random Game. It follows Random Game Behaviour; a short Y still opens Menu. The hold shortcut is inactive in menus and during operations |
 | Navigation | Random Game Behaviour | Whether either random action starts the game, or only moves to it so you can look first |
 | Appearance | Theme | Left and right choose a palette. Press A to open the editor. Standard uses the colours in `degauss.toml`. See [Themes and colours](#themes-and-colours) |

--- a/README.md
+++ b/README.md
@@ -183,11 +183,14 @@ chooser that lists **Main Favourites** (the `_@Favorites` folder itself)
 first, then the folders already inside it, then **New folder**. Choosing Main
 Favourites writes the `.mgl`, or the link for a core file, directly under
 `_@Favorites`; no folder of that name is made, and a folder somebody has
-really called Main Favourites is listed after it as a folder of its own. Both
-random choices use the currently open folder and **Random Game
-Behaviour**. **Find** contains
-jump, search and hiding controls; **Library** contains scraping, core choice,
-data source and rebuilding; **Appearance** contains view and image controls.
+really called Main Favourites is listed after it as a folder of its own. On a
+card that had no `_@Favorites` when Degauss started, the first favourite
+makes it, but the Favourites shelf is only listed after **Rebuild All System
+Lists**; until then every favourite kept or dropped says so. Both random
+choices use the currently open folder and **Random Game Behaviour**.
+**Find** contains jump, search and hiding controls; **Library** contains
+scraping, core choice, data source and rebuilding; **Appearance** contains
+view and image controls.
 
 A gamepad needs no extra setup and browsing and settings need no keyboard. While Degauss
 owns the screen, MiSTer sends the d-pad as arrows and the face buttons as

--- a/src/app.rs
+++ b/src/app.rs
@@ -1592,16 +1592,6 @@ impl FavoriteDestination {
             Self::NewFolder => NEW_FOLDER,
         }
     }
-
-    /// The folder a favourite goes into, under the favourites root. A
-    /// folder still to be named has none yet.
-    fn path(&self, root: &Path) -> Option<PathBuf> {
-        match self {
-            Self::Root => Some(root.to_path_buf()),
-            Self::Folder(name) => Some(root.join(name)),
-            Self::NewFolder => None,
-        }
-    }
 }
 
 /// The chooser's rows in order: the root first, the folders as they were
@@ -3016,11 +3006,11 @@ pub struct App {
     category_picks: std::collections::BTreeMap<String, PathBuf>,
     /// The files offered by the category/system image picker while it is open.
     category_image_choices: Vec<crate::category_images::Choice>,
+    /// The category or system whose image is being chosen.
+    category_image_target: Option<ImageTarget>,
     /// The places offered by the favourite-folder chooser while it is open,
     /// one per row of `menu`.
     favorite_destinations: Vec<FavoriteDestination>,
-    /// The category or system whose image is being chosen.
-    category_image_target: Option<ImageTarget>,
     /// When something was last pressed, for deciding the machine is idle.
     last_input: Instant,
     /// The machine's own state for the bar, re-read on a timer.
@@ -3412,8 +3402,8 @@ impl App {
             show_bar,
             category_picks: std::collections::BTreeMap::new(),
             category_image_choices: Vec::new(),
-            favorite_destinations: Vec::new(),
             category_image_target: None,
+            favorite_destinations: Vec::new(),
             last_input: Instant::now(),
             status: crate::status::Status::read(),
             speed_shown_at: None,
@@ -7979,7 +7969,10 @@ impl App {
                 let name = self.filter.clone();
                 self.filter.clear();
                 match crate::favorites::make_folder(&self.favorites_root(), &name) {
-                    Ok(_) => self.add_favorite_in(&FavoriteDestination::Folder(name)),
+                    Ok(_) => {
+                        let target = self.favorites_root().join(&name);
+                        self.add_favorite_in(&target);
+                    }
                     Err(e) => {
                         self.message = Some(format!("{e}"));
                         self.screen = Screen::Browse;
@@ -8713,24 +8706,14 @@ impl App {
         self.apply_geometry();
     }
 
-    /// Keep the selected game in MiSTer's favourites folder, or in one of
-    /// the folders inside it.
+    /// Keep the selected game in `target`: MiSTer's favourites folder
+    /// itself, or one of the folders inside it.
     ///
     /// Written the way its own script writes one: an `.mgl` naming the core
     /// and the file for a game, a link for a core file. Nothing here is
     /// Degauss's own format, so a favourite made here is a favourite in the
     /// stock menu too.
-    fn add_favorite_in(&mut self, destination: &FavoriteDestination) {
-        // The chooser's rows are done with: the destination was taken
-        // from them before this was called.
-        self.favorite_destinations.clear();
-        let Some(target) = destination.path(&self.favorites_root()) else {
-            // A folder still to be named: the name grid comes back here
-            // with the folder once it has been spelt out.
-            self.filter.clear();
-            self.open_find(FindMode::NewFolder);
-            return;
-        };
+    fn add_favorite_in(&mut self, target: &Path) {
         let Some(game) = self.selected_game() else {
             return;
         };
@@ -8760,7 +8743,7 @@ impl App {
             // the favourite recognisable while making the name one the
             // card can hold.
             let outcome = crate::launch::favorite_mgl_amiga(&config, &install, &title)
-                .and_then(|mgl| crate::favorites::add_game(&target, &sanitise(&title), &mgl));
+                .and_then(|mgl| crate::favorites::add_game(target, &sanitise(&title), &mgl));
             let mut outcome_error = None;
             let mut refresh_error = None;
             match outcome {
@@ -8795,7 +8778,7 @@ impl App {
                 // stem: a favourite called "mslug" would be a stranger in a
                 // list that has always said "Metal Slug".
                 let fav_name = crate::favorites::favorite_name(&name, &game);
-                crate::favorites::add_game(&target, &fav_name, &mgl)
+                crate::favorites::add_game(target, &fav_name, &mgl)
             }
             // A core file is linked to, not described. The link keeps the
             // real filename, not the shown name: the stock script resolves
@@ -8806,7 +8789,7 @@ impl App {
                     .file_name()
                     .map(|s| s.to_string_lossy().into_owned())
                     .unwrap_or_else(|| name.clone());
-                self.link_favorite(&target, &file, &game)
+                crate::favorites::add_core(target, &file, &game)
             }
             Err(e) => Err(e),
         };
@@ -8825,10 +8808,6 @@ impl App {
         self.relist_here();
         self.report_after_relist(outcome_error.or(refresh_error));
         self.dirty = true;
-    }
-
-    fn link_favorite(&self, folder: &Path, name: &str, game: &Path) -> Result<PathBuf> {
-        crate::favorites::add_core(folder, name, game)
     }
 
     /// Say what went wrong with a favourite change, after the redraw that
@@ -12079,13 +12058,27 @@ impl App {
                 Screen::Find => self.pick_letter(),
                 Screen::FavoriteFolder => {
                     // The row's destination, not its words: a folder can
-                    // share its name with the root's entry.
-                    if let Some(destination) = self
+                    // share its name with the root's entry. The rows are
+                    // done with once one is taken.
+                    let destination = self
                         .favorite_destinations
                         .get(self.menu_list.selected())
-                        .cloned()
-                    {
-                        self.add_favorite_in(&destination);
+                        .cloned();
+                    self.favorite_destinations.clear();
+                    match destination {
+                        Some(FavoriteDestination::Root) => {
+                            let target = self.favorites_root();
+                            self.add_favorite_in(&target);
+                        }
+                        Some(FavoriteDestination::Folder(name)) => {
+                            let target = self.favorites_root().join(&name);
+                            self.add_favorite_in(&target);
+                        }
+                        Some(FavoriteDestination::NewFolder) => {
+                            self.filter.clear();
+                            self.open_find(FindMode::NewFolder);
+                        }
+                        None => {}
                     }
                 }
                 Screen::CategoryImage => self.choose_category_image(),
@@ -16725,16 +16718,6 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["Main Favourites", "Arcade", "Consoles", "New folder..."]
         );
-        let root = Path::new("/menu/_@Favorites");
-        // The root writes into the root itself, never into a folder named
-        // after its row.
-        assert_eq!(destinations[0].path(root), Some(root.to_path_buf()));
-        assert_eq!(destinations[1].path(root), Some(root.join("Arcade")));
-        assert_eq!(
-            destinations[3].path(root),
-            None,
-            "a folder still to be named has nowhere to write yet"
-        );
         // A card with no folders offers the root and the chance to name one.
         assert_eq!(
             favorite_destinations(Vec::new()),
@@ -16754,13 +16737,7 @@ mod tests {
             FavoriteDestination::Folder("Main Favourites".into())
         );
         assert_eq!(destinations[0].label(), destinations[1].label());
-        let root = Path::new("/menu/_@Favorites");
-        assert_eq!(destinations[0].path(root), Some(root.to_path_buf()));
-        assert_eq!(
-            destinations[1].path(root),
-            Some(root.join("Main Favourites"))
-        );
-        assert_ne!(destinations[0].path(root), destinations[1].path(root));
+        assert_ne!(destinations[0], destinations[1]);
     }
 
     #[test]
@@ -16778,9 +16755,6 @@ mod tests {
                 FavoriteDestination::NewFolder,
             ]
         );
-        let root = Path::new("/menu/_@Favorites");
-        assert_eq!(destinations[1].path(root), Some(root.join(NEW_FOLDER)));
-        assert_eq!(destinations[2].path(root), None);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1570,6 +1570,50 @@ fn favorite_change(
     })
 }
 
+/// Where a favourite is kept: the root of MiSTer's favourites folder, one
+/// of the folders inside it, or a folder still to be named.
+///
+/// Typed rather than read back from the row's label: a folder somebody
+/// has really called "Main Favourites" shows the same words as the root
+/// and must stay a folder of its own.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FavoriteDestination {
+    Root,
+    Folder(String),
+    NewFolder,
+}
+
+impl FavoriteDestination {
+    /// The words on the chooser's row.
+    fn label(&self) -> &str {
+        match self {
+            Self::Root => MAIN_FAVORITES,
+            Self::Folder(name) => name,
+            Self::NewFolder => NEW_FOLDER,
+        }
+    }
+
+    /// The folder a favourite goes into, under the favourites root. A
+    /// folder still to be named has none yet.
+    fn path(&self, root: &Path) -> Option<PathBuf> {
+        match self {
+            Self::Root => Some(root.to_path_buf()),
+            Self::Folder(name) => Some(root.join(name)),
+            Self::NewFolder => None,
+        }
+    }
+}
+
+/// The chooser's rows in order: the root first, the folders as they were
+/// listed, and the chance to name another last.
+fn favorite_destinations(folders: Vec<String>) -> Vec<FavoriteDestination> {
+    let mut destinations = Vec::with_capacity(folders.len() + 2);
+    destinations.push(FavoriteDestination::Root);
+    destinations.extend(folders.into_iter().map(FavoriteDestination::Folder));
+    destinations.push(FavoriteDestination::NewFolder);
+    destinations
+}
+
 /// Favourites keeps its familiar heart only when it has no real image.
 /// Suppressing an image unconditionally made `Favorites.png` discoverable
 /// by the category code but impossible to see in the Details view.
@@ -1659,7 +1703,7 @@ fn context_help(action: &str) -> &'static str {
         RANDOM_FAVORITE => {
             "Pick only from favourites under the open folder, using Random Game Behaviour."
         }
-        ADD_FAVORITE => "Choose a Favourites folder for the selected game.",
+        ADD_FAVORITE => "Keep the selected game in Main Favourites or in a Favourites folder.",
         REMOVE_FAVORITE => "Remove the selected favourite. The original game is not deleted.",
         JUMP => "Jump to the first entry beginning with the chosen letter.",
         SEARCH => "Filter this list by name. Back keeps the search until it is cleared.",
@@ -1704,6 +1748,9 @@ fn category_image_preview(
 
 /// The entry that spells out a folder name rather than picking one.
 const NEW_FOLDER: &str = "New folder...";
+/// The entry for the favourites root itself, which has no folder name of
+/// its own to show.
+const MAIN_FAVORITES: &str = "Main Favourites";
 
 /// What can be done where the cursor is, in groups.
 ///
@@ -2969,6 +3016,9 @@ pub struct App {
     category_picks: std::collections::BTreeMap<String, PathBuf>,
     /// The files offered by the category/system image picker while it is open.
     category_image_choices: Vec<crate::category_images::Choice>,
+    /// The places offered by the favourite-folder chooser while it is open,
+    /// one per row of `menu`.
+    favorite_destinations: Vec<FavoriteDestination>,
     /// The category or system whose image is being chosen.
     category_image_target: Option<ImageTarget>,
     /// When something was last pressed, for deciding the machine is idle.
@@ -3362,6 +3412,7 @@ impl App {
             show_bar,
             category_picks: std::collections::BTreeMap::new(),
             category_image_choices: Vec::new(),
+            favorite_destinations: Vec::new(),
             category_image_target: None,
             last_input: Instant::now(),
             status: crate::status::Status::read(),
@@ -7928,7 +7979,7 @@ impl App {
                 let name = self.filter.clone();
                 self.filter.clear();
                 match crate::favorites::make_folder(&self.favorites_root(), &name) {
-                    Ok(_) => self.add_favorite_in(&name),
+                    Ok(_) => self.add_favorite_in(&FavoriteDestination::Folder(name)),
                     Err(e) => {
                         self.message = Some(format!("{e}"));
                         self.screen = Screen::Browse;
@@ -8636,11 +8687,11 @@ impl App {
             && self.scraper_pending_terminal.is_none()
     }
 
-    /// Offer the folders MiSTer's favourites are already kept in, and the
-    /// chance to name another.
+    /// Offer the favourites folder itself, the folders MiSTer's favourites
+    /// are already kept in, and the chance to name another.
     fn open_favorite_folders(&mut self) {
-        let mut entries = match crate::favorites::folders(&self.favorites_root()) {
-            Ok(entries) => entries,
+        let folders = match crate::favorites::folders(&self.favorites_root()) {
+            Ok(folders) => folders,
             Err(e) => {
                 self.screen = Screen::Browse;
                 self.apply_geometry();
@@ -8649,20 +8700,33 @@ impl App {
                 return;
             }
         };
-        entries.push(NEW_FOLDER.to_string());
-        self.menu = entries;
+        self.favorite_destinations = favorite_destinations(folders);
+        self.menu = self
+            .favorite_destinations
+            .iter()
+            .map(|destination| destination.label().to_string())
+            .collect();
         self.menu_list = ListState::new(self.menu.len(), self.geometry.visible);
         self.screen = Screen::FavoriteFolder;
         self.apply_geometry();
     }
 
-    /// Keep the selected game in a folder of MiSTer's favourites.
+    /// Keep the selected game in MiSTer's favourites folder, or in one of
+    /// the folders inside it.
     ///
     /// Written the way its own script writes one: an `.mgl` naming the core
     /// and the file for a game, a link for a core file. Nothing here is
     /// Degauss's own format, so a favourite made here is a favourite in the
     /// stock menu too.
-    fn add_favorite_in(&mut self, folder: &str) {
+    fn add_favorite_in(&mut self, destination: &FavoriteDestination) {
+        let Some(target) = destination.path(&self.favorites_root()) else {
+            // A folder still to be named: the name grid comes back here
+            // with the folder once it has been spelt out.
+            self.filter.clear();
+            self.open_find(FindMode::NewFolder);
+            return;
+        };
+        let folder = destination.label();
         let Some(game) = self.selected_game() else {
             return;
         };
@@ -8674,7 +8738,6 @@ impl App {
             .get(self.game_list.selected())
             .map(|row| row.name.clone())
             .unwrap_or_default();
-        let target = self.favorites_root().join(folder);
 
         // A title rather than a file: written as an MGL that starts
         // AmigaVision, carrying the title in an element Main ignores.
@@ -12011,16 +12074,14 @@ impl App {
                 },
                 Screen::Find => self.pick_letter(),
                 Screen::FavoriteFolder => {
-                    let choice = self
-                        .menu
+                    // The row's destination, not its words: a folder can
+                    // share its name with the root's entry.
+                    if let Some(destination) = self
+                        .favorite_destinations
                         .get(self.menu_list.selected())
                         .cloned()
-                        .unwrap_or_default();
-                    if choice == NEW_FOLDER {
-                        self.filter.clear();
-                        self.open_find(FindMode::NewFolder);
-                    } else {
-                        self.add_favorite_in(&choice);
+                    {
+                        self.add_favorite_in(&destination);
                     }
                 }
                 Screen::CategoryImage => self.choose_category_image(),
@@ -16636,6 +16697,66 @@ mod tests {
             None,
             "the shortcut exists only while browsing"
         );
+    }
+
+    #[test]
+    fn main_favourites_is_the_first_destination_and_new_folder_the_last() {
+        // The root is where the stock menu shows favourites first, so it
+        // comes first; the existing folders keep their listed order and
+        // naming a new one stays the last row, where it has always been.
+        let destinations = favorite_destinations(vec!["Arcade".into(), "Consoles".into()]);
+        assert_eq!(
+            destinations,
+            vec![
+                FavoriteDestination::Root,
+                FavoriteDestination::Folder("Arcade".into()),
+                FavoriteDestination::Folder("Consoles".into()),
+                FavoriteDestination::NewFolder,
+            ]
+        );
+        assert_eq!(
+            destinations
+                .iter()
+                .map(FavoriteDestination::label)
+                .collect::<Vec<_>>(),
+            vec!["Main Favourites", "Arcade", "Consoles", "New folder..."]
+        );
+        let root = Path::new("/menu/_@Favorites");
+        // The root writes into the root itself, never into a folder named
+        // after its row.
+        assert_eq!(destinations[0].path(root), Some(root.to_path_buf()));
+        assert_eq!(destinations[1].path(root), Some(root.join("Arcade")));
+        assert_eq!(
+            destinations[3].path(root),
+            None,
+            "a folder still to be named has nowhere to write yet"
+        );
+        // A card with no folders offers the root and the chance to name one.
+        assert_eq!(
+            favorite_destinations(Vec::new()),
+            vec![FavoriteDestination::Root, FavoriteDestination::NewFolder]
+        );
+    }
+
+    #[test]
+    fn a_user_folder_called_main_favourites_stays_distinct_from_the_root() {
+        // Both rows read "Main Favourites", so the label cannot say which
+        // is which; the typed destination must, or the folder would be
+        // unreachable and a choice of the root could land in the folder.
+        let destinations = favorite_destinations(vec!["Main Favourites".into()]);
+        assert_eq!(destinations[0], FavoriteDestination::Root);
+        assert_eq!(
+            destinations[1],
+            FavoriteDestination::Folder("Main Favourites".into())
+        );
+        assert_eq!(destinations[0].label(), destinations[1].label());
+        let root = Path::new("/menu/_@Favorites");
+        assert_eq!(destinations[0].path(root), Some(root.to_path_buf()));
+        assert_eq!(
+            destinations[1].path(root),
+            Some(root.join("Main Favourites"))
+        );
+        assert_ne!(destinations[0].path(root), destinations[1].path(root));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -8759,6 +8759,7 @@ impl App {
                 crate::launch::favorite_mgl_amiga(&config, &install, &title).and_then(|mgl| {
                     crate::favorites::add_game(&target, &sanitise(&title), &mgl).map(|_| title)
                 });
+            let mut outcome_error = None;
             let mut refresh_error = None;
             match outcome {
                 Ok(what) => {
@@ -8766,12 +8767,12 @@ impl App {
                     self.reread_favorites();
                     refresh_error = self.refresh_favorites_system();
                 }
-                Err(e) => self.message = Some(format!("{e}")),
+                Err(e) => outcome_error = Some(format!("{e}")),
             }
             self.screen = Screen::Browse;
             self.apply_geometry();
             self.relist_here();
-            if let Some(error) = refresh_error {
+            if let Some(error) = outcome_error.or(refresh_error) {
                 // Set after show_here, which clears the message field as
                 // part of its redraw; set before, the error would never be
                 // seen.
@@ -8814,6 +8815,7 @@ impl App {
             Err(e) => Err(e),
         };
 
+        let mut outcome_error = None;
         let mut refresh_error = None;
         match outcome {
             Ok(what) => {
@@ -8821,12 +8823,12 @@ impl App {
                 self.reread_favorites();
                 refresh_error = self.refresh_favorites_system();
             }
-            Err(e) => self.message = Some(format!("{e}")),
+            Err(e) => outcome_error = Some(format!("{e}")),
         }
         self.screen = Screen::Browse;
         self.apply_geometry();
         self.relist_here();
-        if let Some(error) = refresh_error {
+        if let Some(error) = outcome_error.or(refresh_error) {
             // Set after show_here, which clears the message field as
             // part of its redraw; set before, the error would never be
             // seen.
@@ -8856,18 +8858,19 @@ impl App {
         let Some(file) = file else {
             return;
         };
+        let mut outcome_error = None;
         let mut refresh_error = None;
         match crate::favorites::remove(&file) {
             Ok(()) => {
                 self.reread_favorites();
                 refresh_error = self.refresh_favorites_system();
             }
-            Err(e) => self.message = Some(format!("{e}")),
+            Err(e) => outcome_error = Some(format!("{e}")),
         }
         self.screen = Screen::Browse;
         self.apply_geometry();
         self.relist_here();
-        if let Some(error) = refresh_error {
+        if let Some(error) = outcome_error.or(refresh_error) {
             // Set after show_here, which clears the message field as
             // part of its redraw; set before, the error would never be
             // seen.

--- a/src/app.rs
+++ b/src/app.rs
@@ -4737,14 +4737,26 @@ impl App {
     /// exact moment that folder moved, and a shelf that shows yesterday's
     /// favourites until a full rebuild is asked for is wrong. The folder is
     /// small, so reading this one system again costs nothing worth noticing.
+    ///
+    /// A card that had no favourites folder when Degauss started has no
+    /// Favorites system: discovery skips a system whose folder is absent,
+    /// and only the full rebuild discovers again. The favourite just
+    /// written is what made the folder, so there is no cache to refresh
+    /// and the shelf stays unlisted until that rebuild. Said, rather than
+    /// left to be found out from the Categories screen.
     fn refresh_favorites_system(&mut self) -> Option<String> {
-        let id = self
+        let Some(system) = self
             .all_systems
             .iter()
-            .find(|system| is_favorites(system.category()))?
-            .def
-            .id
-            .clone();
+            .find(|system| is_favorites(system.category()))
+        else {
+            return Some(
+                "Favourites: its folder was not on the card when Degauss started, \
+                 so the shelf is not listed until Rebuild All System Lists"
+                    .to_string(),
+            );
+        };
+        let id = system.def.id.clone();
         self.refresh_system(&id)
     }
 
@@ -7989,6 +8001,8 @@ impl App {
                 }
             }
             Screen::Find | Screen::FavoriteFolder => {
+                // The chooser's rows are done with once it is left.
+                self.favorite_destinations.clear();
                 self.screen = Screen::Browse;
                 self.resolve_view();
                 self.apply_geometry();
@@ -8719,6 +8733,9 @@ impl App {
     /// Degauss's own format, so a favourite made here is a favourite in the
     /// stock menu too.
     fn add_favorite_in(&mut self, destination: &FavoriteDestination) {
+        // The chooser's rows are done with: the destination was taken
+        // from them before this was called.
+        self.favorite_destinations.clear();
         let Some(target) = destination.path(&self.favorites_root()) else {
             // A folder still to be named: the name grid comes back here
             // with the folder once it has been spelt out.
@@ -8726,7 +8743,6 @@ impl App {
             self.open_find(FindMode::NewFolder);
             return;
         };
-        let folder = destination.label();
         let Some(game) = self.selected_game() else {
             return;
         };
@@ -8755,15 +8771,12 @@ impl App {
             // The title is already the shown name, so sanitising it keeps
             // the favourite recognisable while making the name one the
             // card can hold.
-            let outcome =
-                crate::launch::favorite_mgl_amiga(&config, &install, &title).and_then(|mgl| {
-                    crate::favorites::add_game(&target, &sanitise(&title), &mgl).map(|_| title)
-                });
+            let outcome = crate::launch::favorite_mgl_amiga(&config, &install, &title)
+                .and_then(|mgl| crate::favorites::add_game(&target, &sanitise(&title), &mgl));
             let mut outcome_error = None;
             let mut refresh_error = None;
             match outcome {
-                Ok(what) => {
-                    self.message = Some(format!("{what}\n\nkept in {folder}"));
+                Ok(_) => {
                     self.reread_favorites();
                     refresh_error = self.refresh_favorites_system();
                 }
@@ -8772,12 +8785,7 @@ impl App {
             self.screen = Screen::Browse;
             self.apply_geometry();
             self.relist_here();
-            if let Some(error) = outcome_error.or(refresh_error) {
-                // Set after show_here, which clears the message field as
-                // part of its redraw; set before, the error would never be
-                // seen.
-                self.message = Some(error);
-            }
+            self.report_after_relist(outcome_error.or(refresh_error));
             self.dirty = true;
             return;
         }
@@ -8799,7 +8807,7 @@ impl App {
                 // stem: a favourite called "mslug" would be a stranger in a
                 // list that has always said "Metal Slug".
                 let fav_name = crate::favorites::favorite_name(&name, &game);
-                crate::favorites::add_game(&target, &fav_name, &mgl).map(|_| fav_name)
+                crate::favorites::add_game(&target, &fav_name, &mgl)
             }
             // A core file is linked to, not described. The link keeps the
             // real filename, not the shown name: the stock script resolves
@@ -8818,8 +8826,7 @@ impl App {
         let mut outcome_error = None;
         let mut refresh_error = None;
         match outcome {
-            Ok(what) => {
-                self.message = Some(format!("{what}\n\nkept in {folder}"));
+            Ok(_) => {
                 self.reread_favorites();
                 refresh_error = self.refresh_favorites_system();
             }
@@ -8828,17 +8835,28 @@ impl App {
         self.screen = Screen::Browse;
         self.apply_geometry();
         self.relist_here();
-        if let Some(error) = outcome_error.or(refresh_error) {
-            // Set after show_here, which clears the message field as
-            // part of its redraw; set before, the error would never be
-            // seen.
-            self.message = Some(error);
-        }
+        self.report_after_relist(outcome_error.or(refresh_error));
         self.dirty = true;
     }
 
-    fn link_favorite(&self, folder: &Path, name: &str, game: &Path) -> Result<String> {
-        crate::favorites::add_core(folder, name, game).map(|_| name.to_string())
+    fn link_favorite(&self, folder: &Path, name: &str, game: &Path) -> Result<PathBuf> {
+        crate::favorites::add_core(folder, name, game)
+    }
+
+    /// Say what went wrong with a favourite change, after the redraw that
+    /// follows it: `show_here` clears the message field as part of its
+    /// redraw, so anything set before it would never be seen. When the
+    /// redraw itself could not list the folder, its own message is kept
+    /// under this one: dropped, the empty list left behind would look like
+    /// an empty folder once this was dismissed.
+    fn report_after_relist(&mut self, error: Option<String>) {
+        let Some(error) = error else {
+            return;
+        };
+        self.message = Some(match self.message.take() {
+            Some(listing) => format!("{error}\n\n{listing}"),
+            None => error,
+        });
     }
 
     /// Take a favourite away, by removing the file that makes it one.
@@ -8870,12 +8888,7 @@ impl App {
         self.screen = Screen::Browse;
         self.apply_geometry();
         self.relist_here();
-        if let Some(error) = outcome_error.or(refresh_error) {
-            // Set after show_here, which clears the message field as
-            // part of its redraw; set before, the error would never be
-            // seen.
-            self.message = Some(error);
-        }
+        self.report_after_relist(outcome_error.or(refresh_error));
         self.dirty = true;
     }
 
@@ -16760,6 +16773,26 @@ mod tests {
             Some(root.join("Main Favourites"))
         );
         assert_ne!(destinations[0].path(root), destinations[1].path(root));
+    }
+
+    #[test]
+    fn a_user_folder_called_new_folder_is_a_folder_and_not_the_naming_row() {
+        // The naming row used to be told apart by its words, so a folder
+        // somebody had really called "New folder..." opened the name grid
+        // instead of taking the favourite. Typed rows keep such a folder a
+        // destination of its own and the naming row the last one.
+        let destinations = favorite_destinations(vec![NEW_FOLDER.to_string()]);
+        assert_eq!(
+            destinations,
+            vec![
+                FavoriteDestination::Root,
+                FavoriteDestination::Folder(NEW_FOLDER.to_string()),
+                FavoriteDestination::NewFolder,
+            ]
+        );
+        let root = Path::new("/menu/_@Favorites");
+        assert_eq!(destinations[1].path(root), Some(root.join(NEW_FOLDER)));
+        assert_eq!(destinations[2].path(root), None);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -4737,26 +4737,14 @@ impl App {
     /// exact moment that folder moved, and a shelf that shows yesterday's
     /// favourites until a full rebuild is asked for is wrong. The folder is
     /// small, so reading this one system again costs nothing worth noticing.
-    ///
-    /// A card that had no favourites folder when Degauss started has no
-    /// Favorites system: discovery skips a system whose folder is absent,
-    /// and only the full rebuild discovers again. The favourite just
-    /// written is what made the folder, so there is no cache to refresh
-    /// and the shelf stays unlisted until that rebuild. Said, rather than
-    /// left to be found out from the Categories screen.
     fn refresh_favorites_system(&mut self) -> Option<String> {
-        let Some(system) = self
+        let id = self
             .all_systems
             .iter()
-            .find(|system| is_favorites(system.category()))
-        else {
-            return Some(
-                "Favourites: its folder was not on the card when Degauss started, \
-                 so the shelf is not listed until Rebuild All System Lists"
-                    .to_string(),
-            );
-        };
-        let id = system.def.id.clone();
+            .find(|system| is_favorites(system.category()))?
+            .def
+            .id
+            .clone();
         self.refresh_system(&id)
     }
 

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -666,8 +666,9 @@ fn normalize_path(path: PathBuf) -> PathBuf {
 pub fn folders(root: &Path) -> Result<Vec<String>> {
     let listing = match std::fs::read_dir(root) {
         Ok(listing) => listing,
-        // A card with no favourites yet has no root. The New folder entry is
-        // how the first one is created, so absence is an empty collection.
+        // A card with no favourites yet has no root. The Main Favourites and
+        // New folder entries are how the first one is created, so absence
+        // is an empty collection.
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(e) => return Err(DegaussError::io("reading favourite folders", root, e)),
     };

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -927,6 +927,69 @@ extensions = ["nes", "mgl"]
     }
 
     #[test]
+    fn a_game_favourite_can_be_kept_directly_in_the_root() {
+        // The stock menu lists what sits directly in _@Favorites before any
+        // folder, so the root is a destination in its own right. A card
+        // with no favourites yet has no root, and the first one has to make
+        // it rather than fail on it.
+        let root = temp("root-game");
+        std::fs::remove_dir_all(&root).ok();
+        assert!(!root.exists());
+        let mgl = "<mistergamedescription><rbf>_Console/NES</rbf><file delay=\"1\" type=\"f\" index=\"1\" path=\"/media/fat/games/NES/Game.nes\"/></mistergamedescription>";
+        let written = add_game(&root, "Game", mgl).expect("the first favourite makes the root");
+        assert_eq!(written, root.join("Game.mgl"));
+        assert!(
+            std::fs::symlink_metadata(&written).unwrap().is_file(),
+            "a game favourite is a plain .mgl file"
+        );
+        assert_eq!(std::fs::read_to_string(&written).unwrap(), mgl);
+        assert!(
+            std::fs::read_dir(&root)
+                .unwrap()
+                .all(|item| !item.unwrap().path().is_dir()),
+            "the root gets the file, not a folder"
+        );
+
+        let target = Path::new("/media/fat/games/NES/Game.nes");
+        let found = Favorites::read(&root);
+        assert!(found.holds(target), "a root-level favourite is read back");
+        assert_eq!(found.file_for(target), Some(written.as_path()));
+
+        remove(&written).unwrap();
+        assert!(!Favorites::read(&root).holds(target));
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_core_favourite_can_be_linked_directly_in_the_root() {
+        // A core file kept in the root is the same link the stock script
+        // writes, only one level up; the link goes, the original stays.
+        let root = temp("root-core");
+        let games = temp("root-core-games");
+        std::fs::remove_dir_all(&root).ok();
+        assert!(!root.exists());
+        let source = games.join("Game.mra");
+        std::fs::write(&source, b"fixture core").unwrap();
+
+        let written = add_core(&root, "Game.mra", &source).expect("the first link makes the root");
+        assert_eq!(written, root.join("Game.mra"));
+        assert!(std::fs::symlink_metadata(&written)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(std::fs::read_link(&written).unwrap(), source);
+        assert!(Favorites::read(&root).holds(&source));
+
+        remove(&written).unwrap();
+        assert!(!written.exists());
+        assert!(source.is_file(), "removing the favourite keeps the game");
+        assert!(!Favorites::read(&root).holds(&source));
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&games).ok();
+    }
+
+    #[test]
     fn a_favourites_path_that_cannot_be_a_directory_is_reported() {
         // A storage/path failure must not look like an empty collection and
         // offer New folder as if nothing were wrong.

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -963,9 +963,82 @@ fn run_main_favourites_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
         !favorites_root.exists(),
         "the flow starts on a card that has no favourites yet"
     );
+    assert!(
+        !app.all_systems
+            .iter()
+            .any(|system| crate::systems::is_favorites(system.category())),
+        "a folder absent at startup is a system discovery never found"
+    );
+
+    // The chooser offers the root first even before the root exists, and
+    // leaving it without choosing drops its rows.
+    select_row_named(&mut app, "First Game");
+    accept_game_action(&mut app, ADD_FAVORITE);
+    assert_eq!(app.screen, Screen::FavoriteFolder);
+    assert_eq!(app.menu, vec![MAIN_FAVORITES, NEW_FOLDER]);
+    assert_eq!(app.favorite_destinations[0], FavoriteDestination::Root);
+    assert_eq!(app.menu_list.selected(), 0);
+    app.handle(Action::Quit);
+    assert_eq!(app.screen, Screen::Browse);
+    assert!(app.favorite_destinations.is_empty());
+    assert!(!favorites_root.exists(), "looking does not make the folder");
+
+    // The first favourite makes the root and goes straight into it. With
+    // no Favorites system discovered there is no shelf to refresh, and
+    // that is said rather than left for the Categories screen to show.
+    let root_favorite = favorites_root.join("First Game.mgl");
+    select_row_named(&mut app, "First Game");
+    accept_game_action(&mut app, ADD_FAVORITE);
+    assert_eq!(app.menu_list.selected(), 0);
+    app.handle(Action::Accept);
+    assert_eq!(app.screen, Screen::Browse);
+    assert!(app.favorite_destinations.is_empty());
+    assert!(std::fs::symlink_metadata(&root_favorite).unwrap().is_file());
+    assert!(app.favorites.holds(&game));
+    assert!(app
+        .here
+        .iter()
+        .any(|row| row.name == "First Game" && row.favorite));
+    let unlisted = app
+        .message
+        .clone()
+        .expect("an unlisted shelf is said after the write");
+    assert!(
+        unlisted.contains("not listed until Rebuild All System Lists"),
+        "the way to list the shelf is named: {unlisted}"
+    );
+    assert!(
+        crate::cache::load_system(&app.cache_dir, "Favorites").is_none(),
+        "no shelf was discovered, so none was written"
+    );
+    assert!(app
+        .systems
+        .iter()
+        .all(|system| system.def.id != "Favorites"));
+    app.handle(Action::Quit);
+    assert!(app.message.is_none());
+    // The existing removal takes it away again and says the same, since
+    // the shelf is still unlisted.
+    select_row_named(&mut app, "First Game");
+    accept_game_action(&mut app, REMOVE_FAVORITE);
+    assert_eq!(app.screen, Screen::Browse);
+    assert!(!root_favorite.exists());
+    assert!(!app.favorites.holds(&game));
+    assert!(
+        favorites_root.is_dir(),
+        "removing a favourite keeps the root"
+    );
+    assert!(app
+        .message
+        .as_deref()
+        .is_some_and(|message| message.contains("not listed until Rebuild All System Lists")));
+    app.handle(Action::Quit);
+    assert!(app.message.is_none());
+
     // The master shelf, declared the way the shipped table declares it and
-    // pointed at this card's root, so the refresh after a write has a
-    // system to rewrite.
+    // pointed at this card's root: what the full rebuild discovers now the
+    // folder is there, so the refresh after a write has a system to
+    // rewrite.
     let mut favorites = crate::systems::parse_table(
         include_str!("../assets/systems.toml"),
         Path::new("systems.toml"),
@@ -982,19 +1055,15 @@ fn run_main_favourites_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
         menu_folder: None,
     });
 
-    // The chooser offers the root first even before the root exists.
+    // Choosing the root writes the .mgl straight into _@Favorites and
+    // makes no folder named after the row.
     select_row_named(&mut app, "First Game");
     accept_game_action(&mut app, ADD_FAVORITE);
     assert_eq!(app.screen, Screen::FavoriteFolder);
     assert_eq!(app.menu, vec![MAIN_FAVORITES, NEW_FOLDER]);
-    assert_eq!(app.favorite_destinations[0], FavoriteDestination::Root);
     assert_eq!(app.menu_list.selected(), 0);
-
-    // Choosing it writes the .mgl straight into _@Favorites and makes no
-    // folder named after the row.
     app.handle(Action::Accept);
     assert_eq!(app.screen, Screen::Browse);
-    let root_favorite = favorites_root.join("First Game.mgl");
     assert!(
         std::fs::symlink_metadata(&root_favorite).unwrap().is_file(),
         "a game favourite in the root is a plain .mgl"
@@ -1114,6 +1183,33 @@ fn run_main_favourites_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
     app.handle(Action::Quit);
     assert!(app.message.is_none());
     assert_eq!(app.screen, Screen::Browse);
+
+    // When the redraw after the refusal cannot list the folder either,
+    // both causes are shown: the refusal alone would leave the emptied
+    // list looking like an empty folder once it was dismissed.
+    let place = app.trail.last().unwrap().place.clone();
+    select_row_named(&mut app, "First Game");
+    accept_game_action(&mut app, ADD_FAVORITE);
+    assert_eq!(app.screen, Screen::FavoriteFolder);
+    app.trail.last_mut().unwrap().place = Place::Dir(root.join("games/Gone"));
+    app.handle(Action::Accept);
+    assert_eq!(app.screen, Screen::Browse);
+    let both = app.message.clone().expect("both failures are reported");
+    assert!(
+        both.contains("already has a favourite called First Game"),
+        "the refusal comes first: {both}"
+    );
+    assert!(
+        both.contains("reading folder"),
+        "the listing failure is kept under it: {both}"
+    );
+    assert!(both.find("already has").unwrap() < both.find("reading folder").unwrap());
+    assert!(app.here.is_empty());
+    app.handle(Action::Quit);
+    assert!(app.message.is_none());
+    app.trail.last_mut().unwrap().place = place;
+    app.relist_here();
+    assert_eq!(app.here.len(), 2);
     std::fs::remove_file(&root_favorite).unwrap();
 
     // A folder really called Main Favourites shows the same words as the

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -1011,6 +1011,26 @@ fn run_main_favourites_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
         .here
         .iter()
         .any(|row| row.name == "First Game" && row.favorite));
+    // The refresh rewrote the shelf's cache with the root-level file, and
+    // said nothing: a shelf listed live would look the same on screen while
+    // a failed refresh went unreported.
+    assert!(app.message.is_none(), "{:?}", app.message);
+    let shelf_cache = crate::cache::load_system(&app.cache_dir, "Favorites")
+        .expect("the Favorites cache is written by the refresh");
+    assert!(
+        shelf_cache
+            .folders
+            .values()
+            .flat_map(|folder| &folder.rows)
+            .any(|row| {
+                matches!(
+                    &row.kind,
+                    browse::Kind::Play(browse::Launch::File(path)) if path == &root_favorite
+                )
+            }),
+        "the refreshed cache lists the root-level favourite: {:?}",
+        shelf_cache.folders
+    );
 
     // The shelf shows it after the existing refresh, and the existing
     // removal there takes a root-level favourite away.
@@ -1065,6 +1085,36 @@ fn run_main_favourites_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
         .here
         .iter()
         .any(|row| row.name == "Core Game" && row.favorite));
+
+    // A root-level favourite made outside Degauss, for another file but
+    // under this game's name, is not this game's favourite, so the game is
+    // still offered Add to Favourites. The write is refused by name, and
+    // the refusal is shown rather than lost to the redraw that follows it.
+    std::fs::write(
+        &root_favorite,
+        "<mistergamedescription><rbf>_Console/NES</rbf><file delay=\"1\" type=\"f\" index=\"1\" path=\"/media/fat/games/NES/Other Game.nes\"/></mistergamedescription>",
+    )
+    .unwrap();
+    select_row_named(&mut app, "First Game");
+    accept_game_action(&mut app, ADD_FAVORITE);
+    assert_eq!(app.screen, Screen::FavoriteFolder);
+    assert_eq!(app.menu_list.selected(), 0);
+    app.handle(Action::Accept);
+    assert_eq!(app.screen, Screen::Browse);
+    let refusal = app.message.clone().expect("a failed write is reported");
+    assert!(
+        refusal.contains("already has a favourite called First Game"),
+        "the real cause is shown: {refusal}"
+    );
+    assert!(
+        !app.favorites.holds(&game),
+        "a refused write does not mark the game"
+    );
+    // The next press dismisses the message and is spent on that.
+    app.handle(Action::Quit);
+    assert!(app.message.is_none());
+    assert_eq!(app.screen, Screen::Browse);
+    std::fs::remove_file(&root_favorite).unwrap();
 
     // A folder really called Main Favourites shows the same words as the
     // root and stays a destination of its own, chosen by row rather than

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -907,6 +907,231 @@ fn run_hold_y_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
     app.ui.hide().unwrap();
 }
 
+/// Open Actions over the selected game and accept one entry of its Game
+/// group, the way a controller reaches it.
+fn accept_game_action(app: &mut App, action: &str) {
+    assert_eq!(app.screen, Screen::Browse);
+    app.handle(Action::Context);
+    assert_eq!(app.screen, Screen::Context);
+    assert_eq!(
+        app.menu.first().map(String::as_str),
+        Some(ContextPage::Game.label())
+    );
+    app.menu_list.select(0);
+    app.handle(Action::Accept);
+    let index = app
+        .menu
+        .iter()
+        .position(|entry| entry == action)
+        .unwrap_or_else(|| panic!("{action} is offered: {:?}", app.menu));
+    app.menu_list.select(index);
+    app.handle(Action::Accept);
+}
+
+fn select_row_named(app: &mut App, name: &str) {
+    let index = app
+        .here
+        .iter()
+        .position(|row| row.name == name)
+        .unwrap_or_else(|| panic!("{name} is listed: {:?}", app.here));
+    app.game_list.select(index);
+}
+
+fn run_main_favourites_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
+    let root = root.join("main-favourites");
+    std::fs::create_dir_all(root.join("games/NES")).unwrap();
+    std::fs::create_dir(root.join("_Console")).unwrap();
+    std::fs::write(root.join("_Console/NES.rbf"), b"fixture core").unwrap();
+    let game = root.join("games/NES/First Game.nes");
+    std::fs::write(&game, b"fixture game").unwrap();
+    std::fs::write(
+        root.join("games/NES/gamelist.xml"),
+        "<gameList><game><path>First Game.nes</path><name>First Game</name></game></gameList>",
+    )
+    .unwrap();
+    // A ready-made descriptor is a core file to the favourites code: it is
+    // linked to rather than described again.
+    let core_file = root.join("games/NES/Core Game.mgl");
+    std::fs::write(
+        &core_file,
+        "<mistergamedescription><rbf>_Console/NES</rbf><file delay=\"1\" type=\"f\" index=\"1\" path=\"/media/fat/games/NES/Core Game.nes\"/></mistergamedescription>",
+    )
+    .unwrap();
+    let favorites_root = root.join("_@Favorites");
+    let mut app = fixture_app(&root, window, Settings::default());
+    assert!(
+        !favorites_root.exists(),
+        "the flow starts on a card that has no favourites yet"
+    );
+    // The master shelf, declared the way the shipped table declares it and
+    // pointed at this card's root, so the refresh after a write has a
+    // system to rewrite.
+    let mut favorites = crate::systems::parse_table(
+        include_str!("../assets/systems.toml"),
+        Path::new("systems.toml"),
+    )
+    .unwrap()
+    .into_iter()
+    .find(|system| system.id == "Favorites")
+    .unwrap();
+    favorites.folders = vec![favorites_root.to_string_lossy().into_owned()];
+    app.all_systems.push(FoundSystem {
+        def: favorites,
+        paths: vec![favorites_root.clone()],
+        logo_dir: None,
+        menu_folder: None,
+    });
+
+    // The chooser offers the root first even before the root exists.
+    select_row_named(&mut app, "First Game");
+    accept_game_action(&mut app, ADD_FAVORITE);
+    assert_eq!(app.screen, Screen::FavoriteFolder);
+    assert_eq!(app.menu, vec![MAIN_FAVORITES, NEW_FOLDER]);
+    assert_eq!(app.favorite_destinations[0], FavoriteDestination::Root);
+    assert_eq!(app.menu_list.selected(), 0);
+
+    // Choosing it writes the .mgl straight into _@Favorites and makes no
+    // folder named after the row.
+    app.handle(Action::Accept);
+    assert_eq!(app.screen, Screen::Browse);
+    let root_favorite = favorites_root.join("First Game.mgl");
+    assert!(
+        std::fs::symlink_metadata(&root_favorite).unwrap().is_file(),
+        "a game favourite in the root is a plain .mgl"
+    );
+    assert!(std::fs::read_to_string(&root_favorite)
+        .unwrap()
+        .contains("<mistergamedescription>"));
+    assert!(
+        !favorites_root.join(MAIN_FAVORITES).exists(),
+        "Main Favourites is the root, not a folder"
+    );
+    assert!(app.favorites.holds(&game));
+    assert!(app
+        .here
+        .iter()
+        .any(|row| row.name == "First Game" && row.favorite));
+
+    // The shelf shows it after the existing refresh, and the existing
+    // removal there takes a root-level favourite away.
+    app.open_system_by_index(1);
+    assert_eq!(app.open_system.as_deref(), Some("Favorites"));
+    assert!(app.in_favorites());
+    assert!(
+        app.here.iter().any(|row| {
+            row.name == "First Game"
+                && matches!(
+                    &row.kind,
+                    browse::Kind::Play(browse::Launch::File(path)) if path == &root_favorite
+                )
+        }),
+        "the shelf lists the root-level favourite: {:?}",
+        app.here
+    );
+    select_row_named(&mut app, "First Game");
+    accept_game_action(&mut app, REMOVE_FAVORITE);
+    assert_eq!(app.screen, Screen::Browse);
+    assert!(app.message.is_none(), "{:?}", app.message);
+    assert!(!root_favorite.exists());
+    assert!(!app.here.iter().any(|row| row.name == "First Game"));
+    assert!(!app.favorites.holds(&game));
+
+    // The held-X shortcut reaches the same chooser, and a core file kept
+    // in the root is the standard link.
+    app.open_system_by_index(0);
+    assert_eq!(app.open_system.as_deref(), Some("NES"));
+    select_option(&mut app, OptionsPage::Navigation, OptionId::HoldXFavorite);
+    app.handle(Action::Accept);
+    assert!(app.hold_x_favorite);
+    app.handle(Action::Quit);
+    app.handle(Action::Quit);
+    app.handle(Action::Quit);
+    assert_eq!(app.screen, Screen::Browse);
+    select_row_named(&mut app, "Core Game");
+    assert_eq!(app.favorite_change(), Some(FavoriteChange::Add));
+    app.handle(Action::FavoriteShortcut);
+    assert_eq!(app.screen, Screen::FavoriteFolder);
+    assert_eq!(app.menu.first().map(String::as_str), Some(MAIN_FAVORITES));
+    app.handle(Action::Accept);
+    assert_eq!(app.screen, Screen::Browse);
+    let root_link = favorites_root.join("Core Game.mgl");
+    assert!(std::fs::symlink_metadata(&root_link)
+        .unwrap()
+        .file_type()
+        .is_symlink());
+    assert_eq!(std::fs::read_link(&root_link).unwrap(), core_file);
+    assert!(app.favorites.holds(&core_file));
+    assert!(app
+        .here
+        .iter()
+        .any(|row| row.name == "Core Game" && row.favorite));
+
+    // A folder really called Main Favourites shows the same words as the
+    // root and stays a destination of its own, chosen by row rather than
+    // by label.
+    let named_folder = favorites_root.join(MAIN_FAVORITES);
+    std::fs::create_dir(&named_folder).unwrap();
+    select_row_named(&mut app, "First Game");
+    accept_game_action(&mut app, ADD_FAVORITE);
+    assert_eq!(app.screen, Screen::FavoriteFolder);
+    assert_eq!(app.menu, vec![MAIN_FAVORITES, MAIN_FAVORITES, NEW_FOLDER]);
+    assert_eq!(
+        app.favorite_destinations,
+        vec![
+            FavoriteDestination::Root,
+            FavoriteDestination::Folder(MAIN_FAVORITES.to_string()),
+            FavoriteDestination::NewFolder,
+        ]
+    );
+    app.menu_list.select(1);
+    app.handle(Action::Accept);
+    assert_eq!(app.screen, Screen::Browse);
+    assert!(named_folder.join("First Game.mgl").is_file());
+    assert!(
+        !root_favorite.exists(),
+        "the folder's row must not write into the root"
+    );
+    assert!(app.favorites.holds(&game));
+    select_row_named(&mut app, "First Game");
+    accept_game_action(&mut app, REMOVE_FAVORITE);
+    assert!(!named_folder.join("First Game.mgl").exists());
+    assert!(!app.favorites.holds(&game));
+    select_row_named(&mut app, "First Game");
+    accept_game_action(&mut app, ADD_FAVORITE);
+    assert_eq!(app.menu.len(), 3);
+    app.menu_list.select(0);
+    app.handle(Action::Accept);
+    assert!(root_favorite.is_file());
+    assert!(
+        !named_folder.join("First Game.mgl").exists(),
+        "the root's row must not write into the folder of the same name"
+    );
+    select_row_named(&mut app, "First Game");
+    accept_game_action(&mut app, REMOVE_FAVORITE);
+    assert!(!root_favorite.exists());
+    assert!(!app.favorites.holds(&game));
+
+    // Naming a new folder is still the last row and still makes the folder
+    // before writing into it.
+    select_row_named(&mut app, "First Game");
+    accept_game_action(&mut app, ADD_FAVORITE);
+    app.menu_list.select(app.menu.len() - 1);
+    app.handle(Action::Accept);
+    assert_eq!(app.screen, Screen::Find);
+    assert_eq!(app.find_mode, FindMode::NewFolder);
+    assert!(app.filter.is_empty());
+    app.filter = "ARCADE".into();
+    app.handle(Action::Quit);
+    assert_eq!(app.screen, Screen::Browse);
+    assert!(favorites_root.join("ARCADE/First Game.mgl").is_file());
+    assert!(
+        !favorites_root.join("First Game.mgl").exists(),
+        "the new folder's row must not write into the root"
+    );
+    assert!(app.favorites.holds(&game));
+    app.ui.hide().unwrap();
+}
+
 fn run_scraper_cache_refresh_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
     let root = root.join("scraper-refresh");
     let games = root.join("games/NES");
@@ -3574,6 +3799,7 @@ pub(super) fn run_ui_acceptance_flow(window: Rc<MinimalSoftwareWindow>) {
     drop(restarted);
     run_favorite_information_flow(&root, window.clone());
     run_hold_y_flow(&root, window.clone());
+    run_main_favourites_flow(&root, window.clone());
     run_scraper_cache_refresh_flow(&root, window.clone());
     run_indexing_ui_flow(&root, window.clone());
     capture_ui_if_requested(&root, window);

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -985,7 +985,8 @@ fn run_main_favourites_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
 
     // The first favourite makes the root and goes straight into it. With
     // no Favorites system discovered there is no shelf to refresh, and
-    // that is said rather than left for the Categories screen to show.
+    // the save stays press-free, the way a folder save on such a card has
+    // always been: the shelf is listed by the next full rebuild.
     let root_favorite = favorites_root.join("First Game.mgl");
     select_row_named(&mut app, "First Game");
     accept_game_action(&mut app, ADD_FAVORITE);
@@ -999,13 +1000,10 @@ fn run_main_favourites_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
         .here
         .iter()
         .any(|row| row.name == "First Game" && row.favorite));
-    let unlisted = app
-        .message
-        .clone()
-        .expect("an unlisted shelf is said after the write");
     assert!(
-        unlisted.contains("not listed until Rebuild All System Lists"),
-        "the way to list the shelf is named: {unlisted}"
+        app.message.is_none(),
+        "a save with no shelf to refresh costs no press: {:?}",
+        app.message
     );
     assert!(
         crate::cache::load_system(&app.cache_dir, "Favorites").is_none(),
@@ -1015,10 +1013,7 @@ fn run_main_favourites_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
         .systems
         .iter()
         .all(|system| system.def.id != "Favorites"));
-    app.handle(Action::Quit);
-    assert!(app.message.is_none());
-    // The existing removal takes it away again and says the same, since
-    // the shelf is still unlisted.
+    // The existing removal takes it away again, as press-free as before.
     select_row_named(&mut app, "First Game");
     accept_game_action(&mut app, REMOVE_FAVORITE);
     assert_eq!(app.screen, Screen::Browse);
@@ -1028,12 +1023,7 @@ fn run_main_favourites_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
         favorites_root.is_dir(),
         "removing a favourite keeps the root"
     );
-    assert!(app
-        .message
-        .as_deref()
-        .is_some_and(|message| message.contains("not listed until Rebuild All System Lists")));
-    app.handle(Action::Quit);
-    assert!(app.message.is_none());
+    assert!(app.message.is_none(), "{:?}", app.message);
 
     // The master shelf, declared the way the shipped table declares it and
     // pointed at this card's root: what the full rebuild discovers now the


### PR DESCRIPTION
## Summary

- The favourite-folder chooser lists **Main Favourites** first, then the existing folders in their listed order, then **New folder...**. It is reached from the Add to Favourites action and from the optional hold-X shortcut alike.
- Choosing Main Favourites writes the favourite directly under `_@Favorites`: a standard `.mgl` for a game, the existing symlink representation for a core file. No folder named after the row is created. When `_@Favorites` does not exist yet, the first favourite creates it, as a folder save already did.
- Each chooser row carries a typed destination (`Root`, `Folder(name)`, `NewFolder`) rather than being identified by its label, so a real user folder called Main Favourites is listed after the root as a distinct, selectable folder.
- The new favourite appears in the main Favourites shelf after the existing refresh, and a root-level favourite is removed through the existing removal flow.
- A refused favourite write (a name already present in the chosen destination, or an I/O failure) and a failed removal are now shown after the redraw that follows them; before, that redraw cleared the message. When the redraw itself cannot list the folder, both causes are shown, the refusal first.
- The "kept in" confirmation set before that same redraw was never visible in any release; it is removed together with the payloads that only fed it. Adding a favourite stays press-free.
- README: the Actions paragraph, the X control row, the Hold X option row and the favourites feature bullet describe the chooser and the root destination.

Fixes #55

## Compatibility

- Existing subfolder selection and New folder behaviour are unchanged. One delta follows from the typed rows: the chooser used to recognise the naming row by comparing the row's label with "New folder...", so a user folder literally named "New folder..." opened the name grid instead of taking the favourite. Such a folder is now a selectable folder like any other.
- Favourite files are written in MiSTer's own format at the same locations the stock menu reads; favourite reading, removal, settings, cache format and installation are untouched. No migration or rebuild is required.
- On a card that had no `_@Favorites` when Degauss started, the first favourite creates the folder and the save is press-free, but the Favourites shelf is listed only after Rebuild All System Lists, as before this change. The README states this.
- The context help for Add to Favourites reads "Keep the selected game in Main Favourites or in a Favourites folder."

## Tests

- `favorites::tests::a_game_favourite_can_be_kept_directly_in_the_root`: with no root present, `add_game` creates `_@Favorites` and writes a plain `.mgl` directly in it, no folder is created, the favourite is read back and resolved for its game, and `remove` takes it away.
- `favorites::tests::a_core_favourite_can_be_linked_directly_in_the_root` (unix): a core file kept in the root is a symlink to the original, is read back as the favourite of that file, and removing it keeps the original.
- `app::tests::main_favourites_is_the_first_destination_and_new_folder_the_last`: row order and labels, including a card with no folders (root and naming row only).
- `app::tests::a_user_folder_called_main_favourites_stays_distinct_from_the_root`: two rows with identical labels compare unequal as destinations, so the folder cannot be mistaken for the root.
- `app::tests::a_user_folder_called_new_folder_is_a_folder_and_not_the_naming_row`: a folder literally named "New folder..." is a `Folder` destination and the naming row stays last.
- `run_main_favourites_flow` in the UI acceptance flow: starts with no Favorites system and no `_@Favorites`; opening and leaving the chooser creates nothing and drops its rows; a root save creates the folder, writes the `.mgl` there with no message, and the existing removal takes it away; with the Favorites system discovered, a root save is reflected in the shelf's cache and in the shelf itself, where the removal flow drops it; the hold-X shortcut reaches the same chooser and links a core file in the root; a root-level name collision is reported on screen and is dismissed by the next press; a refusal combined with a listing failure shows both causes in order; a real folder called Main Favourites is listed after the root, written to as a folder, and removed from as a folder while the root's file stays.
- The host capture of the chooser frame shows Main Favourites as the first, selected row above New folder...

## Validation

- Host gates on the branch head: `cargo fmt --check`, `cargo test`, the release rehearsal and RA release checks, and `cargo clippy --target armv7-unknown-linux-musleabihf --all-targets -- -D warnings`, all passing.
- CodeRabbit CLI review against main reports no findings.
- The chooser was rendered on the host from the acceptance capture; it is the existing plain row list with the new first row.
- Not validated on a MiSTer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer favourite destinations, including **Main Favourites**, existing folders and newly created folders.
  * Favourites can be created directly in the main area or within nested folders.
  * Favourite shortcuts now open the same folder-selection interface.
  * Favourite shelf navigation and folder creation are supported.

* **Bug Fixes**
  * Improved handling of folders with names matching special entries.
  * Favourites now refresh and display correctly after creation or removal.
  * Added safeguards against duplicate favourite names.

* **Documentation**
  * Updated the favourites documentation to explain main-area storage, nested folders and folder selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->