### PR TITLE
Add Details Style option for information or larger artwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,14 +510,11 @@ unless a library read starts at the same time and takes the screen first,
 and always in `/tmp/degauss.log`, which is the copy that survives such a
 read. Pictures are decoded to `cover_size` in `degauss.toml` or half the
 longer screen edge, whichever is larger. With the shipped `cover_size` of
-320 and the default 5% screen margins, the Large Artwork box outgrows that
-decode on screens wider than about 590 pixels for a landscape picture, and
-for a portrait picture from about 570 pixels on a 4:3 screen and about 540
-pixels on a 5:4 screen, so a picture is drawn a little enlarged there: up
-to about a tenth wider, and up to about a quarter taller in the portrait
-case. Smaller margins lower those widths. A `cover_size` of at least two
-thirds of the screen width keeps every picture within its decode at the
-default margins.
+320 and the default screen margins, the Large Artwork box outgrows that
+decode on screens wider than about 600 pixels (a little sooner for a
+portrait picture on a 4:3 or 5:4 screen), so a picture is drawn slightly
+enlarged there; a `cover_size` of at least two thirds of the screen width
+keeps every picture within its decode.
 
 **Options → Appearance → View** is the global default. Every browse place can instead
 keep its own custom view: the Categories screen, each category's Systems
@@ -692,9 +689,9 @@ is running appears after the next start. `Green Mono`, `Modern` and `Neon` remai
 available without files because they are built into Degauss. The chosen theme
 is remembered by name in `settings.toml`. If that name resolves to neither a
 built-in theme nor a valid card-theme file, Degauss uses the standard palette
-and a message says so. A same-name card file takes precedence over a built-in;
-if that file is broken, Degauss reports it instead of concealing it with the
-built-in theme.
+and a message says so on the first screen and in `/tmp/degauss.log`. A
+same-name card file takes precedence over a built-in; if that file is broken,
+Degauss reports it instead of concealing it with the built-in theme.
 
 #### Editing a theme on-device
 

--- a/README.md
+++ b/README.md
@@ -485,8 +485,13 @@ running under Degauss Main already have the Frontend menu and shortcut.
 ## Views
 
 - **List**: plain text in one column.
-- **Details**: the list beside a large picture, with a compact year/players
-  and publisher summary. Game Information opens the complete metadata.
+- **Details**: the list beside a large picture. **Options → Appearance →
+  Details Style** chooses how the two share the screen while browsing games:
+  **Information**, the default, keeps the list wider with a compact
+  year/players and publisher summary under the picture; **Large Artwork**
+  gives the picture most of the width and the whole height of its column,
+  with no lines under it. Game Information in Actions opens the complete
+  metadata in either style.
 - **Tiled**: a grid of pictures with their titles underneath.
 - **Carousel**: one large cover with its neighbours either side.
 - **Multi list**: two text columns in reading order, showing twice as many entries
@@ -558,6 +563,7 @@ require **A** and confirmation, never a sideways press.
 | Appearance | Theme | Left and right choose a palette. Press A to open the editor. Standard uses the colours in `degauss.toml`. See [Themes and colours](#themes-and-colours) |
 | Appearance | View | The global default for places without a custom view: Details, Tiled, Carousel, List, Multi List or Gallery |
 | Appearance | Reset All Custom Views | With A and confirmation, remove every place-specific view without changing the global View setting |
+| Appearance | Details Style | How Details shares the screen while browsing games. Information (default) keeps the list beside a picture of about 42% of the width with the compact summary under it; Large Artwork gives the picture about 62% of the width and the whole height of its column, with no lines under it. Home, category and system screens and the other views are unchanged, and switching does not rebuild the library or the artwork cache |
 | Appearance | Text | The typeface: Smooth, Pixel (a DOS font on whole pixels), and the bolder Smooth 2 and Pixel 2 |
 | Appearance | Artwork | Turn pictures off entirely |
 | Appearance | Artwork Scale Factor | Framebuffer keeps the original square-pixel fit and is the default. 4:3 and 16:9 correct game artwork for that physical display shape in Details, Tiled, Carousel and Gallery. Category logos, system logos and the screensaver are unchanged |
@@ -1426,8 +1432,10 @@ framebuffer, which works while the frontend is running. `--screen`,
 shows. `--layout` accepts `details`, `tiled`, `list`, `carousel`,
 `multi-list` and `gallery`. An explicit `--layout` is temporary and takes
 precedence over saved global and custom views; without it, render, bench and
-selftest use Details. This headless facility is useful for inspection and
-diagnostics; it is separate from capturing the live MiSTer framebuffer.
+selftest use Details. A Details frame follows the Details Style saved in
+`settings.toml`; there is no separate flag for it. This headless facility is
+useful for inspection and diagnostics; it is separate from capturing the live
+MiSTer framebuffer.
 
 `--screen options` shows the Options categories. Add
 `--options-page navigation|appearance|library|display|developer` to render

--- a/README.md
+++ b/README.md
@@ -511,10 +511,10 @@ and always in `/tmp/degauss.log`, which is the copy that survives such a
 read. Pictures are decoded to `cover_size` in `degauss.toml` or half the
 longer screen edge, whichever is larger. With the shipped `cover_size` of
 320 and the default screen margins, the Large Artwork box outgrows that
-decode on screens wider than about 600 pixels (a little sooner for a
-portrait picture on a 4:3 or 5:4 screen), so a picture is drawn slightly
-enlarged there; a `cover_size` of at least two thirds of the screen width
-keeps every picture within its decode.
+decode on landscape screens wider than about 600 pixels (a little sooner
+for a portrait picture on a 4:3 or 5:4 screen), so a picture is drawn
+slightly enlarged there; on a landscape screen, a `cover_size` of at least
+two thirds of the screen width keeps every picture within its decode.
 
 **Options → Appearance → View** is the global default. Every browse place can instead
 keep its own custom view: the Categories screen, each category's Systems
@@ -689,7 +689,8 @@ is running appears after the next start. `Green Mono`, `Modern` and `Neon` remai
 available without files because they are built into Degauss. The chosen theme
 is remembered by name in `settings.toml`. If that name resolves to neither a
 built-in theme nor a valid card-theme file, Degauss uses the standard palette
-and a message says so on the first screen and in `/tmp/degauss.log`. A
+and a message says so on the first screen (unless a library read starts at
+the same time and takes the screen first) and in `/tmp/degauss.log`. A
 same-name card file takes precedence over a built-in; if that file is broken,
 Degauss reports it instead of concealing it with the built-in theme.
 

--- a/README.md
+++ b/README.md
@@ -500,6 +500,13 @@ running under Degauss Main already have the Frontend menu and shortcut.
   image has an outline and its title appears above the bottom bar for half a
   second. Entries without artwork remain visible as named text cells.
 
+The Details Style changes only the games level of Details: the Home,
+category and system screens and the other views keep their proportions, and
+switching it does not rebuild the library or the artwork cache. Pictures are
+decoded to `cover_size` in `degauss.toml` or half the screen, whichever is
+larger, so on a screen wider than about twice that edge Large Artwork
+enlarges a landscape picture a little; a larger `cover_size` keeps it sharp.
+
 **Options → Appearance → View** is the global default. Every browse place can instead
 keep its own custom view: the Categories screen, each category's Systems
 screen, each system root, and every folder inside a system. Use **X Actions →
@@ -564,7 +571,7 @@ require **A** and confirmation, never a sideways press.
 | Appearance | Theme | Left and right choose a palette. Press A to open the editor. Standard uses the colours in `degauss.toml`. See [Themes and colours](#themes-and-colours) |
 | Appearance | View | The global default for places without a custom view: Details, Tiled, Carousel, List, Multi List or Gallery |
 | Appearance | Reset All Custom Views | With A and confirmation, remove every place-specific view without changing the global View setting |
-| Appearance | Details Style | How Details shares the screen while browsing games. Information (default) keeps the list beside a picture of about 42% of the width with the compact summary under it; Large Artwork gives the picture about 62% of the width and the whole height of its column, with no lines under it. Home, category and system screens and the other views are unchanged, and switching does not rebuild the library or the artwork cache. Pictures are decoded to `cover_size` in `degauss.toml` or half the screen, whichever is larger, so on a screen wider than about twice that edge Large Artwork enlarges a landscape picture a little; a larger `cover_size` keeps it sharp |
+| Appearance | Details Style | How Details shares the screen while browsing games. Information (default) keeps the list beside a picture of about 42% of the width, with the compact summary under it; Large Artwork gives the picture about 62% and the whole column height, with no lines under it. An unrecognised saved value draws Information and says so on the first screen |
 | Appearance | Text | The typeface: Smooth, Pixel (a DOS font on whole pixels), and the bolder Smooth 2 and Pixel 2 |
 | Appearance | Artwork | Turn pictures off entirely |
 | Appearance | Artwork Scale Factor | Framebuffer keeps the original square-pixel fit and is the default. 4:3 and 16:9 correct game artwork for that physical display shape in Details, Tiled, Carousel and Gallery. Category logos, system logos and the screensaver are unchanged |

--- a/README.md
+++ b/README.md
@@ -533,8 +533,8 @@ inspect long values and the full description; left/right moves by a page.
 without launching it or changing the view. Information comes from the system's
 selected Gamelist or Artwork Pack source, including for favourites. Missing
 fields remain empty. Details in its Information style keeps the compact
-summary and Large Artwork drops it; Information is where all available fields
-and the complete description can be read.
+summary and Large Artwork drops it; Game Information is where all available
+fields and the complete description can be read.
 
 Complete descriptions are read only when Game Information opens, with a visible
 loading or error state. Existing compact caches remain valid; no library rebuild
@@ -575,7 +575,7 @@ require **A** and confirmation, never a sideways press.
 | Appearance | Theme | Left and right choose a palette. Press A to open the editor. Standard uses the colours in `degauss.toml`. See [Themes and colours](#themes-and-colours) |
 | Appearance | View | The global default for places without a custom view: Details, Tiled, Carousel, List, Multi List or Gallery |
 | Appearance | Reset All Custom Views | With A and confirmation, remove every place-specific view without changing the global View setting |
-| Appearance | Details Style | How Details shares the screen while browsing games. Information (default) keeps the list beside a picture of about 42% of the width, with the compact summary under it; Large Artwork gives the picture about 62% and the whole column height, with no lines under it. An unrecognised saved value draws Information and says so on the first screen |
+| Appearance | Details Style | How Details shares the screen while browsing games. Information (default) keeps the list beside a picture of about 42% of the width, with the compact summary under it; Large Artwork gives the picture about 62% and the whole column height, with no lines under it. An unrecognised saved value draws Information and says so on the first screen, unless a library read starts at the same time |
 | Appearance | Text | The typeface: Smooth, Pixel (a DOS font on whole pixels), and the bolder Smooth 2 and Pixel 2 |
 | Appearance | Artwork | Turn pictures off entirely |
 | Appearance | Artwork Scale Factor | Framebuffer keeps the original square-pixel fit and is the default. 4:3 and 16:9 correct game artwork for that physical display shape in Details, Tiled, Carousel and Gallery. Category logos, system logos and the screensaver are unchanged |

--- a/README.md
+++ b/README.md
@@ -502,14 +502,22 @@ running under Degauss Main already have the Frontend menu and shortcut.
 
 The Details Style changes only the games level of Details: the Home,
 category and system screens and the other views keep their proportions, and
-switching it does not rebuild the library or the artwork cache. Pictures are
-decoded to `cover_size` in `degauss.toml` or half the longer screen edge,
-whichever is larger. With the default `cover_size` the Large Artwork box
-outgrows that decode on screens wider than about 580 pixels, so a picture is
-drawn a little enlarged there: up to about a tenth wider for a landscape
-picture, and up to about a quarter taller for a portrait one on a 4:3 or 5:4
-screen. A `cover_size` of at least two thirds of the screen width keeps every
-picture within its decode.
+switching it does not rebuild the library or the artwork cache. It is saved
+as `details_style` in `settings.toml`; a saved value that is neither
+`information` nor `large-artwork` draws Information and is left in the file
+for you to correct. That substitution is reported on the first screen,
+unless a library read starts at the same time and takes the screen first,
+and always in `/tmp/degauss.log`, which is the copy that survives such a
+read. Pictures are decoded to `cover_size` in `degauss.toml` or half the
+longer screen edge, whichever is larger. With the shipped `cover_size` of
+320 and the default 5% screen margins, the Large Artwork box outgrows that
+decode on screens wider than about 590 pixels for a landscape picture, and
+for a portrait picture from about 570 pixels on a 4:3 screen and about 540
+pixels on a 5:4 screen, so a picture is drawn a little enlarged there: up
+to about a tenth wider, and up to about a quarter taller in the portrait
+case. Smaller margins lower those widths. A `cover_size` of at least two
+thirds of the screen width keeps every picture within its decode at the
+default margins.
 
 **Options → Appearance → View** is the global default. Every browse place can instead
 keep its own custom view: the Categories screen, each category's Systems
@@ -575,7 +583,7 @@ require **A** and confirmation, never a sideways press.
 | Appearance | Theme | Left and right choose a palette. Press A to open the editor. Standard uses the colours in `degauss.toml`. See [Themes and colours](#themes-and-colours) |
 | Appearance | View | The global default for places without a custom view: Details, Tiled, Carousel, List, Multi List or Gallery |
 | Appearance | Reset All Custom Views | With A and confirmation, remove every place-specific view without changing the global View setting |
-| Appearance | Details Style | How Details shares the screen while browsing games. Information (default) keeps the list beside a picture of about 42% of the width, with the compact summary under it; Large Artwork gives the picture about 62% and the whole column height, with no lines under it. An unrecognised saved value draws Information and says so on the first screen, unless a library read starts at the same time |
+| Appearance | Details Style | How Details shares the screen while browsing games. Information (default) keeps the list beside a picture of about 42% of the width, with the compact summary under it; Large Artwork gives the picture about 62% and the whole column height, with no lines under it |
 | Appearance | Text | The typeface: Smooth, Pixel (a DOS font on whole pixels), and the bolder Smooth 2 and Pixel 2 |
 | Appearance | Artwork | Turn pictures off entirely |
 | Appearance | Artwork Scale Factor | Framebuffer keeps the original square-pixel fit and is the default. 4:3 and 16:9 correct game artwork for that physical display shape in Details, Tiled, Carousel and Gallery. Category logos, system logos and the screensaver are unchanged |

--- a/README.md
+++ b/README.md
@@ -503,9 +503,13 @@ running under Degauss Main already have the Frontend menu and shortcut.
 The Details Style changes only the games level of Details: the Home,
 category and system screens and the other views keep their proportions, and
 switching it does not rebuild the library or the artwork cache. Pictures are
-decoded to `cover_size` in `degauss.toml` or half the screen, whichever is
-larger, so on a screen wider than about twice that edge Large Artwork
-enlarges a landscape picture a little; a larger `cover_size` keeps it sharp.
+decoded to `cover_size` in `degauss.toml` or half the longer screen edge,
+whichever is larger. With the default `cover_size` the Large Artwork box
+outgrows that decode on screens wider than about 580 pixels, so a picture is
+drawn a little enlarged there: up to about a tenth wider for a landscape
+picture, and up to about a quarter taller for a portrait one on a 4:3 or 5:4
+screen. A `cover_size` of at least two thirds of the screen width keeps every
+picture within its decode.
 
 **Options → Appearance → View** is the global default. Every browse place can instead
 keep its own custom view: the Categories screen, each category's Systems

--- a/README.md
+++ b/README.md
@@ -521,8 +521,9 @@ inspect long values and the full description; left/right moves by a page.
 **B** or **X** returns to Actions / Game, and backing out restores the same game
 without launching it or changing the view. Information comes from the system's
 selected Gamelist or Artwork Pack source, including for favourites. Missing
-fields remain empty. Details keeps the compact summary; Information is where
-all available fields and the complete description can be read.
+fields remain empty. Details in its Information style keeps the compact
+summary and Large Artwork drops it; Information is where all available fields
+and the complete description can be read.
 
 Complete descriptions are read only when Game Information opens, with a visible
 loading or error state. Existing compact caches remain valid; no library rebuild
@@ -563,7 +564,7 @@ require **A** and confirmation, never a sideways press.
 | Appearance | Theme | Left and right choose a palette. Press A to open the editor. Standard uses the colours in `degauss.toml`. See [Themes and colours](#themes-and-colours) |
 | Appearance | View | The global default for places without a custom view: Details, Tiled, Carousel, List, Multi List or Gallery |
 | Appearance | Reset All Custom Views | With A and confirmation, remove every place-specific view without changing the global View setting |
-| Appearance | Details Style | How Details shares the screen while browsing games. Information (default) keeps the list beside a picture of about 42% of the width with the compact summary under it; Large Artwork gives the picture about 62% of the width and the whole height of its column, with no lines under it. Home, category and system screens and the other views are unchanged, and switching does not rebuild the library or the artwork cache |
+| Appearance | Details Style | How Details shares the screen while browsing games. Information (default) keeps the list beside a picture of about 42% of the width with the compact summary under it; Large Artwork gives the picture about 62% of the width and the whole height of its column, with no lines under it. Home, category and system screens and the other views are unchanged, and switching does not rebuild the library or the artwork cache. Pictures are decoded to `cover_size` in `degauss.toml` or half the screen, whichever is larger, so on a screen wider than about twice that edge Large Artwork enlarges a landscape picture a little; a larger `cover_size` keeps it sharp |
 | Appearance | Text | The typeface: Smooth, Pixel (a DOS font on whole pixels), and the bolder Smooth 2 and Pixel 2 |
 | Appearance | Artwork | Turn pictures off entirely |
 | Appearance | Artwork Scale Factor | Framebuffer keeps the original square-pixel fit and is the default. 4:3 and 16:9 correct game artwork for that physical display shape in Details, Tiled, Carousel and Gallery. Category logos, system logos and the screensaver are unchanged |

--- a/degauss.toml
+++ b/degauss.toml
@@ -36,7 +36,8 @@ menu_root = "/media/fat"
 
 [app]
 # Longest edge artwork is decoded to. The picture view draws it at roughly
-# half the screen, so this wants to be at least that big.
+# half the screen, or about 62% of the width with the Large Artwork Details
+# Style, so this wants to be at least that big.
 cover_size = 320
 
 # How many decoded pictures to keep in memory. Memory only, never the card.

--- a/deploy/Scripts/.config/degauss/degauss.toml
+++ b/deploy/Scripts/.config/degauss/degauss.toml
@@ -36,7 +36,8 @@ menu_root = "/media/fat"
 
 [app]
 # Longest edge artwork is decoded to. The picture view draws it at roughly
-# half the screen, so this wants to be at least that big.
+# half the screen, or about 62% of the width with the Large Artwork Details
+# Style, so this wants to be at least that big.
 cover_size = 320
 
 # How many decoded pictures to keep in memory. Memory only, never the card.

--- a/src/app.rs
+++ b/src/app.rs
@@ -3110,7 +3110,7 @@ impl App {
         } = loaded;
         let ThemeSet {
             themes,
-            problems: mut theme_problems,
+            problems: mut startup_problems,
         } = themes;
         let scraper_settings_path = crate::scraper::ScraperSettings::path_beside(&settings_path);
         let (scraper_settings, scraper_settings_problem) =
@@ -3140,7 +3140,7 @@ impl App {
                     // "Did not load" rather than "is missing": the file may
                     // be there and broken, in which case the folder's own
                     // problem line above this one says what is wrong.
-                    theme_problems.push(format!("Theme {name} did not load; using standard."));
+                    startup_problems.push(format!("Theme {name} did not load; using standard."));
                 }
                 found
             }
@@ -3170,7 +3170,7 @@ impl App {
         let details_style = match settings.details_style.as_deref() {
             None => DetailsStyle::default(),
             Some(text) => DetailsStyle::parse(text).unwrap_or_else(|| {
-                theme_problems.push(format!(
+                startup_problems.push(format!(
                     "Details Style {text} is not information or large-artwork; using Information."
                 ));
                 DetailsStyle::default()
@@ -3493,11 +3493,11 @@ impl App {
         // Details Style token that is neither name, is said out loud on the
         // first screen. Any press takes it down, and a first-start library
         // read replaces it with its own progress, so the log keeps a copy.
-        if !theme_problems.is_empty() {
-            for line in &theme_problems {
+        if !startup_problems.is_empty() {
+            for line in &startup_problems {
                 crate::note(&format!("startup      {line}"));
             }
-            app.message = Some(theme_problems.join("\n"));
+            app.message = Some(startup_problems.join("\n"));
             app.startup_problems = app.message.clone();
         }
         app.resolve_artwork_sources(None, SourceResolutionAction::Startup);

--- a/src/app.rs
+++ b/src/app.rs
@@ -3159,11 +3159,19 @@ impl App {
             .as_deref()
             .and_then(ArtworkScale::parse)
             .unwrap_or_default();
-        let details_style = settings
-            .details_style
-            .as_deref()
-            .and_then(DetailsStyle::parse)
-            .unwrap_or_default();
+        // Absent means the layout older installations draw. A token that
+        // is present but not one of the two names is said out loud rather
+        // than quietly drawn as Information, and stays in settings.toml
+        // untouched, like a theme name the folder does not answer to.
+        let details_style = match settings.details_style.as_deref() {
+            None => DetailsStyle::default(),
+            Some(text) => DetailsStyle::parse(text).unwrap_or_else(|| {
+                theme_problems.push(format!(
+                    "Details Style {text} is not information or large-artwork; using Information."
+                ));
+                DetailsStyle::default()
+            }),
+        };
         // Margins are saved when changed and read back here. Without this the
         // Options screen would show the saved figure while the screen kept
         // the one from the config file, and the two would disagree.
@@ -3476,8 +3484,9 @@ impl App {
             }));
         app.ui.set_about_copyright(SharedString::from(COPYRIGHT));
         app.ui.set_about_licence(SharedString::from(LICENCE));
-        // A theme file that did not load, or a saved theme that is gone, is
-        // said out loud on the first screen. Any press takes it down.
+        // A theme file that did not load, a saved theme that is gone, or a
+        // Details Style token that is neither name, is said out loud on the
+        // first screen. Any press takes it down.
         if !theme_problems.is_empty() {
             app.message = Some(theme_problems.join("\n"));
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -7673,9 +7673,6 @@ impl App {
                 let at = step(self.details_style.index(), delta, DetailsStyle::ALL.len());
                 self.details_style = DetailsStyle::ALL[at];
                 self.settings.details_style = Some(self.details_style.setting().to_string());
-                // Only the shape of the browse screen changes; the picture
-                // and the lists are what they were.
-                self.apply_geometry();
             }
             OptionId::ShowStats => {
                 self.show_stats = !self.show_stats;

--- a/src/app.rs
+++ b/src/app.rs
@@ -3055,6 +3055,10 @@ pub struct App {
     /// Seed for picking a game at random.
     seed: u64,
     message: Option<String>,
+    /// The theme and Details Style problem lines the first screen carries,
+    /// kept apart so the startup source check can tell them from whatever
+    /// has been put on screen since.
+    startup_problems: Option<String>,
     dirty: bool,
 }
 
@@ -3452,6 +3456,7 @@ impl App {
             message_after_build: None,
             skipped_systems: false,
             message: None,
+            startup_problems: None,
             dirty: true,
         };
         app.all_systems = std::mem::take(&mut app.systems);
@@ -3489,6 +3494,7 @@ impl App {
         // first screen. Any press takes it down.
         if !theme_problems.is_empty() {
             app.message = Some(theme_problems.join("\n"));
+            app.startup_problems = app.message.clone();
         }
         app.resolve_artwork_sources(None, SourceResolutionAction::Startup);
         app.apply_geometry();
@@ -5004,16 +5010,22 @@ impl App {
     }
 
     /// What the screen says once a source check is in. Startup keeps the
-    /// lines the first screen already carries, a theme or Details Style
-    /// problem waiting for a press, and puts the check's word under them;
-    /// every other check replaces its own "Checking..." line.
+    /// lines the first screen carries, a theme or Details Style problem
+    /// waiting for a press, and puts the check's word under them; once
+    /// something else is on screen, the build report opened with a press
+    /// or nothing at all, the check's word stands alone. Every other check
+    /// replaces its own "Checking..." line.
     fn report_source_check(&mut self, action: SourceResolutionAction, text: Option<String>) {
-        self.message = match (action, self.message.take(), text) {
-            (SourceResolutionAction::Startup, Some(lines), Some(text)) => {
-                Some(format!("{lines}\n{text}"))
-            }
-            (SourceResolutionAction::Startup, lines, text) => lines.or(text),
-            (_, _, text) => text,
+        let lines = match action {
+            SourceResolutionAction::Startup => self
+                .startup_problems
+                .take()
+                .filter(|lines| self.message.as_deref() == Some(lines.as_str())),
+            _ => None,
+        };
+        self.message = match (lines, text) {
+            (Some(lines), Some(text)) => Some(format!("{lines}\n{text}")),
+            (lines, text) => lines.or(text),
         };
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3491,8 +3491,12 @@ impl App {
         app.ui.set_about_licence(SharedString::from(LICENCE));
         // A theme file that did not load, a saved theme that is gone, or a
         // Details Style token that is neither name, is said out loud on the
-        // first screen. Any press takes it down.
+        // first screen. Any press takes it down, and a first-start library
+        // read replaces it with its own progress, so the log keeps a copy.
         if !theme_problems.is_empty() {
+            for line in &theme_problems {
+                crate::note(&format!("startup      {line}"));
+            }
             app.message = Some(theme_problems.join("\n"));
             app.startup_problems = app.message.clone();
         }
@@ -5062,7 +5066,7 @@ impl App {
                     self.build = None;
                     self.ui.set_index_active(false);
                 }
-                self.message = Some("Game data source check cancelled".into());
+                self.report_source_check(action, Some("Game data source check cancelled".into()));
                 self.dirty = true;
                 return;
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -260,6 +260,7 @@ fn option_operation(option: OptionId, input: OptionInput) -> OptionOperation {
         | OptionId::Font
         | OptionId::ShowArt
         | OptionId::ArtworkScale
+        | OptionId::DetailsStyle
         | OptionId::ShowHidden
         | OptionId::ShowEmpty
         | OptionId::ShowOther
@@ -809,6 +810,63 @@ impl ArtworkScale {
             "framebuffer dimensions are non-zero"
         );
         (width as f32 / height as f32) / display_aspect
+    }
+}
+
+/// How Details divides its width between the list and the picture, and
+/// whether the compact lines sit under the picture. The stored names are
+/// part of the settings format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DetailsStyle {
+    /// Preserve the original layout: the list beside a picture with the
+    /// compact summary, publisher and information hint under it.
+    #[default]
+    Information,
+    /// A wider picture taking the whole height of its column, with no
+    /// lines under it.
+    LargeArtwork,
+}
+
+impl DetailsStyle {
+    const ALL: [DetailsStyle; 2] = [DetailsStyle::Information, DetailsStyle::LargeArtwork];
+
+    fn setting(self) -> &'static str {
+        match self {
+            DetailsStyle::Information => "information",
+            DetailsStyle::LargeArtwork => "large-artwork",
+        }
+    }
+
+    fn shown(self) -> &'static str {
+        match self {
+            DetailsStyle::Information => "Information",
+            DetailsStyle::LargeArtwork => "Large Artwork",
+        }
+    }
+
+    fn parse(text: &str) -> Option<Self> {
+        match text {
+            "information" => Some(DetailsStyle::Information),
+            "large-artwork" => Some(DetailsStyle::LargeArtwork),
+            _ => None,
+        }
+    }
+
+    fn index(self) -> usize {
+        DetailsStyle::ALL
+            .iter()
+            .position(|&style| style == self)
+            .expect("every details style is listed")
+    }
+
+    /// What the picture's half of the safe width becomes while browsing
+    /// games: 42% for Information, which leaves the list room for a long
+    /// title, and 62% for Large Artwork.
+    fn art_factor(self) -> f32 {
+        match self {
+            DetailsStyle::Information => 0.84,
+            DetailsStyle::LargeArtwork => 1.24,
+        }
     }
 }
 
@@ -2822,6 +2880,7 @@ pub struct App {
     speed: usize,
     show_art: bool,
     artwork_scale: ArtworkScale,
+    details_style: DetailsStyle,
     show_stats: bool,
     show_hidden: bool,
     /// Every system found, before hiding is applied. `systems` is the
@@ -3100,6 +3159,11 @@ impl App {
             .as_deref()
             .and_then(ArtworkScale::parse)
             .unwrap_or_default();
+        let details_style = settings
+            .details_style
+            .as_deref()
+            .and_then(DetailsStyle::parse)
+            .unwrap_or_default();
         // Margins are saved when changed and read back here. Without this the
         // Options screen would show the saved figure while the screen kept
         // the one from the config file, and the two would disagree.
@@ -3188,6 +3252,7 @@ impl App {
                 .min(SPEED_STEPS.len() - 1),
             show_art: settings.show_art.unwrap_or(true),
             artwork_scale,
+            details_style,
             show_stats: settings.show_stats.unwrap_or(config.app.show_stats),
             show_hidden: settings.show_hidden.unwrap_or(false),
             all_systems: Vec::new(),
@@ -3490,8 +3555,9 @@ impl App {
             && self.browsing == Browsing::Games
             && self.layout == Layout::Details
         {
-            // The approved compact preview leaves more room for game titles.
-            geometry.art_width *= 0.84;
+            // The approved compact preview leaves more room for game titles;
+            // Large Artwork gives that room to the picture instead.
+            geometry.art_width *= self.details_style.art_factor();
         }
         let help_height = if matches!(
             self.screen,
@@ -7603,6 +7669,14 @@ impl App {
                 self.settings.artwork_scale = Some(self.artwork_scale.setting().to_string());
                 self.touch_selection();
             }
+            OptionId::DetailsStyle => {
+                let at = step(self.details_style.index(), delta, DetailsStyle::ALL.len());
+                self.details_style = DetailsStyle::ALL[at];
+                self.settings.details_style = Some(self.details_style.setting().to_string());
+                // Only the shape of the browse screen changes; the picture
+                // and the lists are what they were.
+                self.apply_geometry();
+            }
             OptionId::ShowStats => {
                 self.show_stats = !self.show_stats;
                 self.settings.show_stats = Some(self.show_stats);
@@ -7762,6 +7836,7 @@ impl App {
             },
             OptionId::ShowArt => on_off(self.show_art),
             OptionId::ArtworkScale => self.artwork_scale.shown().to_string(),
+            OptionId::DetailsStyle => self.details_style.shown().to_string(),
             OptionId::ShowStats => on_off(self.show_stats),
             OptionId::Present => capitalised(self.present_label),
             OptionId::ShowHidden => on_off(self.show_hidden),
@@ -12798,7 +12873,11 @@ impl App {
                 .is_some_and(|row| !row.is_folder());
         // Not the carousel: it is a row of pictures, and six lines of text
         // under them leaves the picture too small to be the point of it.
-        let wants = self.layout == Layout::Details && over_game;
+        // Not Large Artwork either: its rows go to the picture, and Game
+        // Information in Actions still carries every line.
+        let wants = self.layout == Layout::Details
+            && over_game
+            && self.details_style == DetailsStyle::Information;
         self.ui.set_detail_line(line);
         self.ui.set_detail_height(if wants { panel } else { 0.0 });
     }
@@ -15816,6 +15895,27 @@ mod tests {
             ArtworkScale::Framebuffer,
             "an absent setting must retain the original geometry"
         );
+    }
+
+    #[test]
+    fn every_details_style_is_reachable_and_round_trips() {
+        // The option cycles only through ALL and persists the setting token.
+        // Missing either side would make a style unreachable or forget it
+        // at the next start.
+        for (at, style) in DetailsStyle::ALL.iter().copied().enumerate() {
+            assert_eq!(style.index(), at);
+            assert_eq!(DetailsStyle::parse(style.setting()), Some(style));
+        }
+        assert_eq!(DetailsStyle::parse("nonsense"), None);
+        assert_eq!(
+            DetailsStyle::default(),
+            DetailsStyle::Information,
+            "an absent setting must draw the layout older installations have"
+        );
+        // Half the safe width times these factors is the 42% and 62% the
+        // two styles give the picture; the list keeps the rest.
+        assert!((0.5 * DetailsStyle::Information.art_factor() - 0.42).abs() < 0.0001);
+        assert!((0.5 * DetailsStyle::LargeArtwork.art_factor() - 0.62).abs() < 0.0001);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -4997,10 +4997,24 @@ impl App {
                     self.build = None;
                     self.ui.set_index_active(false);
                 }
-                self.message = Some(error.to_string());
+                self.report_source_check(action, Some(error.to_string()));
             }
         }
         self.dirty = true;
+    }
+
+    /// What the screen says once a source check is in. Startup keeps the
+    /// lines the first screen already carries, a theme or Details Style
+    /// problem waiting for a press, and puts the check's word under them;
+    /// every other check replaces its own "Checking..." line.
+    fn report_source_check(&mut self, action: SourceResolutionAction, text: Option<String>) {
+        self.message = match (action, self.message.take(), text) {
+            (SourceResolutionAction::Startup, Some(lines), Some(text)) => {
+                Some(format!("{lines}\n{text}"))
+            }
+            (SourceResolutionAction::Startup, lines, text) => lines.or(text),
+            (_, _, text) => text,
+        };
     }
 
     fn poll_artwork_sources(&mut self) {
@@ -5054,7 +5068,7 @@ impl App {
                     self.build = None;
                     self.ui.set_index_active(false);
                 }
-                self.message = Some(error.to_string());
+                self.report_source_check(action, Some(error.to_string()));
                 self.dirty = true;
                 return;
             }
@@ -5109,7 +5123,7 @@ impl App {
                 self.artwork_source_errors.insert(group, error.clone());
             }
         }
-        self.message = (!resolution.errors.is_empty()).then(|| {
+        let errors = (!resolution.errors.is_empty()).then(|| {
             resolution
                 .errors
                 .values()
@@ -5117,6 +5131,7 @@ impl App {
                 .collect::<Vec<_>>()
                 .join("\n")
         });
+        self.report_source_check(action, errors);
         match action {
             SourceResolutionAction::Startup => {
                 let missing_pack_cache = self.all_systems.iter().any(|system| {

--- a/src/options.rs
+++ b/src/options.rs
@@ -290,7 +290,7 @@ impl OptionId {
                 "Remove all custom views after confirmation. Every place will use the global view."
             }
             OptionId::DetailsStyle => {
-                "Information keeps the compact summary under the picture. Large Artwork widens the picture to the full height."
+                "Information keeps the summary under the picture. Large Artwork gives it more width and the full height."
             }
             OptionId::Font => {
                 "Choose Smooth or Pixel text. Smooth 2 and Pixel 2 use bolder lettering."

--- a/src/options.rs
+++ b/src/options.rs
@@ -21,6 +21,9 @@ pub enum OptionId {
     Layout,
     /// Remove every place-specific view after confirmation.
     ResetCustomViews,
+    /// How Details shares its width between the list and the picture, and
+    /// whether the compact lines sit under the picture.
+    DetailsStyle,
     /// Which typeface the interface is set in.
     Font,
     /// Which named palette from the themes folder is on, if any.
@@ -83,6 +86,7 @@ pub const OPTIONS: &[OptionId] = &[
     OptionId::Theme,
     OptionId::Layout,
     OptionId::ResetCustomViews,
+    OptionId::DetailsStyle,
     OptionId::Font,
     OptionId::ShowArt,
     OptionId::ArtworkScale,
@@ -195,6 +199,7 @@ impl OptionsPage {
                 OptionId::Theme,
                 OptionId::Layout,
                 OptionId::ResetCustomViews,
+                OptionId::DetailsStyle,
                 OptionId::Font,
                 OptionId::ShowArt,
                 OptionId::ArtworkScale,
@@ -234,6 +239,7 @@ impl OptionId {
             OptionId::ArtLimit => "Skip Artwork Faster Than",
             OptionId::Layout => "View",
             OptionId::ResetCustomViews => "Reset All Custom Views",
+            OptionId::DetailsStyle => "Details Style",
             OptionId::Font => "Text",
             OptionId::Theme => "Theme",
             OptionId::ShowArt => "Artwork",
@@ -282,6 +288,9 @@ impl OptionId {
             }
             OptionId::ResetCustomViews => {
                 "Remove all custom views after confirmation. Every place will use the global view."
+            }
+            OptionId::DetailsStyle => {
+                "Information keeps the compact summary under the picture. Large Artwork widens the picture to the full height."
             }
             OptionId::Font => {
                 "Choose Smooth or Pixel text. Smooth 2 and Pixel 2 use bolder lettering."

--- a/src/options.rs
+++ b/src/options.rs
@@ -290,7 +290,7 @@ impl OptionId {
                 "Remove all custom views after confirmation. Every place will use the global view."
             }
             OptionId::DetailsStyle => {
-                "Information keeps the summary under the picture. Large Artwork gives it more width and the full height."
+                "Information keeps the summary under the picture. Large Artwork uses the whole column."
             }
             OptionId::Font => {
                 "Choose Smooth or Pixel text. Smooth 2 and Pixel 2 use bolder lettering."

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -148,6 +148,11 @@ pub struct Settings {
     /// framebuffer-pixel behaviour.
     #[serde(default)]
     pub artwork_scale: Option<String>,
+    /// How Details balances the list, the picture and the compact lines:
+    /// "information" or "large-artwork". Absent means information, the
+    /// layout Degauss always drew.
+    #[serde(default)]
+    pub details_style: Option<String>,
     pub present: Option<String>,
     /// Systems the user has hidden, by id. Hiding is per-system and
     /// reversible; nothing is ever removed from the table.
@@ -321,6 +326,10 @@ mod tests {
         assert_eq!(settings.theme_font_override, None);
         assert_eq!(settings.layout.as_deref(), Some("details"));
         assert!(settings.artwork_scale.is_none());
+        assert!(
+            settings.details_style.is_none(),
+            "an older settings file must keep the Information layout it was drawn with"
+        );
         assert_eq!(settings.overscan_x, Some(5));
         assert_eq!(settings.hidden, ["PDP1", "VC4000"]);
         assert_eq!(settings.folder_views.len(), 2);
@@ -351,6 +360,7 @@ mod tests {
         assert_eq!(settings.folder_views.len(), 2);
         assert!(settings.custom_views.is_empty());
         assert!(settings.artwork_scale.is_none());
+        assert!(settings.details_style.is_none());
         assert_eq!(settings.hold_x_favorite, None);
         assert_eq!(settings.hold_y_random, None);
         assert!(
@@ -383,6 +393,7 @@ mod tests {
             art_limit: Some(0),
             layout: Some("covers".into()),
             artwork_scale: Some("4:3".into()),
+            details_style: Some("large-artwork".into()),
             left_right: Some("letter".into()),
             font: Some("pixel".into()),
             theme_font_override: Some(true),

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3221,6 +3221,33 @@ fn run_details_style_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
         app.ui.hide().unwrap();
     }
 
+    // A token that is neither name is not quietly drawn as Information:
+    // the first screen says so, and the text stays in the setting for the
+    // user to correct rather than being replaced by a choice never made.
+    {
+        let app = unopened_fixture_app(
+            root,
+            window.clone(),
+            Settings {
+                details_style: Some("large_artwork".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(app.details_style, DetailsStyle::Information);
+        assert_eq!(
+            app.settings.details_style.as_deref(),
+            Some("large_artwork"),
+            "startup must not rewrite the text it could not read"
+        );
+        let message = app
+            .message
+            .clone()
+            .expect("an unreadable Details Style is reported at start");
+        assert!(message.contains("large_artwork"), "{message}");
+        assert!(message.contains("using Information"), "{message}");
+        app.ui.hide().unwrap();
+    }
+
     // Both styles persist: the choice is written when the page is left and
     // survives a fresh App from the reloaded file, in both directions.
     let mut app = fixture_app(root, window.clone(), Settings::default());

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -2535,7 +2535,13 @@ fn capture_ui_if_requested(root: &Path, window: Rc<MinimalSoftwareWindow>) {
             240,
         );
         app.open_options_page(OptionsPage::Appearance);
-        app.select(3);
+        app.select(
+            OptionsPage::Appearance
+                .ids()
+                .iter()
+                .position(|id| *id == OptionId::Font)
+                .unwrap(),
+        );
         capture_frame(
             &mut app,
             &directory,

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3231,8 +3231,14 @@ fn run_details_style_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
     // the first screen says so, and the text stays in the setting for the
     // user to correct rather than being replaced by a choice never made.
     // The startup source check finishes before anyone has read the line,
-    // so its result must go under the report rather than replace it.
+    // so its result must go under the report rather than replace it. The
+    // log gets the same line, because a first-start library read takes
+    // the screen before it and would leave the substitution without a
+    // trace.
     {
+        let log_before = std::fs::metadata(crate::LOG_PATH)
+            .map(|meta| meta.len() as usize)
+            .unwrap_or(0);
         let mut app = unopened_fixture_app(
             root,
             window.clone(),
@@ -3246,6 +3252,19 @@ fn run_details_style_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
             app.settings.details_style.as_deref(),
             Some("large_artwork"),
             "startup must not rewrite the text it could not read"
+        );
+        // The log is the one path outside the fixture; a log that cannot
+        // be read fails the same assertion, with the reason in its place.
+        let logged = match std::fs::read(crate::LOG_PATH) {
+            Ok(log) => String::from_utf8_lossy(&log[log_before.min(log.len())..]).into_owned(),
+            Err(error) => format!(
+                "(the log at {} could not be read: {error})",
+                crate::LOG_PATH
+            ),
+        };
+        assert!(
+            logged.contains("Details Style large_artwork is not information or large-artwork"),
+            "the unreadable token is logged: {logged}"
         );
         app.finish_background_work_for_headless();
         assert!(
@@ -3264,6 +3283,44 @@ fn run_details_style_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
             app.message.is_none(),
             "a press takes the report down: {:?}",
             app.message
+        );
+        app.ui.hide().unwrap();
+    }
+
+    // Cancelling the startup check with B is its third way to finish and
+    // follows the same rule as the other two: the problem lines stay and
+    // the check's word goes under them, and the lines are given up so
+    // nothing later can put them back over another message.
+    {
+        let mut app = unopened_fixture_app(
+            root,
+            window.clone(),
+            Settings {
+                details_style: Some("large_artwork".into()),
+                ..Default::default()
+            },
+        );
+        assert!(
+            app.source_resolution.is_some() && app.build.is_none(),
+            "the startup check is pending and B can cancel it"
+        );
+        app.handle(Action::Quit);
+        app.finish_background_work_for_headless();
+        let message = app
+            .message
+            .clone()
+            .expect("the cancelled check leaves the problem lines up");
+        assert!(
+            message.starts_with("Details Style large_artwork"),
+            "{message}"
+        );
+        assert!(
+            message.ends_with("\nGame data source check cancelled"),
+            "{message}"
+        );
+        assert!(
+            app.startup_problems.is_none(),
+            "every completion of the startup check takes the lines"
         );
         app.ui.hide().unwrap();
     }

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3261,6 +3261,52 @@ fn run_details_style_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
         app.ui.hide().unwrap();
     }
 
+    // A first start reads the card, and a press while the startup check is
+    // pending opens the build report in place of the problem lines. A
+    // check that then fails must say only its own word: the report it did
+    // not write, ending in "No problems reported", must not stand above
+    // the failure.
+    {
+        let first = root.join("details-style-first-start");
+        std::fs::create_dir_all(first.join("games/NES")).unwrap();
+        std::fs::write(first.join("games/NES/First Game.nes"), b"fixture").unwrap();
+        let mut app = unopened_fixture_app(
+            &first,
+            window.clone(),
+            Settings {
+                details_style: Some("large_artwork".into()),
+                ..Default::default()
+            },
+        );
+        assert!(app.build.is_some(), "a first start reads the card");
+        assert!(
+            app.source_resolution.is_some(),
+            "the startup check is still pending"
+        );
+        assert!(
+            app.message
+                .as_deref()
+                .is_some_and(|message| message.contains("large_artwork")),
+            "{:?}",
+            app.message
+        );
+        app.leave_splash();
+        app.handle(Action::Accept);
+        assert!(app.index_details, "a press opens the build report");
+        let report = app.message.clone().expect("the build report is on screen");
+        assert!(report.contains("No problems reported"), "{report}");
+        app.report_source_check(
+            SourceResolutionAction::Startup,
+            Some("Game data source check failed".into()),
+        );
+        assert_eq!(
+            app.message.as_deref(),
+            Some("Game data source check failed"),
+            "a failed check replaces the report it did not write"
+        );
+        app.ui.hide().unwrap();
+    }
+
     // Both styles persist: the choice is written when the page is left and
     // survives a fresh App from the reloaded file, in both directions.
     let mut app = fixture_app(root, window.clone(), Settings::default());

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3149,16 +3149,19 @@ fn assert_details_split(app: &App, style: DetailsStyle, over_game: bool, context
     assert_eq!(app.details_style, style, "{context}");
     assert_eq!(app.layout, Layout::Details, "{context}");
     // The picture's share of the safe width while browsing games, 42% for
-    // Information and 62% for Large Artwork, pinned as the share itself
-    // rather than the multiplier applied to the half, so a drift in either
-    // the base split or the factor fails here.
+    // Information and 62% for Large Artwork, measured from the safe width
+    // itself rather than from the Details half, so a drift in either the
+    // base split or the factor fails here. The half is rounded to a pixel
+    // before the factor, hence the tolerance.
     let share = match style {
         DetailsStyle::Information => 0.42,
         DetailsStyle::LargeArtwork => 0.62,
     };
-    let expected = 2.0 * details_half_width(app) * share;
+    let inset = (app.width as f32 * app.config.app.overscan_x as f32 / 100.0).round();
+    let safe = (app.width as f32 - inset * 2.0).max(64.0);
+    let expected = safe * share;
     assert!(
-        (app.ui.get_art_width() - expected).abs() < 0.01,
+        (app.ui.get_art_width() - expected).abs() <= 1.0,
         "{context}: {style:?} must give the picture {expected} of the width, not {}",
         app.ui.get_art_width()
     );
@@ -3189,8 +3192,6 @@ fn leave_options_to_browse(app: &mut App) {
 fn run_details_style_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
     let artwork = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/logos/NES.png");
     assert!(artwork.is_file());
-    let captures = root.join("details-style");
-    std::fs::create_dir_all(&captures).unwrap();
 
     // An older settings file has no key: it must draw exactly the layout
     // it was drawn with, and starting must not write a choice the user
@@ -3484,8 +3485,14 @@ fn run_details_style_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
         app.details_style = style;
         app.game_list.select(1);
         for (width, height) in [(352, 240), (640, 480), (1280, 720)] {
-            let name = format!("details-{}", style.setting());
-            capture_frame(&mut app, &captures, &name, width, height);
+            app.width = width;
+            app.height = height;
+            app.window.set_size(slint::PhysicalSize::new(width, height));
+            app.apply_geometry();
+            if let Some(directory) = std::env::var_os("DEGAUSS_UI_CAPTURE_DIR") {
+                let name = format!("details-{}", style.setting());
+                capture_frame(&mut app, &PathBuf::from(directory), &name, width, height);
+            }
             app.load_art();
             app.refresh();
             assert_details_split(&app, style, true, &format!("{width}x{height}"));

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3389,6 +3389,32 @@ fn run_details_style_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
         assert!(app.ui.get_has_art());
     }
 
+    // The display correction belongs to the picture, not to the style:
+    // 4:3 artwork on a 4:3 tube needs the same horizontal stretch whether
+    // its column is the narrow one or the wide one.
+    app.game_list.select(1);
+    app.artwork_scale = ArtworkScale::FourThree;
+    let corrected = artwork_horizontal(ArtworkScale::FourThree, app.width, app.height, true);
+    assert!(
+        (corrected - 1.0).abs() > 0.01,
+        "the fixture screen must need correction for this to prove anything"
+    );
+    for style in DetailsStyle::ALL {
+        app.details_style = style;
+        app.apply_geometry();
+        app.load_art();
+        app.refresh();
+        assert!(app.ui.get_has_art());
+        assert_eq!(
+            app.ui.get_art_scale_x(),
+            corrected,
+            "{style:?} must keep the artwork aspect correction"
+        );
+    }
+    app.artwork_scale = ArtworkScale::Framebuffer;
+    app.load_art();
+    assert_eq!(app.ui.get_art_scale_x(), 1.0);
+
     // The tube first, then the higher resolutions: every one of them
     // draws through the same split and hands the picture the whole column
     // in Large Artwork.

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3145,19 +3145,18 @@ fn details_half_width(app: &App) -> f32 {
     .art_width
 }
 
-/// The multiplier each style applies to that half while browsing games:
-/// 42% of the width for Information, 62% for Large Artwork.
-fn details_style_factor(style: DetailsStyle) -> f32 {
-    match style {
-        DetailsStyle::Information => 0.84,
-        DetailsStyle::LargeArtwork => 1.24,
-    }
-}
-
 fn assert_details_split(app: &App, style: DetailsStyle, over_game: bool, context: &str) {
     assert_eq!(app.details_style, style, "{context}");
     assert_eq!(app.layout, Layout::Details, "{context}");
-    let expected = details_half_width(app) * details_style_factor(style);
+    // The picture's share of the safe width while browsing games, 42% for
+    // Information and 62% for Large Artwork, pinned as the share itself
+    // rather than the multiplier applied to the half, so a drift in either
+    // the base split or the factor fails here.
+    let share = match style {
+        DetailsStyle::Information => 0.42,
+        DetailsStyle::LargeArtwork => 0.62,
+    };
+    let expected = 2.0 * details_half_width(app) * share;
     assert!(
         (app.ui.get_art_width() - expected).abs() < 0.01,
         "{context}: {style:?} must give the picture {expected} of the width, not {}",
@@ -3304,7 +3303,6 @@ fn run_details_style_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
         .cycle()
         .take(120)
         .collect();
-    assert_eq!(long_title.chars().count(), 120);
     let game = |name: &str, cover: Option<PathBuf>| {
         let mut row = information_row();
         row.name = name.to_string();

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3130,6 +3130,332 @@ fn run_auto_source_choice_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
     app.ui.hide().unwrap();
 }
 
+/// The picture's half of the safe width in Details, before the browse-games
+/// split is applied to it.
+fn details_half_width(app: &App) -> f32 {
+    Geometry::compute(
+        Layout::Details,
+        app.plain_screen(),
+        app.chrome_here(),
+        app.bar_here(),
+        app.width,
+        app.height,
+        &app.config,
+    )
+    .art_width
+}
+
+/// The multiplier each style applies to that half while browsing games:
+/// 42% of the width for Information, 62% for Large Artwork.
+fn details_style_factor(style: DetailsStyle) -> f32 {
+    match style {
+        DetailsStyle::Information => 0.84,
+        DetailsStyle::LargeArtwork => 1.24,
+    }
+}
+
+fn assert_details_split(app: &App, style: DetailsStyle, over_game: bool, context: &str) {
+    assert_eq!(app.details_style, style, "{context}");
+    assert_eq!(app.layout, Layout::Details, "{context}");
+    let expected = details_half_width(app) * details_style_factor(style);
+    assert!(
+        (app.ui.get_art_width() - expected).abs() < 0.01,
+        "{context}: {style:?} must give the picture {expected} of the width, not {}",
+        app.ui.get_art_width()
+    );
+    let panel = app.ui.get_detail_height();
+    match style {
+        DetailsStyle::Information if over_game => assert!(
+            panel > 0.0,
+            "{context}: Information keeps the compact lines under the picture"
+        ),
+        DetailsStyle::Information => {
+            assert_eq!(panel, 0.0, "{context}: a folder has no compact lines")
+        }
+        DetailsStyle::LargeArtwork => assert_eq!(
+            panel, 0.0,
+            "{context}: Large Artwork gives the whole column height to the picture"
+        ),
+    }
+}
+
+fn leave_options_to_browse(app: &mut App) {
+    app.handle(Action::Quit);
+    assert_eq!(app.screen, Screen::OptionsRoot, "leaving the page saves");
+    app.handle(Action::Quit);
+    app.handle(Action::Quit);
+    assert_eq!(app.screen, Screen::Browse);
+}
+
+fn run_details_style_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
+    let artwork = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/logos/NES.png");
+    assert!(artwork.is_file());
+    let captures = root.join("details-style");
+    std::fs::create_dir_all(&captures).unwrap();
+
+    // An older settings file has no key: it must draw exactly the layout
+    // it was drawn with, and starting must not write a choice the user
+    // never made. The legacy "preview" name still means Details.
+    let games_place = {
+        let app = fixture_app(root, window.clone(), Settings::default());
+        let place = app.current_view_place().unwrap();
+        app.ui.hide().unwrap();
+        place
+    };
+    for layout in [None, Some("preview")] {
+        let mut app = fixture_app(
+            root,
+            window.clone(),
+            Settings {
+                layout: layout.map(str::to_string),
+                ..Default::default()
+            },
+        );
+        app.refresh();
+        assert_details_split(&app, DetailsStyle::Information, true, "no saved key");
+        assert!(
+            app.settings.details_style.is_none(),
+            "startup must not rewrite a choice"
+        );
+        assert_eq!(app.option_value(OptionId::DetailsStyle), "Information");
+        app.ui.hide().unwrap();
+    }
+
+    // Both styles persist: the choice is written when the page is left and
+    // survives a fresh App from the reloaded file, in both directions.
+    let mut app = fixture_app(root, window.clone(), Settings::default());
+    let cache_before = cache_snapshot(&app.cache_dir);
+    for (style, saved) in [
+        (DetailsStyle::LargeArtwork, "large-artwork"),
+        (DetailsStyle::Information, "information"),
+    ] {
+        let loads = app.art.loads;
+        select_option(&mut app, OptionsPage::Appearance, OptionId::DetailsStyle);
+        app.handle(Action::Faster);
+        assert_eq!(app.details_style, style);
+        assert_eq!(app.option_value(OptionId::DetailsStyle), style.shown());
+        assert_eq!(
+            app.art.loads, loads,
+            "a style change must not decode or load a picture"
+        );
+        assert!(
+            app.build.is_none(),
+            "a style change must not rebuild the library"
+        );
+        leave_options_to_browse(&mut app);
+        app.refresh();
+        assert_details_split(&app, style, true, "after leaving Options");
+        assert_eq!(app.settings.details_style.as_deref(), Some(saved));
+        let reloaded = Settings::load(&app.settings_path).unwrap();
+        assert_eq!(reloaded.details_style.as_deref(), Some(saved));
+        assert_eq!(
+            cache_snapshot(&app.cache_dir),
+            cache_before,
+            "a display option must not touch the index or the artwork cache"
+        );
+        app.ui.hide().unwrap();
+        drop(app);
+        app = fixture_app(root, window.clone(), reloaded);
+        app.refresh();
+        assert_details_split(&app, style, true, "the saved style survives restart");
+        assert_eq!(app.settings.details_style.as_deref(), Some(saved));
+    }
+    // Left steps back through the same two values, so neither is a dead end.
+    select_option(&mut app, OptionsPage::Appearance, OptionId::DetailsStyle);
+    app.handle(Action::Slower);
+    assert_eq!(app.details_style, DetailsStyle::LargeArtwork);
+    app.handle(Action::Slower);
+    assert_eq!(app.details_style, DetailsStyle::Information);
+    leave_options_to_browse(&mut app);
+
+    // A folder, a game with a picture, a game without one and a title far
+    // longer than the list column: every one has to remain usable in both
+    // styles. The long title is left to the row to elide or scroll; the
+    // list must hand it over whole.
+    let long_title: String = "Fixture Game With A Very Long Name "
+        .chars()
+        .cycle()
+        .take(120)
+        .collect();
+    assert_eq!(long_title.chars().count(), 120);
+    let game = |name: &str, cover: Option<PathBuf>| {
+        let mut row = information_row();
+        row.name = name.to_string();
+        row.sort_key = row.name.to_ascii_uppercase();
+        row.kind = browse::Kind::Play(browse::Launch::File(root.join("games/NES/First Game.nes")));
+        row.cover = cover;
+        row
+    };
+    let rows = vec![
+        browse::Row {
+            name: "Fixture Folder".into(),
+            sort_key: "FIXTURE FOLDER".into(),
+            kind: browse::Kind::Enter(Place::Dir(root.join("games/NES"))),
+            cover: None,
+            genre: None,
+            favorite: false,
+            below: Some(2),
+            details: browse::Details::default(),
+        },
+        game("Fixture Game With Picture", Some(artwork.clone())),
+        game("Fixture Game Without Picture", None),
+        game(&long_title, Some(artwork.clone())),
+    ];
+    app.here = rows.clone();
+    app.all_here = rows;
+    app.game_list = ListState::new(app.here.len(), app.geometry.visible);
+    for style in DetailsStyle::ALL {
+        app.details_style = style;
+        app.apply_geometry();
+        for (index, has_art, over_game) in [
+            (0, false, false),
+            (1, true, true),
+            (2, false, true),
+            (3, true, true),
+        ] {
+            app.game_list.select(index);
+            app.load_art();
+            app.refresh();
+            let context = format!("{style:?} over row {index}");
+            assert_details_split(&app, style, over_game, &context);
+            assert_eq!(app.ui.get_has_art(), has_art, "{context}");
+            if !has_art {
+                assert_eq!(
+                    app.ui.get_art_caption().as_str(),
+                    app.here[index].name,
+                    "{context}: the name stands in for a missing picture"
+                );
+            }
+            // A folder's title is bracketed; a game's is the name itself.
+            let title = app
+                .rows
+                .row_data(app.ui.get_selected() as usize)
+                .unwrap()
+                .title;
+            assert!(
+                title.contains(app.here[index].name.as_str()),
+                "{context}: the selected row must carry its whole title, not {title:?}"
+            );
+            app.open_context();
+            assert_eq!(app.screen, Screen::Context);
+            assert_eq!(
+                app.context_actions
+                    .iter()
+                    .any(|entry| entry == GAME_INFORMATION),
+                over_game,
+                "{context}: Game Information stays in Actions in both styles"
+            );
+            app.handle(Action::Quit);
+            assert_eq!(app.screen, Screen::Browse);
+        }
+        // With artwork off the column shows the name instead of the
+        // picture; the split and the compact lines are the style's own.
+        app.game_list.select(1);
+        app.show_art = false;
+        app.load_art();
+        app.refresh();
+        assert!(!app.ui.get_has_art());
+        assert_details_split(&app, style, true, "artwork off");
+        app.show_art = true;
+        app.load_art();
+        app.refresh();
+        assert!(app.ui.get_has_art());
+    }
+
+    // The tube first, then the higher resolutions: every one of them
+    // draws through the same split and hands the picture the whole column
+    // in Large Artwork.
+    for style in DetailsStyle::ALL {
+        app.details_style = style;
+        app.game_list.select(1);
+        for (width, height) in [(352, 240), (640, 480), (1280, 720)] {
+            let name = format!("details-{}", style.setting());
+            capture_frame(&mut app, &captures, &name, width, height);
+            app.load_art();
+            app.refresh();
+            assert_details_split(&app, style, true, &format!("{width}x{height}"));
+        }
+    }
+    app.width = 352;
+    app.height = 240;
+    app.window.set_size(slint::PhysicalSize::new(352, 240));
+    app.apply_geometry();
+
+    // Only the games level of Details changes shape. The category and
+    // system screens keep the half split their logos are placed in, and
+    // every other view keeps the whole width for its rows.
+    for style in DetailsStyle::ALL {
+        app.details_style = style;
+        for browsing in [Browsing::Categories, Browsing::Systems] {
+            app.browsing = browsing;
+            app.apply_geometry();
+            assert!(
+                (app.ui.get_art_width() - details_half_width(&app)).abs() < 0.01,
+                "{style:?} must leave {browsing:?} at half the width"
+            );
+            assert_eq!(app.ui.get_detail_height(), 0.0);
+        }
+        app.browsing = Browsing::Games;
+        for layout in Layout::ALL {
+            if layout == Layout::Details {
+                continue;
+            }
+            app.layout = layout;
+            app.apply_geometry();
+            assert_eq!(
+                app.ui.get_art_width(),
+                0.0,
+                "{style:?} must leave {layout:?} without a picture column"
+            );
+            assert_eq!(app.ui.get_detail_height(), 0.0);
+        }
+        app.layout = Layout::Details;
+        app.apply_geometry();
+    }
+    app.ui.hide().unwrap();
+    drop(app);
+
+    // A custom view naming Details, and the legacy "preview" spelling,
+    // resolve to Details under either style: this is a style of one view,
+    // not a seventh view.
+    for (style, saved) in [
+        (DetailsStyle::Information, "information"),
+        (DetailsStyle::LargeArtwork, "large-artwork"),
+    ] {
+        let mut custom_views = CustomViews::default();
+        games_place.set(&mut custom_views, "details".into());
+        let mut app = fixture_app(
+            root,
+            window.clone(),
+            Settings {
+                layout: Some("tiled".into()),
+                custom_views,
+                details_style: Some(saved.into()),
+                ..Default::default()
+            },
+        );
+        app.refresh();
+        assert_eq!(app.global_layout, Layout::Tiled);
+        assert_details_split(&app, style, true, "custom Details view");
+        app.ui.hide().unwrap();
+        drop(app);
+
+        let mut app = fixture_app(
+            root,
+            window.clone(),
+            Settings {
+                layout: Some("preview".into()),
+                details_style: Some(saved.into()),
+                ..Default::default()
+            },
+        );
+        app.refresh();
+        assert_eq!(app.global_layout, Layout::Details);
+        assert_details_split(&app, style, true, "legacy preview view");
+        app.ui.hide().unwrap();
+    }
+}
+
 pub(super) fn run_ui_acceptance_flow(window: Rc<MinimalSoftwareWindow>) {
     let root = fixture_directory();
     std::fs::create_dir_all(root.join("games/NES")).unwrap();
@@ -3141,6 +3467,7 @@ pub(super) fn run_ui_acceptance_flow(window: Rc<MinimalSoftwareWindow>) {
     let gamelist_xml = format!("<gameList><game><path>First Game.nes</path><desc><![CDATA[{complete_description}]]></desc></game><game><path>Second Game.nes</path><desc><![CDATA[{complete_description}]]></desc></game></gameList>");
     std::fs::write(&gamelist_path, &gamelist_xml).unwrap();
     run_browse_bar_settings_flow(&root, window.clone());
+    run_details_style_flow(&root, window.clone());
     run_scripts_flow(&root, window.clone());
     run_artwork_matte_flow(&root, window.clone());
     run_fresh_auto_pack_index_flow(&root, window.clone());

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3223,8 +3223,10 @@ fn run_details_style_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
     // A token that is neither name is not quietly drawn as Information:
     // the first screen says so, and the text stays in the setting for the
     // user to correct rather than being replaced by a choice never made.
+    // The startup source check finishes before anyone has read the line,
+    // so its result must go under the report rather than replace it.
     {
-        let app = unopened_fixture_app(
+        let mut app = unopened_fixture_app(
             root,
             window.clone(),
             Settings {
@@ -3238,12 +3240,24 @@ fn run_details_style_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
             Some("large_artwork"),
             "startup must not rewrite the text it could not read"
         );
+        app.finish_background_work_for_headless();
+        assert!(
+            app.source_resolution.is_none(),
+            "the startup source check must have finished"
+        );
         let message = app
             .message
             .clone()
-            .expect("an unreadable Details Style is reported at start");
+            .expect("an unreadable Details Style is still reported once the startup check is in");
         assert!(message.contains("large_artwork"), "{message}");
         assert!(message.contains("using Information"), "{message}");
+        app.leave_splash();
+        app.handle(Action::Accept);
+        assert!(
+            app.message.is_none(),
+            "a press takes the report down: {:?}",
+            app.message
+        );
         app.ui.hide().unwrap();
     }
 
@@ -3255,14 +3269,18 @@ fn run_details_style_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
         (DetailsStyle::LargeArtwork, "large-artwork"),
         (DetailsStyle::Information, "information"),
     ] {
-        let loads = app.art.loads;
         select_option(&mut app, OptionsPage::Appearance, OptionId::DetailsStyle);
+        // On the Options screen load_art wants no picture and only clears
+        // the request, so a handler that asked for one again would leave
+        // the flag raised.
+        app.load_art();
+        assert!(!app.art_pending);
         app.handle(Action::Faster);
         assert_eq!(app.details_style, style);
         assert_eq!(app.option_value(OptionId::DetailsStyle), style.shown());
-        assert_eq!(
-            app.art.loads, loads,
-            "a style change must not decode or load a picture"
+        assert!(
+            !app.art_pending,
+            "a style change must not ask for the picture again"
         );
         assert!(
             app.build.is_none(),


### PR DESCRIPTION
## Summary

- Options, Appearance gains **Details Style** (row after Reset All Custom Views) with two values, Information and Large Artwork.
- Information keeps the existing Details layout: the list beside a picture of about 42% of the width, with the compact summary, publisher and information hint under it.
- Large Artwork gives the picture about 62% of the width and the whole height of its column, with no lower panel (`detail_height` 0; no slint change).
- The choice is global and saved as `details_style = "information" | "large-artwork"` in `settings.toml`. An absent key means Information.
- A saved token that is neither name draws Information and is named on the first screen, like a theme that did not load; the text stays in `settings.toml` untouched.
- Not part of the Details Style feature, a fix of a pre-existing defect found while testing the first-screen report, and applied to every installation (commits 8843f99, e24fb0c, 3724cd0): on main the startup source check replaced the first-screen message when it completed, failed or was cancelled, so the theme problem line was taken down before any press. Now the first-screen problem lines (theme and Details Style) survive the check: its text is put under them instead of replacing them, unless a press has already put the first-start build report on screen. Other source checks keep their replace-in-place behaviour. Every first-screen problem line, the theme line included, is also written to `/tmp/degauss.log`, the copy that survives a first-start library read taking the screen; main logged none of them.
- The wider split applies only inside the Browse, Games, Details geometry branch. Home, category and system screens keep their half split; Tiled, List, Carousel, Multi List and Gallery are unchanged.
- Changing the style adjusts the browse geometry only; the library index and the artwork caches are not touched.
- Game Information stays in Actions in both styles. Custom views and the legacy `preview` name still resolve to Details.
- README (Views, Game Information, Options table, headless rendering, theme message) and the `cover_size` comment in `degauss.toml` describe the option, including the decode edge condition under which Large Artwork draws a picture slightly enlarged with the shipped `cover_size` and default margins, and the `cover_size` value that avoids it.

Fixes #52

## Compatibility

- Older settings files without `details_style` render exactly the existing Information layout, and starting does not write a choice the user never made.
- No migration, no index rebuild, no cache invalidation.
- Existing artwork aspect-ratio correction (Artwork Scale Factor) applies the same in both styles.
- Existing global and per-place view selection continues to use Details; this is a style of one view, not a seventh view.
- Headless `--render` and `--bench` Details frames follow the saved key; there is no new CLI flag.
- Behaviour change for every installation, independent of the new setting: a theme problem line now stays on the first screen through the startup source check and is logged to `/tmp/degauss.log`; on main a completed, failed or cancelled startup check replaced or cleared it and nothing was logged. Nothing else about the theme handling changes.

## Tests

- `app::tests::every_details_style_is_reachable_and_round_trips`: every style is reachable through the option cycle, its setting token round-trips through parse, an unknown token parses to None, the default is Information, and half the safe width times the factors gives the 42% and 62% shares.
- `settings` tests: an older settings file leaves `details_style` absent; the field round-trips through save and load.
- Acceptance flow (`ui_acceptance_tests`): an older file with no key draws the Information split and the legacy `preview` name resolves to Details; an unrecognised token is reported on the first screen and in the log, kept through the startup source check whether it completes or is cancelled, taken down by a press, and left in the setting; both styles persist when Options is left and survive a fresh App from the reloaded file, in both directions, and Left steps back through the same values; folders, games with and without a picture and a title longer than the list column remain usable in both styles, with the long title handed over whole; artwork off is usable in both styles; the artwork aspect correction is identical in both styles; the split holds at 352x240 and higher resolutions with the picture given the whole column in Large Artwork; category and system screens keep the half split and the other views keep the whole width; a custom view naming Details resolves to Details under either style.

## Validation

- Host gates (fmt, test, rehearse, ra, clippy for the ARM target) passed on the pushed head; CI and CodeRabbit are green on it, and the local CodeRabbit review of the branch reports no findings.
- Device validation on the MiSTer is pending for the maintainer. Earlier headless renders on this branch (both styles at several resolutions, games with and without artwork, folders, the other views and screens, the first-screen problem lines and their log copy, and cache integrity) matched the release build where no change was expected; they inform that validation and do not replace it.
