### PR TITLE
Avoid repeat batch scrapes and continue past invalid searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,20 +966,22 @@ artwork or metadata, set the corresponding Images or Metadata policy to
 Folder, system and all-systems scrapes never stop for a match choice. Missing
 and ambiguous ScreenScraper matches are counted, skipped without changes, and the remaining
 games continue. A request ScreenScraper rejects for one game (HTTP 400 or one
-of its documented texts about that game's rom name or hash fields) or a match
-response it serves unreadable is counted as failed for that game and the run
-continues; a file whose name leaves nothing to search for once its extension
-and dump tags are removed is counted as missing with the reason "no
-searchable title" and no title search is sent, although a hash lookup is
-still made for a file that can be hashed. A network failure, a rejected
-login, a rate limit, a service outage, a refused client, a request address
-reported as incomplete (Degauss sends the same fields for every game), an
-error text Degauss does not recognise or an answer that is neither XML nor an
-error text still stops the run. Unsupported systems are also skipped and
-counted.
-If two systems use the same folder but require different ScreenScraper
-platform IDs, the all-systems scrape skips that shared target; a per-system
-scrape remains available.
+of its documented texts about that game's rom name or hash fields) or a
+ScreenScraper XML answer it serves unreadable is counted as failed for that
+game and the run continues; a file whose name leaves nothing to search for
+once its extension and dump tags are removed is counted as missing with the
+reason "no searchable title" and no title search is sent, although a hash
+lookup is still made for a file that can be hashed. A network failure, a
+rejected login, a rate limit, a service outage, a refused client or an
+exhausted allowance stops the run whatever HTTP status or text it arrives
+with, as does a request address reported as incomplete (Degauss sends the
+same fields for every game), an error text Degauss does not recognise on a
+successful status (under HTTP 400 it counts as that game's rejection) or an
+answer that is neither a ScreenScraper XML answer nor an error text, such as
+a maintenance or intermediary page, whatever its content type. Unsupported
+systems are also skipped and counted. If two systems use the same folder but
+require different ScreenScraper platform IDs, the all-systems scrape skips
+that shared target; a per-system scrape remains available.
 
 Symlinked copies share a single scrape and gamelist update only when they point
 to the same physical file and the same existing gamelist entry; extra paths

--- a/README.md
+++ b/README.md
@@ -969,8 +969,8 @@ games continue. A request ScreenScraper rejects for one game or a match
 response it serves unreadable is counted as failed for that game and the run
 continues; a file whose name leaves nothing to search for once its extension
 and dump tags are removed is counted as a missing match without a request. A
-network failure, a rejected login, a rate limit or a service outage still
-stops the run. Unsupported systems are also
+network failure, a rejected login, a rate limit, a service outage or an answer
+that is not XML at all still stops the run. Unsupported systems are also
 skipped and counted. If two
 systems use the same folder but require different ScreenScraper platform IDs,
 the all-systems scrape skips that shared target; a per-system scrape remains

--- a/README.md
+++ b/README.md
@@ -965,10 +965,13 @@ artwork or metadata, set the corresponding Images or Metadata policy to
 
 Folder, system and all-systems scrapes never stop for a match choice. Missing
 and ambiguous ScreenScraper matches are counted, skipped without changes, and the remaining
-games continue. A request ScreenScraper rejects for one game, or a match
-response it serves unreadable, is counted as failed for that game and the run
-continues; a network failure, a rejected login, a rate limit or a service
-outage still stops the run. Unsupported systems are also skipped and counted. If two
+games continue. A request ScreenScraper rejects for one game or a match
+response it serves unreadable is counted as failed for that game and the run
+continues; a file whose name leaves nothing to search for once its extension
+and dump tags are removed is counted as a missing match without a request. A
+network failure, a rejected login, a rate limit or a service outage still
+stops the run. Unsupported systems are also
+skipped and counted. If two
 systems use the same folder but require different ScreenScraper platform IDs,
 the all-systems scrape skips that shared target; a per-system scrape remains
 available.
@@ -984,11 +987,13 @@ written, unchanged, unresolved and failed counts. **A Details** opens a
 scrollable report with status, scope, current title, completed/total, written,
 unchanged, linked copies, unresolved and skipped/error breakdowns, allowance,
 throughput and the last problem. After the run, the report continues with
-every game the run could not resolve and the reason, one row per game: no
-match, several matches, no image to fetch, or a failed lookup, download or
-gamelist write. A game whose image failed but whose metadata was written is
-listed with the image error. A missing, ambiguous or rejected game can then be
-found and scraped individually. **B Overview** returns without cancelling.
+every game the run attempted and could not resolve and the reason, one row
+per game: no match, several matches, no image to fetch, or a failed lookup,
+download or gamelist write. A game whose image failed but whose metadata was
+written is listed with the image error. Games not reached before a failure
+or cancellation are not listed. A missing, ambiguous or rejected game can
+then be found and scraped individually. **B Overview** returns without
+cancelling.
 The report retains
 worker counts, account limits reported by ScreenScraper and Degauss's allowance
 estimate. Another

--- a/README.md
+++ b/README.md
@@ -1022,7 +1022,10 @@ available. No helper or background service stays running after Degauss exits.
 
 Connection and server failures remain on the progress screen until they are
 dismissed. The on-screen message is kept concise; technical curl and HTTP
-details are written to `/tmp/degauss.log` without request URLs or login data.
+details are written to `/tmp/degauss.log`. Degauss never writes its own
+request URLs or login data there; a server error text quoted in the log is
+cut to one line and has its login and developer credential parameters
+replaced by "[redacted]".
 Degauss allows 10 seconds to establish each connection and 60 seconds for an
 ordinary API request. An image transfer receives 60 to 300 seconds according
 to its size and the account's reported speed. Retryable failures receive up

--- a/README.md
+++ b/README.md
@@ -965,12 +965,15 @@ artwork or metadata, set the corresponding Images or Metadata policy to
 
 Folder, system and all-systems scrapes never stop for a match choice. Missing
 and ambiguous ScreenScraper matches are counted, skipped without changes, and the remaining
-games continue. A request ScreenScraper rejects for one game or a match
-response it serves unreadable is counted as failed for that game and the run
-continues; a file whose name leaves nothing to search for once its extension
-and dump tags are removed is counted as a missing match without a request. A
-network failure, a rejected login, a rate limit, a service outage or an answer
-that is not XML at all still stops the run. Unsupported systems are also
+games continue. A request ScreenScraper rejects for one game (HTTP 400 or one
+of its documented bad-request texts) or a match response it serves unreadable
+is counted as failed for that game and the run continues; a file whose name
+leaves nothing to search for once its extension and dump tags are removed is
+counted as missing with the reason "no searchable title" and no title search
+is sent, although a hash lookup is still made for a file that can be hashed.
+A network failure, a rejected login, a rate limit, a service outage, an error
+text Degauss does not recognise or an answer that is neither XML nor an error
+text still stops the run. Unsupported systems are also
 skipped and counted. If two
 systems use the same folder but require different ScreenScraper platform IDs,
 the all-systems scrape skips that shared target; a per-system scrape remains
@@ -988,8 +991,8 @@ scrollable report with status, scope, current title, completed/total, written,
 unchanged, linked copies, unresolved and skipped/error breakdowns, allowance,
 throughput and the last problem. After the run, the report continues with
 every game the run attempted and could not resolve and the reason, one row
-per game: no match, several matches, no image to fetch, or a failed lookup,
-download or gamelist write. A game whose image failed but whose metadata was
+per game: no match, no searchable title, several matches, no image to fetch,
+or a failed lookup, download or gamelist write. A game whose image failed but whose metadata was
 written is listed with the image error. Games not reached before a failure
 or cancellation are not listed. A missing, ambiguous or rejected game can
 then be found and scraped individually. **B Overview** returns without

--- a/README.md
+++ b/README.md
@@ -965,25 +965,23 @@ artwork or metadata, set the corresponding Images or Metadata policy to
 
 Folder, system and all-systems scrapes never stop for a match choice. Missing
 and ambiguous ScreenScraper matches are counted, skipped without changes, and the remaining
-games continue. A request ScreenScraper rejects for one game (HTTP 400 or one
-of its documented texts about that game's rom name or hash fields) or a
-ScreenScraper XML answer it serves unreadable is counted as failed for that
-game and the run continues; a picture request it rejects the same way keeps
-the metadata already fetched for that game, which is written, and lists the
-game with the picture error. A file whose name leaves nothing to search for
-once its extension and dump tags are removed is counted as missing with the
-reason "no searchable title" and no title search is sent, although a hash
-lookup is still made for a file that can be hashed. A network failure, a
-rejected login, a rate limit, a service outage, a refused client or an
-exhausted allowance stops the run whatever HTTP status or text it arrives
-with, as does a request address reported as incomplete (Degauss sends the
-same fields for every game), an error text Degauss does not recognise on a
-successful status (under HTTP 400 it counts as that game's rejection) or an
-answer that is neither a ScreenScraper XML answer nor an error text, such as
-a maintenance or intermediary page, whatever its content type. Unsupported
-systems are also skipped and counted. If two systems use the same folder but
-require different ScreenScraper platform IDs, the all-systems scrape skips
-that shared target; a per-system scrape remains available.
+games continue. A search ScreenScraper rejects for one game, or an answer it
+serves unreadable for one game, is counted as failed for that game and the
+run continues. If only the picture request is rejected, any metadata the run
+was also asked to fill for that game is still written and the game is listed
+with the picture error; a game whose metadata was already complete is only
+listed. A file whose name leaves nothing to search for once its extension
+and dump tags are removed is counted as missing with the reason "no
+searchable title" and no title search is sent, although a hash lookup is
+still made for a file that can be hashed. A network failure, a rejected
+login, a rate limit, a service outage, a refused client, an exhausted
+allowance, a request address reported as incomplete (Degauss sends the same
+fields for every game) or an answer that is not a ScreenScraper answer at
+all, such as a maintenance or intermediary page, stops the run. The log
+names the rejection or page behind each of these. Unsupported systems are
+also skipped and counted. If two systems use the same folder but require
+different ScreenScraper platform IDs, the all-systems scrape skips that
+shared target; a per-system scrape remains available.
 
 Symlinked copies share a single scrape and gamelist update only when they point
 to the same physical file and the same existing gamelist entry; extra paths

--- a/README.md
+++ b/README.md
@@ -966,14 +966,17 @@ artwork or metadata, set the corresponding Images or Metadata policy to
 Folder, system and all-systems scrapes never stop for a match choice. Missing
 and ambiguous ScreenScraper matches are counted, skipped without changes, and the remaining
 games continue. A request ScreenScraper rejects for one game (HTTP 400 or one
-of its documented bad-request texts) or a match response it serves unreadable
-is counted as failed for that game and the run continues; a file whose name
-leaves nothing to search for once its extension and dump tags are removed is
-counted as missing with the reason "no searchable title" and no title search
-is sent, although a hash lookup is still made for a file that can be hashed.
-A network failure, a rejected login, a rate limit, a service outage, an error
-text Degauss does not recognise or an answer that is neither XML nor an error
-text still stops the run. Unsupported systems are also skipped and counted.
+of its documented texts about that game's rom name or hash fields) or a match
+response it serves unreadable is counted as failed for that game and the run
+continues; a file whose name leaves nothing to search for once its extension
+and dump tags are removed is counted as missing with the reason "no
+searchable title" and no title search is sent, although a hash lookup is
+still made for a file that can be hashed. A network failure, a rejected
+login, a rate limit, a service outage, a refused client, a request address
+reported as incomplete (Degauss sends the same fields for every game), an
+error text Degauss does not recognise or an answer that is neither XML nor an
+error text still stops the run. Unsupported systems are also skipped and
+counted.
 If two systems use the same folder but require different ScreenScraper
 platform IDs, the all-systems scrape skips that shared target; a per-system
 scrape remains available.
@@ -992,9 +995,10 @@ throughput and the last problem. After the run, the report continues with
 every game the run attempted and could not resolve, one row per game with
 its reason: "no match", "no searchable title", the number of matches (for
 example "3 matches"), "no image", or the message of a failed lookup,
-download or gamelist write. A game whose image failed but whose metadata
-was written is listed with the image error. Games not reached before a
-failure or cancellation are not listed. A missing, ambiguous or rejected
+download or gamelist write. A game whose image failed, or whose match has
+no image, is listed even when its metadata was written, so the rows agree
+with the "no image" count. Games not reached before a failure or
+cancellation are not listed. A missing, ambiguous or rejected
 game can then be found and scraped individually. **B Overview** returns
 without cancelling.
 The report retains

--- a/README.md
+++ b/README.md
@@ -919,7 +919,7 @@ policies for pictures and metadata:
 | **Images: Missing only** | Keeps the effective `<image>`, `<screenshot>` or `<thumbnail>` when its file exists, and fetches a picture only when artwork is absent or broken. |
 | **Images: Replace existing** | Downloads the selected ScreenScraper media and makes it the entry's `<image>`. The previous media file is not overwritten or deleted. |
 | **Metadata: Off** | Never changes metadata. |
-| **Metadata: Fill missing** | Fills empty fields and preserves every non-empty local or inherited value. A folder, system or all-systems run treats an entry with any stored field as complete; **Scrape This Game** fills its empty fields one by one. |
+| **Metadata: Fill missing** | Fills empty fields and preserves every non-empty local or inherited value. A folder, system or all-systems run treats an entry with any stored field as complete; **Scrape This Game** and **Search Manually** fill its empty fields one by one. |
 | **Metadata: Replace existing** | Replaces only fields ScreenScraper actually returned. A missing upstream value never erases a local one. |
 
 Both settings cannot be Off when a scrape starts. The metadata fields are

--- a/README.md
+++ b/README.md
@@ -919,7 +919,7 @@ policies for pictures and metadata:
 | **Images: Missing only** | Keeps the effective `<image>`, `<screenshot>` or `<thumbnail>` when its file exists, and fetches a picture only when artwork is absent or broken. |
 | **Images: Replace existing** | Downloads the selected ScreenScraper media and makes it the entry's `<image>`. The previous media file is not overwritten or deleted. |
 | **Metadata: Off** | Never changes metadata. |
-| **Metadata: Fill missing** | Fills empty fields and preserves every non-empty local or inherited value. A folder, system or all-systems run treats an entry with any stored field as complete; **Scrape This Game** and **Search Manually** fill its empty fields one by one. |
+| **Metadata: Fill missing** | Fills empty fields and preserves every non-empty local or inherited value. A folder, system or all-systems run treats an entry with any non-empty local or inherited field as complete; **Scrape This Game** and **Search Manually** fill its empty fields one by one. |
 | **Metadata: Replace existing** | Replaces only fields ScreenScraper actually returned. A missing upstream value never erases a local one. |
 
 Both settings cannot be Off when a scrape starts. The metadata fields are
@@ -930,16 +930,16 @@ Pictures and metadata are checked independently before any ScreenScraper
 request. Under **Images: Missing only** a picture is requested only when the
 effective image is absent or its file does not exist. In a folder, system or
 all-systems run, **Metadata: Fill missing** requests metadata only when every
-one of the eight fields is empty: a game with an existing picture and at least
-one stored field is skipped without a request, so a blank language, publisher
-or other optional field does not send the same games back on every run. An
-entry with metadata but no picture receives only its picture; an entry with a
-picture but no metadata receives only metadata, and its picture is not
-downloaded again. **Scrape This Game** and **Search Manually** keep filling
-individual empty fields, because choosing one game is permission to complete
-that record field by field; a field ScreenScraper does not supply remains
-blank and is retried on the next single-game scrape. **Replace existing**
-requests and replaces the selected data as before.
+one of the eight fields is empty: a game with an existing picture and at
+least one non-empty local or inherited field is skipped without a request, so
+a blank language, publisher or other optional field does not send the same
+games back on every run. An entry with metadata but no picture receives only
+its picture; an entry with a picture but no metadata receives only metadata,
+and its picture is not downloaded again. **Scrape This Game** and **Search
+Manually** keep filling individual empty fields, because choosing one game is
+permission to complete that record field by field; a field ScreenScraper does
+not supply remains blank and is retried on the next single-game scrape.
+**Replace existing** requests and replaces the selected data as before.
 
 Ordinary ROM files are matched by CRC32, MD5 and SHA-1 when they are no more
 than 64 MiB. Larger files, archives, `.mgl`, `.mra` and other wrappers use an
@@ -968,7 +968,9 @@ and ambiguous ScreenScraper matches are counted, skipped without changes, and th
 games continue. A request ScreenScraper rejects for one game (HTTP 400 or one
 of its documented texts about that game's rom name or hash fields) or a
 ScreenScraper XML answer it serves unreadable is counted as failed for that
-game and the run continues; a file whose name leaves nothing to search for
+game and the run continues; a picture request it rejects the same way keeps
+the metadata already fetched for that game, which is written, and lists the
+game with the picture error. A file whose name leaves nothing to search for
 once its extension and dump tags are removed is counted as missing with the
 reason "no searchable title" and no title search is sent, although a hash
 lookup is still made for a file that can be hashed. A network failure, a

--- a/README.md
+++ b/README.md
@@ -965,7 +965,7 @@ artwork or metadata, set the corresponding Images or Metadata policy to
 
 Folder, system and all-systems scrapes never stop for a match choice. Missing
 and ambiguous ScreenScraper matches are counted, skipped without changes, and the remaining
-games continue. A search ScreenScraper rejects for one game, or a match
+games continue. A request ScreenScraper rejects for one game, or a match
 response it serves unreadable, is counted as failed for that game and the run
 continues; a network failure, a rejected login, a rate limit or a service
 outage still stops the run. Unsupported systems are also skipped and counted. If two
@@ -984,9 +984,11 @@ written, unchanged, unresolved and failed counts. **A Details** opens a
 scrollable report with status, scope, current title, completed/total, written,
 unchanged, linked copies, unresolved and skipped/error breakdowns, allowance,
 throughput and the last problem. After the run, the report continues with
-every game that was not written and the reason, one row per game, so a
-missing, ambiguous or rejected game can be found and scraped individually.
-**B Overview** returns without cancelling.
+every game the run could not resolve and the reason, one row per game: no
+match, several matches, no image to fetch, or a failed lookup, download or
+gamelist write. A game whose image failed but whose metadata was written is
+listed with the image error. A missing, ambiguous or rejected game can then be
+found and scraped individually. **B Overview** returns without cancelling.
 The report retains
 worker counts, account limits reported by ScreenScraper and Degauss's allowance
 estimate. Another

--- a/README.md
+++ b/README.md
@@ -965,19 +965,20 @@ artwork or metadata, set the corresponding Images or Metadata policy to
 
 Folder, system and all-systems scrapes never stop for a match choice. Missing
 and ambiguous ScreenScraper matches are counted, skipped without changes, and the remaining
-games continue. A search ScreenScraper rejects for one game, or an answer it
-serves unreadable for one game, is counted as failed for that game and the
-run continues. If only the picture request is rejected, any metadata the run
-was also asked to fill for that game is still written and the game is listed
-with the picture error; a game whose metadata was already complete is only
-listed. A file whose name leaves nothing to search for once its extension
-and dump tags are removed is counted as missing with the reason "no
-searchable title" and no title search is sent, although a hash lookup is
-still made for a file that can be hashed. A network failure, a rejected
-login, a rate limit, a service outage, a refused client, an exhausted
-allowance, a request address reported as incomplete (Degauss sends the same
-fields for every game) or an answer that is not a ScreenScraper answer at
-all, such as a maintenance or intermediary page, stops the run. The log
+games continue. A search ScreenScraper rejects for one game, or a genuine
+ScreenScraper answer for one game whose content cannot be read, is counted
+as failed for that game and the run continues. If only the picture request
+is rejected, any metadata the run was also asked to fill for that game is
+still written and the game is listed with the picture error; a game whose
+metadata was already complete is only listed. A file whose name leaves
+nothing to search for once its extension and dump tags are removed is
+counted as missing with the reason "no searchable title" and no title search
+is sent, although a hash lookup is still made for a file that can be hashed.
+A network failure, a rejected login, a rate limit, a service outage, a
+refused client, an exhausted allowance, a request address reported as
+incomplete (Degauss sends the same fields for every game) or a response that
+is not a ScreenScraper answer at all (an empty body, a body that is neither
+text nor XML, or a maintenance or intermediary page) stops the run. The log
 names the rejection or page behind each of these. Unsupported systems are
 also skipped and counted. If two systems use the same folder but require
 different ScreenScraper platform IDs, the all-systems scrape skips that

--- a/README.md
+++ b/README.md
@@ -973,11 +973,10 @@ counted as missing with the reason "no searchable title" and no title search
 is sent, although a hash lookup is still made for a file that can be hashed.
 A network failure, a rejected login, a rate limit, a service outage, an error
 text Degauss does not recognise or an answer that is neither XML nor an error
-text still stops the run. Unsupported systems are also
-skipped and counted. If two
-systems use the same folder but require different ScreenScraper platform IDs,
-the all-systems scrape skips that shared target; a per-system scrape remains
-available.
+text still stops the run. Unsupported systems are also skipped and counted.
+If two systems use the same folder but require different ScreenScraper
+platform IDs, the all-systems scrape skips that shared target; a per-system
+scrape remains available.
 
 Symlinked copies share a single scrape and gamelist update only when they point
 to the same physical file and the same existing gamelist entry; extra paths
@@ -990,13 +989,14 @@ written, unchanged, unresolved and failed counts. **A Details** opens a
 scrollable report with status, scope, current title, completed/total, written,
 unchanged, linked copies, unresolved and skipped/error breakdowns, allowance,
 throughput and the last problem. After the run, the report continues with
-every game the run attempted and could not resolve and the reason, one row
-per game: no match, no searchable title, several matches, no image to fetch,
-or a failed lookup, download or gamelist write. A game whose image failed but whose metadata was
-written is listed with the image error. Games not reached before a failure
-or cancellation are not listed. A missing, ambiguous or rejected game can
-then be found and scraped individually. **B Overview** returns without
-cancelling.
+every game the run attempted and could not resolve, one row per game with
+its reason: "no match", "no searchable title", the number of matches (for
+example "3 matches"), "no image", or the message of a failed lookup,
+download or gamelist write. A game whose image failed but whose metadata
+was written is listed with the image error. Games not reached before a
+failure or cancellation are not listed. A missing, ambiguous or rejected
+game can then be found and scraped individually. **B Overview** returns
+without cancelling.
 The report retains
 worker counts, account limits reported by ScreenScraper and Degauss's allowance
 estimate. Another

--- a/README.md
+++ b/README.md
@@ -919,20 +919,27 @@ policies for pictures and metadata:
 | **Images: Missing only** | Keeps the effective `<image>`, `<screenshot>` or `<thumbnail>` when its file exists, and fetches a picture only when artwork is absent or broken. |
 | **Images: Replace existing** | Downloads the selected ScreenScraper media and makes it the entry's `<image>`. The previous media file is not overwritten or deleted. |
 | **Metadata: Off** | Never changes metadata. |
-| **Metadata: Fill missing** | Fills empty fields and preserves every non-empty local or inherited value. |
+| **Metadata: Fill missing** | Fills empty fields and preserves every non-empty local or inherited value. A folder, system or all-systems run treats an entry with any stored field as complete; **Scrape This Game** fills its empty fields one by one. |
 | **Metadata: Replace existing** | Replaces only fields ScreenScraper actually returned. A missing upstream value never erases a local one. |
 
 Both settings cannot be Off when a scrape starts. The metadata fields are
 name, description, publisher, developer, release date, players, genre and
 language.
 
-When the selected image exists and every enabled metadata field is populated,
-Degauss skips the game before making any ScreenScraper request. Fill missing
-still checks all eight fields: a blank language, publisher or other field can
-therefore cause another metadata lookup even when the picture and description
-are present. A field ScreenScraper does not supply remains blank and may be
-retried on a later run; existing artwork is not downloaded again for that
-metadata lookup.
+Pictures and metadata are checked independently before any ScreenScraper
+request. Under **Images: Missing only** a picture is requested only when the
+effective image is absent or its file does not exist. In a folder, system or
+all-systems run, **Metadata: Fill missing** requests metadata only when every
+one of the eight fields is empty: a game with an existing picture and at least
+one stored field is skipped without a request, so a blank language, publisher
+or other optional field does not send the same games back on every run. An
+entry with metadata but no picture receives only its picture; an entry with a
+picture but no metadata receives only metadata, and its picture is not
+downloaded again. **Scrape This Game** and **Search Manually** keep filling
+individual empty fields, because choosing one game is permission to complete
+that record field by field; a field ScreenScraper does not supply remains
+blank and is retried on the next single-game scrape. **Replace existing**
+requests and replaces the selected data as before.
 
 Ordinary ROM files are matched by CRC32, MD5 and SHA-1 when they are no more
 than 64 MiB. Larger files, archives, `.mgl`, `.mra` and other wrappers use an
@@ -958,7 +965,10 @@ artwork or metadata, set the corresponding Images or Metadata policy to
 
 Folder, system and all-systems scrapes never stop for a match choice. Missing
 and ambiguous ScreenScraper matches are counted, skipped without changes, and the remaining
-games continue. Unsupported systems are also skipped and counted. If two
+games continue. A search ScreenScraper rejects for one game, or a match
+response it serves unreadable, is counted as failed for that game and the run
+continues; a network failure, a rejected login, a rate limit or a service
+outage still stops the run. Unsupported systems are also skipped and counted. If two
 systems use the same folder but require different ScreenScraper platform IDs,
 the all-systems scrape skips that shared target; a per-system scrape remains
 available.
@@ -973,7 +983,10 @@ During a run, the progress dashboard shows current work, game progress,
 written, unchanged, unresolved and failed counts. **A Details** opens a
 scrollable report with status, scope, current title, completed/total, written,
 unchanged, linked copies, unresolved and skipped/error breakdowns, allowance,
-throughput and the last problem. **B Overview** returns without cancelling.
+throughput and the last problem. After the run, the report continues with
+every game that was not written and the reason, one row per game, so a
+missing, ambiguous or rejected game can be found and scraped individually.
+**B Overview** returns without cancelling.
 The report retains
 worker counts, account limits reported by ScreenScraper and Degauss's allowance
 estimate. Another

--- a/src/app.rs
+++ b/src/app.rs
@@ -1420,7 +1420,7 @@ fn scraper_search_error(error: &crate::scraper::Error) -> &'static str {
         ErrorKind::DailyQuota => "Daily request allowance exhausted",
         ErrorKind::FailedQuota => "Failed-search allowance exhausted",
         ErrorKind::NotFound => "No Matches",
-        ErrorKind::InvalidRequest => "Search Rejected",
+        ErrorKind::InvalidRequest => "Request Rejected",
         ErrorKind::MalformedResponse => "ScreenScraper response was unreadable",
         ErrorKind::Transport => "Network connection failed",
         ErrorKind::Timeout => "ScreenScraper timed out",
@@ -11157,8 +11157,8 @@ impl App {
     }
 
     /// The fixed report rows, then a header and one row per game the run
-    /// did not write. The list arrives with the terminal event, so a running
-    /// job shows the fixed rows only.
+    /// could not resolve. The list arrives with the terminal event, so a
+    /// running job shows the fixed rows only.
     fn scraper_progress_row_count(&self) -> usize {
         let unresolved = self.scraper_progress.unresolved_games.len();
         SCRAPER_PROGRESS_ROWS + if unresolved == 0 { 0 } else { 1 + unresolved }
@@ -11226,8 +11226,12 @@ impl App {
         self.scraper_cancelling = false;
         self.scraper_pending_terminal = Some(terminal);
         self.scraper_progress.phase = crate::scraper::Phase::Finishing;
+        // The report grows by the unresolved rows; a Details view scrolled
+        // during the run keeps its place.
+        let selected = self.scraper_progress_list.selected();
         self.scraper_progress_list =
             ListState::new(self.scraper_progress_row_count(), self.geometry.visible);
+        self.scraper_progress_list.select(selected);
         self.scraper_refresh_queue = self
             .scraper_progress
             .updated_systems
@@ -16540,6 +16544,7 @@ mod tests {
             (ErrorKind::DailyQuota, "Daily request allowance exhausted"),
             (ErrorKind::FailedQuota, "Failed-search allowance exhausted"),
             (ErrorKind::NotFound, "No Matches"),
+            (ErrorKind::InvalidRequest, "Request Rejected"),
             (
                 ErrorKind::MalformedResponse,
                 "ScreenScraper response was unreadable",
@@ -16572,6 +16577,12 @@ mod tests {
             (ErrorKind::DailyQuota, "Daily request allowance exhausted"),
             (ErrorKind::FailedQuota, "Failed-search allowance exhausted"),
             (ErrorKind::NotFound, "No matching game was found"),
+            // The same kind answers a lookup, a media transfer and the
+            // account check, so the text names none of them.
+            (
+                ErrorKind::InvalidRequest,
+                "ScreenScraper rejected this request",
+            ),
             (
                 ErrorKind::MalformedResponse,
                 "ScreenScraper response was unreadable",

--- a/src/app.rs
+++ b/src/app.rs
@@ -11417,6 +11417,9 @@ impl App {
             return;
         }
         self.scraper_terminal = None;
+        // The report is unreachable once the run is closed; a full-library
+        // list would otherwise stay in memory until the next scrape.
+        self.scraper_progress.unresolved_games = Vec::new();
         self.screen = self.scraper_return;
         self.resolve_view();
         self.apply_geometry();

--- a/src/app.rs
+++ b/src/app.rs
@@ -1420,6 +1420,7 @@ fn scraper_search_error(error: &crate::scraper::Error) -> &'static str {
         ErrorKind::DailyQuota => "Daily request allowance exhausted",
         ErrorKind::FailedQuota => "Failed-search allowance exhausted",
         ErrorKind::NotFound => "No Matches",
+        ErrorKind::InvalidRequest => "Search Rejected",
         ErrorKind::MalformedResponse => "ScreenScraper response was unreadable",
         ErrorKind::Transport => "Network connection failed",
         ErrorKind::Timeout => "ScreenScraper timed out",
@@ -11155,6 +11156,27 @@ impl App {
         ]
     }
 
+    /// The fixed report rows, then a header and one row per game the run
+    /// did not write. The list arrives with the terminal event, so a running
+    /// job shows the fixed rows only.
+    fn scraper_progress_row_count(&self) -> usize {
+        let unresolved = self.scraper_progress.unresolved_games.len();
+        SCRAPER_PROGRESS_ROWS + if unresolved == 0 { 0 } else { 1 + unresolved }
+    }
+
+    /// One report row past the fixed rows. Built per visible row rather than
+    /// for the whole list, which can hold every game of a library scrape.
+    fn scraper_unresolved_row(&self, index: usize) -> (String, String) {
+        let unresolved = &self.scraper_progress.unresolved_games;
+        match index.checked_sub(SCRAPER_PROGRESS_ROWS + 1) {
+            None => ("Unresolved games".to_string(), unresolved.len().to_string()),
+            Some(at) => {
+                let crate::scraper::UnresolvedGame { label, reason } = &unresolved[at];
+                (label.clone(), reason.clone())
+            }
+        }
+    }
+
     fn poll_scraper(&mut self) {
         self.poll_scraper_cache_refresh();
         loop {
@@ -11204,6 +11226,8 @@ impl App {
         self.scraper_cancelling = false;
         self.scraper_pending_terminal = Some(terminal);
         self.scraper_progress.phase = crate::scraper::Phase::Finishing;
+        self.scraper_progress_list =
+            ListState::new(self.scraper_progress_row_count(), self.geometry.visible);
         self.scraper_refresh_queue = self
             .scraper_progress
             .updated_systems
@@ -12678,8 +12702,12 @@ impl App {
             Screen::ScraperProgress => {
                 let progress = self.scraper_progress_rows();
                 for index in range {
-                    let (title, value) = &progress[index];
-                    rows.push(plain_row(title, value));
+                    if let Some((title, value)) = progress.get(index) {
+                        rows.push(plain_row(title, value));
+                    } else {
+                        let (title, value) = self.scraper_unresolved_row(index);
+                        rows.push(plain_row(&title, &value));
+                    }
                 }
             }
             Screen::ScraperMatches => {

--- a/src/scraper/api.rs
+++ b/src/scraper/api.rs
@@ -973,17 +973,14 @@ fn response_status(response: &HttpResponse) -> Result<()> {
         if trimmed.to_lowercase().starts_with("erreur") {
             let body_error = text_error(trimmed);
             if response.status < 300 || body_error.kind == ErrorKind::Authentication {
-                crate::note(&match authentication_source(trimmed) {
+                crate::note(match authentication_source(trimmed) {
                     Some(AuthenticationSource::Application) => {
-                        "scraper      ScreenScraper rejected application authentication".to_string()
+                        "scraper      ScreenScraper rejected application authentication"
                     }
                     Some(AuthenticationSource::Account) => {
-                        "scraper      ScreenScraper rejected account authentication".to_string()
+                        "scraper      ScreenScraper rejected account authentication"
                     }
-                    None => format!(
-                        "scraper      ScreenScraper returned a body-level error: {}",
-                        excerpt(trimmed)
-                    ),
+                    None => "scraper      ScreenScraper returned a body-level error",
                 });
                 return Err(body_error);
             }
@@ -1043,21 +1040,6 @@ fn text_error(text: &str) -> Error {
                 "the ScreenScraper allowance is exhausted",
             );
         }
-        // The documented 431 text ("Faite du tri dans vos fichiers roms et
-        // repassez demain !") names no quota.
-        if lower.contains("tri dans vos fichiers") {
-            return Error::new(
-                ErrorKind::FailedQuota,
-                "the daily failed-search allowance is exhausted",
-            );
-        }
-        // Every documented 429 text, French or English, names threads.
-        if lower.contains("threads") {
-            return Error::new(
-                ErrorKind::RateLimited,
-                "ScreenScraper's concurrent or per-minute limit was reached",
-            );
-        }
         if lower.contains("introuv") || lower.contains("non trouv") {
             return Error::new(ErrorKind::NotFound, "no matching game");
         }
@@ -1115,12 +1097,15 @@ fn text_error(text: &str) -> Error {
 /// flood the log.
 fn excerpt(text: &str) -> String {
     const LIMIT: usize = 120;
-    let line = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    if line.chars().count() <= LIMIT {
-        line
+    let mut chars = text
+        .split_whitespace()
+        .flat_map(|word| std::iter::once(' ').chain(word.chars()))
+        .skip(1);
+    let line: String = chars.by_ref().take(LIMIT).collect();
+    if chars.next().is_some() {
+        format!("{line}...")
     } else {
-        let cut: String = line.chars().take(LIMIT).collect();
-        format!("{cut}...")
+        line
     }
 }
 
@@ -2384,23 +2369,23 @@ mod tests {
             ),
             (
                 "Erreur : Faite du tri dans vos fichiers roms et repassez demain !",
-                ErrorKind::FailedQuota,
+                ErrorKind::Unavailable,
             ),
             (
                 "Erreur : Le nombre de threads autorisé pour le membre est atteint",
-                ErrorKind::RateLimited,
+                ErrorKind::Unavailable,
             ),
             (
                 "Erreur : Le nombre de threads par minute autorisé pour le membre est atteint",
-                ErrorKind::RateLimited,
+                ErrorKind::Unavailable,
             ),
             (
                 "Erreur : The maximum threads allowed to leecher users is already used",
-                ErrorKind::RateLimited,
+                ErrorKind::Unavailable,
             ),
             (
                 "Erreur : The maximum threads is already used",
-                ErrorKind::RateLimited,
+                ErrorKind::Unavailable,
             ),
             ("Erreur : Jeu non trouvée !", ErrorKind::NotFound),
             ("Service paused for maintenance", ErrorKind::Unavailable),
@@ -2435,9 +2420,10 @@ mod tests {
         .by_name(3, "Game")
         .unwrap_err();
         assert_eq!(closed.kind, ErrorKind::Unavailable);
-        // A limit or an exhausted failed-search allowance delivered as a
-        // 2xx text must keep its meaning: the batch stops instead of
-        // repeating a lookup the server is refusing for every game.
+        // The 429 and 431 texts are classified by their HTTP status; the
+        // same text in a 2xx body is an outage, as it always was: the batch
+        // stops instead of repeating a lookup the server is refusing for
+        // every game.
         let limited = client(HttpResponse {
             status: 200,
             content_type: Some("text/plain".into()),
@@ -2447,7 +2433,7 @@ mod tests {
         })
         .by_name(3, "Game")
         .unwrap_err();
-        assert_eq!(limited.kind, ErrorKind::RateLimited);
+        assert_eq!(limited.kind, ErrorKind::Unavailable);
         let exhausted = client(HttpResponse {
             status: 200,
             content_type: Some("text/plain".into()),
@@ -2457,7 +2443,7 @@ mod tests {
         })
         .by_name(3, "Game")
         .unwrap_err();
-        assert_eq!(exhausted.kind, ErrorKind::FailedQuota);
+        assert_eq!(exhausted.kind, ErrorKind::Unavailable);
         // A page that is not XML at all is not a match response for one
         // game: it stops the run like any other outage.
         let page = client(HttpResponse {
@@ -2526,6 +2512,12 @@ mod tests {
             "{}",
             plain.detail
         );
+        // The cut falls exactly at the limit, with the whitespace between
+        // words counted once, so a documented text is never shortened.
+        let exact = format!("{} {}", "a".repeat(60), "b".repeat(59));
+        assert_eq!(excerpt(&exact), exact);
+        assert_eq!(excerpt(&format!("{exact} c")), format!("{exact}..."));
+        assert_eq!(excerpt("  one \n\t two  "), "one two");
     }
 
     #[test]

--- a/src/scraper/api.rs
+++ b/src/scraper/api.rs
@@ -974,14 +974,9 @@ fn status(code: u16) -> Result<()> {
 /// Interpret a body-level ScreenScraper error before losing its more precise
 /// login diagnosis to a generic HTTP status. In particular, the service can
 /// use HTTP 403 for either developer credentials or an end-user login and
-/// states which pair failed only in its plain-text response. HTTP 400 no
-/// longer stops the run, so a documented text under it keeps the text's
-/// classification: a service-wide text (a closure, a limit, an exhausted
-/// allowance, a refused client) stops the run instead of passing as one
-/// game's rejection, a per-request text keeps the server's words in its
-/// detail and a not-found text is that game's miss. An unrecognised text
-/// under HTTP 400 keeps the status's meaning for `answer`, with the
-/// server's words in the detail so the log shows what was rejected.
+/// states which pair failed only in its plain-text response. A documented
+/// error text keeps its classification under HTTP 400 as well; any other
+/// body under that status is classified by `rejected_request`.
 fn response_status(response: &HttpResponse, answer: Answer) -> Result<()> {
     let text = std::str::from_utf8(&response.body)
         .ok()
@@ -1015,16 +1010,9 @@ fn response_status(response: &HttpResponse, answer: Answer) -> Result<()> {
     }
 }
 
-/// HTTP 400. ScreenScraper documents it only for problems with the one
-/// request (a rom name carrying a path, a bad hash, missing fields) and
-/// answers it with an error text, so on a lookup or a media transfer it
-/// stops that game rather than the run, with the server's words in the
-/// detail; the account check sends only the credential fields, so a 400
-/// there is a setup fault, as before. The XML endpoints answer HTTP 400
-/// with text: a page, an empty body or a body that is not text under that
-/// status is an intermediary's answer, not ScreenScraper's, and stops the
-/// run as it would on a successful status. An image transfer answers with
-/// bytes, so that rule does not apply to it.
+/// HTTP 400 is one game's rejection on a lookup or a media transfer and a
+/// setup fault at the account check. The XML endpoints answer it with text,
+/// so markup, a page content type, an empty or non-text body stops the run.
 fn rejected_request(response: &HttpResponse, text: Option<&str>, answer: Answer) -> Error {
     let text = text.map(str::trim).filter(|text| !text.is_empty());
     let kind = match answer {
@@ -1040,6 +1028,9 @@ fn rejected_request(response: &HttpResponse, text: Option<&str>, answer: Answer)
         }
         if text.is_none() {
             return not_an_answer("no error text under HTTP 400");
+        }
+        if text.is_some_and(|text| text.starts_with('<')) {
+            return not_an_answer("markup instead of an error text under HTTP 400");
         }
     }
     let rejected = "ScreenScraper rejected the request parameters (HTTP 400)";
@@ -1185,12 +1176,8 @@ fn documented_error(lower: &str, text: &str) -> Option<Error> {
     None
 }
 
-/// An error text ScreenScraper has not documented. On a lookup it is that
-/// game's rejection, the invalid search the batch must continue past,
-/// with the server's words in the detail; a service-wide text present
-/// when the run starts still stops it at the account check, which runs
-/// before any game, and a media transfer is not a search, so both keep
-/// the outage classification.
+/// An error text ScreenScraper has not documented: one game's rejection
+/// on a lookup, an outage at the account check or on a media transfer.
 fn unrecognised_error(text: &str, answer: Answer) -> Error {
     match answer {
         Answer::Lookup => Error::new(
@@ -1366,7 +1353,8 @@ fn parse(
             Ok(Event::Start(element)) => {
                 let tag = element.name().as_ref().to_ascii_lowercase();
                 if !saw_data_root {
-                    saw_data_root = require_data_root(&tag)?;
+                    require_data_root(&tag)?;
+                    saw_data_root = true;
                 }
                 let attributes = xml_attributes(&element)?;
                 let parent = stack.last().map(String::as_str);
@@ -1464,8 +1452,8 @@ fn parse(
             }
             Ok(Event::Empty(element)) => {
                 if !saw_data_root {
-                    saw_data_root =
-                        require_data_root(&element.name().as_ref().to_ascii_lowercase())?;
+                    require_data_root(&element.name().as_ref().to_ascii_lowercase())?;
+                    saw_data_root = true;
                 }
                 xml_attributes(&element)?;
                 if element.name().as_ref().eq_ignore_ascii_case("jeux") {
@@ -1542,11 +1530,11 @@ fn parse(
     Ok(parsed)
 }
 
-/// True for ScreenScraper's `<Data>` root; any other root element is a
+/// Accepts ScreenScraper's `<Data>` root; any other root element is a
 /// page the service did not answer with.
-fn require_data_root(tag: &str) -> Result<bool> {
+fn require_data_root(tag: &str) -> Result<()> {
     if tag == "data" {
-        return Ok(true);
+        return Ok(());
     }
     Err(not_an_answer(&format!("root element <{}>", excerpt(tag))))
 }
@@ -2913,13 +2901,14 @@ mod tests {
 
     #[test]
     fn a_page_under_http_400_stops_the_run_and_a_text_names_the_rejection() {
-        // ScreenScraper answers HTTP 400 with an error text. An HTML page,
-        // an empty body or a body that is not text under that status comes
-        // from an intermediary, as it would on a successful status, and
-        // must not cost one lookup per remaining game while the log stays
-        // silent about the cause. A text that is not one of the documented
-        // error texts is still that game's rejection, with the server's
-        // words in the log detail.
+        // ScreenScraper answers HTTP 400 with an error text. An HTML page
+        // (whatever content type it is served with, or none), an empty body
+        // or a body that is not text under that status comes from an
+        // intermediary, as it would on a successful status, and must not
+        // cost one lookup per remaining game while the log stays silent
+        // about the cause. A text that is not one of the documented error
+        // texts is still that game's rejection, with the server's words in
+        // the log detail.
         let hashes = Hashes {
             size: 3,
             crc32: "352441C2".into(),
@@ -2931,6 +2920,16 @@ mod tests {
                 Some("text/html"),
                 &b"<html><body>Bad request</body></html>"[..],
                 "content type text/html",
+            ),
+            (
+                None,
+                &b"<html><body>Bad request</body></html>"[..],
+                "markup instead of an error text",
+            ),
+            (
+                Some("application/xml"),
+                &b"<!DOCTYPE html><html><body><p>Bad request</html>"[..],
+                "markup instead of an error text",
             ),
             (Some("application/xml"), &b""[..], "no error text"),
             (Some("text/plain"), &b" \n"[..], "no error text"),

--- a/src/scraper/api.rs
+++ b/src/scraper/api.rs
@@ -966,13 +966,28 @@ fn status(code: u16) -> Result<()> {
 /// Interpret a body-level ScreenScraper error before losing its more precise
 /// login diagnosis to a generic HTTP status. In particular, the service can
 /// use HTTP 403 for either developer credentials or an end-user login and
-/// states which pair failed only in its plain-text response.
+/// states which pair failed only in its plain-text response. HTTP 400 no
+/// longer stops the run, so a documented service-wide text under it (a
+/// closure, an exhausted allowance, a refused client) keeps the text's
+/// classification instead of passing as one game's rejection.
 fn response_status(response: &HttpResponse) -> Result<()> {
     if let Ok(text) = std::str::from_utf8(&response.body) {
         let trimmed = text.trim_start_matches('\u{feff}').trim_start();
-        if trimmed.to_lowercase().starts_with("erreur") {
-            let body_error = text_error(trimmed);
-            if response.status < 300 || body_error.kind == ErrorKind::Authentication {
+        let lower = trimmed.to_lowercase();
+        if lower.starts_with("erreur") {
+            let documented = documented_error(&lower, trimmed);
+            let service_wide_under_400 = response.status == 400
+                && documented.as_ref().is_some_and(|error| {
+                    matches!(
+                        error.kind,
+                        ErrorKind::Configuration | ErrorKind::DailyQuota | ErrorKind::Unavailable
+                    )
+                });
+            let body_error = documented.unwrap_or_else(|| unrecognised_error(trimmed));
+            if response.status < 300
+                || body_error.kind == ErrorKind::Authentication
+                || service_wide_under_400
+            {
                 crate::note(match authentication_source(trimmed) {
                     Some(AuthenticationSource::Application) => {
                         "scraper      ScreenScraper rejected application authentication"
@@ -1020,73 +1035,99 @@ fn content_is_xml(response: &HttpResponse) -> Result<()> {
 }
 
 fn text_error(text: &str) -> Error {
-    let lower = text.to_lowercase();
-    if lower.starts_with("erreur") {
-        if lower.contains("développeur") || lower.contains("developpeur") {
-            return Error::new(
-                ErrorKind::Authentication,
-                "this Degauss build could not authenticate with ScreenScraper",
-            );
-        }
-        if lower.contains("utilisateur") {
-            return Error::new(
-                ErrorKind::Authentication,
-                "ScreenScraper rejected the login. Check the username and password",
-            );
-        }
-        if lower.contains("quota") {
-            return Error::new(
-                ErrorKind::DailyQuota,
-                "the ScreenScraper allowance is exhausted",
-            );
-        }
-        if lower.contains("introuv") || lower.contains("non trouv") {
-            return Error::new(ErrorKind::NotFound, "no matching game");
-        }
-        // The documented closure texts ("API fermé pour les non membres",
-        // "API totalement fermé") describe the service, not the request.
-        if lower.contains("ferm") {
-            return Error::new(
-                ErrorKind::Unavailable,
-                "ScreenScraper reported that the API is closed",
-            );
-        }
-        if lower.contains("blacklist") {
-            return Error::new(
-                ErrorKind::Configuration,
-                "this Degauss scraper client was refused by ScreenScraper",
-            );
-        }
-        // The documented HTTP 400 texts (a rom name carrying a path or not
-        // conforming, a malformed hash field, a call missing its fields)
-        // concern this one request: the run continues with the next game.
-        if lower.contains("fichier rom")
-            || lower.contains("l'url")
-            || lower.contains("crc, md5 ou sha1")
-        {
-            return Error::new(
-                ErrorKind::InvalidRequest,
-                format!("ScreenScraper rejected this request: {}", excerpt(text)),
-            );
-        }
-        // An error text ScreenScraper has not documented cannot be tied to
-        // the one request, so it stops the run as before rather than
-        // costing one lookup per remaining game; the log keeps the
-        // server's words so the cause stays diagnosable.
+    if text.trim().is_empty() {
         return Error::new(
             ErrorKind::Unavailable,
-            format!(
-                "ScreenScraper returned an unrecognised error response: {}",
-                excerpt(text)
-            ),
+            "ScreenScraper returned an empty response",
         );
     }
+    let lower = text.to_lowercase();
+    if lower.starts_with("erreur") {
+        return documented_error(&lower, text).unwrap_or_else(|| unrecognised_error(text));
+    }
     // Neither XML nor an error text is not an answer to the one request
-    // (an empty body, a maintenance notice), so the run stops.
+    // (a maintenance notice), so the run stops.
     Error::new(
         ErrorKind::Unavailable,
         format!(
             "ScreenScraper returned a response that was not XML: {}",
+            excerpt(text)
+        ),
+    )
+}
+
+/// The classification of an error text ScreenScraper documents; `lower`
+/// is `text` lowercased. None for a text the service has not documented.
+fn documented_error(lower: &str, text: &str) -> Option<Error> {
+    if lower.contains("développeur") || lower.contains("developpeur") {
+        return Some(Error::new(
+            ErrorKind::Authentication,
+            "this Degauss build could not authenticate with ScreenScraper",
+        ));
+    }
+    if lower.contains("utilisateur") {
+        return Some(Error::new(
+            ErrorKind::Authentication,
+            "ScreenScraper rejected the login. Check the username and password",
+        ));
+    }
+    if lower.contains("quota") {
+        return Some(Error::new(
+            ErrorKind::DailyQuota,
+            "the ScreenScraper allowance is exhausted",
+        ));
+    }
+    if lower.contains("introuv") || lower.contains("non trouv") {
+        return Some(Error::new(ErrorKind::NotFound, "no matching game"));
+    }
+    // The documented closure texts ("API fermé pour les non membres",
+    // "API totalement fermé") describe the service, not the request.
+    if lower.contains("ferm") {
+        return Some(Error::new(
+            ErrorKind::Unavailable,
+            "ScreenScraper reported that the API is closed",
+        ));
+    }
+    // The blacklist text is the one HTTP 426 carries: the same kind, so a
+    // refused client stops the run wherever the text arrives.
+    if lower.contains("blacklist") {
+        return Some(Error::new(
+            ErrorKind::Configuration,
+            "this Degauss scraper client was refused by ScreenScraper",
+        ));
+    }
+    // Degauss sends the same request fields for every game, so the
+    // documented texts for a call missing its fields concern the run.
+    if lower.contains("l'url") {
+        return Some(Error::new(
+            ErrorKind::Configuration,
+            format!(
+                "ScreenScraper rejected the request address, which is the same for every game: {}",
+                excerpt(text)
+            ),
+        ));
+    }
+    // The documented HTTP 400 texts for a rom name carrying a path or not
+    // conforming and for a malformed hash field concern this one request:
+    // the run continues with the next game.
+    if lower.contains("fichier rom") || lower.contains("crc, md5 ou sha1") {
+        return Some(Error::new(
+            ErrorKind::InvalidRequest,
+            format!("ScreenScraper rejected this request: {}", excerpt(text)),
+        ));
+    }
+    None
+}
+
+/// An error text ScreenScraper has not documented cannot be tied to the
+/// one request, so it stops the run as before rather than costing one
+/// lookup per remaining game; the log keeps the server's words so the
+/// cause stays diagnosable.
+fn unrecognised_error(text: &str) -> Error {
+    Error::new(
+        ErrorKind::Unavailable,
+        format!(
+            "ScreenScraper returned an unrecognised error response: {}",
             excerpt(text)
         ),
     )
@@ -2319,11 +2360,15 @@ mod tests {
 
     #[test]
     fn only_documented_per_request_error_texts_leave_the_run_going() {
-        // The documented 400 texts concern one request and must not stop
-        // the batch by masquerading as an outage. A closure, a refused
-        // client, a text ScreenScraper has not documented, or a body that
-        // is no answer at all concerns every remaining game and stops the
-        // run instead of costing one lookup per game.
+        // The documented 400 texts about one rom name or hash field concern
+        // one request and must not stop the batch by masquerading as an
+        // outage. The documented 400 texts about the request address concern
+        // every game, because Degauss sends the same fields for each. A
+        // closure, a refused client (the blacklist text is classified like
+        // HTTP 426, which carries it), a text ScreenScraper has not
+        // documented, or a body that is no answer at all concerns every
+        // remaining game and stops the run instead of costing one lookup
+        // per game.
         for (body, kind) in [
             (
                 "Erreur : API fermé pour les non membres ou les membres inactifs",
@@ -2348,9 +2393,9 @@ mod tests {
             ),
             (
                 "Erreur : Il manque des champs obligatoires dans l'url",
-                ErrorKind::InvalidRequest,
+                ErrorKind::Configuration,
             ),
-            ("Erreur : problème avec l'url", ErrorKind::InvalidRequest),
+            ("Erreur : problème avec l'url", ErrorKind::Configuration),
             (
                 "Erreur : Problème dans la recherche",
                 ErrorKind::Unavailable,
@@ -2404,6 +2449,16 @@ mod tests {
         .unwrap_err();
         assert_eq!(rejected.kind, ErrorKind::InvalidRequest);
         assert!(!rejected.retryable());
+        let incomplete = client(HttpResponse {
+            status: 200,
+            content_type: Some("text/plain".into()),
+            body: "Erreur : Il manque des champs obligatoires dans l'url"
+                .as_bytes()
+                .to_vec(),
+        })
+        .by_name(3, "Game")
+        .unwrap_err();
+        assert_eq!(incomplete.kind, ErrorKind::Configuration);
         let undocumented = client(HttpResponse {
             status: 200,
             content_type: Some("text/plain".into()),
@@ -2478,6 +2533,58 @@ mod tests {
     }
 
     #[test]
+    fn a_service_wide_text_under_http_400_still_stops_the_run() {
+        // HTTP 400 is one game's rejection, so it no longer stops the run.
+        // A documented closure, allowance or refused-client text delivered
+        // with that status would otherwise cost one lookup per remaining
+        // game; a per-request text, a not-found text, or one ScreenScraper
+        // has not documented keeps the status's per-game meaning.
+        for (body, kind) in [
+            ("Erreur : API totalement fermé", ErrorKind::Unavailable),
+            (
+                "Erreur : Le logiciel de scrape utilisé a été blacklisté",
+                ErrorKind::Configuration,
+            ),
+            (
+                "Erreur : Votre quota de scrape est dépassé pour aujourd'hui !",
+                ErrorKind::DailyQuota,
+            ),
+            (
+                "Erreur : Il manque des champs obligatoires dans l'url",
+                ErrorKind::Configuration,
+            ),
+            (
+                "Erreur : Problème dans le nom du fichier rom",
+                ErrorKind::InvalidRequest,
+            ),
+            ("Erreur : Jeu non trouvée !", ErrorKind::InvalidRequest),
+            (
+                "Erreur : Problème dans la recherche",
+                ErrorKind::InvalidRequest,
+            ),
+        ] {
+            let error = client(HttpResponse {
+                status: 400,
+                content_type: Some("text/plain".into()),
+                body: body.as_bytes().to_vec(),
+            })
+            .by_name(3, "Game")
+            .unwrap_err();
+            assert_eq!(error.kind, kind, "{body}");
+        }
+        // Other statuses keep their own meaning over a body text, so a
+        // rate limit stays retryable whatever the text says.
+        let limited = client(HttpResponse {
+            status: 429,
+            content_type: Some("text/plain".into()),
+            body: "Erreur : API totalement fermé".as_bytes().to_vec(),
+        })
+        .by_name(3, "Game")
+        .unwrap_err();
+        assert_eq!(limited.kind, ErrorKind::RateLimited);
+    }
+
+    #[test]
     fn an_undocumented_error_text_is_kept_in_the_diagnosis_but_bounded() {
         // The interface shows only the kind's fixed message, so the log
         // detail is the one place the server's actual words can be seen,
@@ -2512,6 +2619,13 @@ mod tests {
             "{}",
             plain.detail
         );
+        // An empty answer has no words to keep: the detail names the
+        // emptiness instead of ending in a bare colon.
+        for empty in ["", " \n\t"] {
+            let error = text_error(empty);
+            assert_eq!(error.kind, ErrorKind::Unavailable);
+            assert_eq!(error.detail, "ScreenScraper returned an empty response");
+        }
         // The cut falls exactly at the limit, with the whitespace between
         // words counted once, so a documented text is never shortened.
         let exact = format!("{} {}", "a".repeat(60), "b".repeat(59));

--- a/src/scraper/api.rs
+++ b/src/scraper/api.rs
@@ -973,14 +973,17 @@ fn response_status(response: &HttpResponse) -> Result<()> {
         if trimmed.to_lowercase().starts_with("erreur") {
             let body_error = text_error(trimmed);
             if response.status < 300 || body_error.kind == ErrorKind::Authentication {
-                crate::note(match authentication_source(trimmed) {
+                crate::note(&match authentication_source(trimmed) {
                     Some(AuthenticationSource::Application) => {
-                        "scraper      ScreenScraper rejected application authentication"
+                        "scraper      ScreenScraper rejected application authentication".to_string()
                     }
                     Some(AuthenticationSource::Account) => {
-                        "scraper      ScreenScraper rejected account authentication"
+                        "scraper      ScreenScraper rejected account authentication".to_string()
                     }
-                    None => "scraper      ScreenScraper returned a body-level error",
+                    None => format!(
+                        "scraper      ScreenScraper returned a body-level error: {}",
+                        excerpt(trimmed)
+                    ),
                 });
                 return Err(body_error);
             }
@@ -990,13 +993,20 @@ fn response_status(response: &HttpResponse) -> Result<()> {
 }
 
 fn content_is_xml(response: &HttpResponse) -> Result<()> {
-    if response.content_type.as_deref().is_some_and(|value| {
+    // ScreenScraper answers with XML or a plain-text error. Any other
+    // content type (a maintenance or intermediary page) is not an answer
+    // to the one request, so it counts as the service being unavailable
+    // rather than as one game's unreadable match.
+    if let Some(content_type) = response.content_type.as_deref().filter(|value| {
         let value = value.to_ascii_lowercase();
         !value.contains("xml") && !value.starts_with("text/plain")
     }) {
         return Err(Error::new(
-            ErrorKind::MalformedResponse,
-            "ScreenScraper returned a non-XML response",
+            ErrorKind::Unavailable,
+            format!(
+                "ScreenScraper returned a non-XML response (content type {})",
+                excerpt(content_type)
+            ),
         ));
     }
     let text = std::str::from_utf8(&response.body).map_err(|_| {
@@ -1033,6 +1043,21 @@ fn text_error(text: &str) -> Error {
                 "the ScreenScraper allowance is exhausted",
             );
         }
+        // The documented 431 text ("Faite du tri dans vos fichiers roms et
+        // repassez demain !") names no quota.
+        if lower.contains("tri dans vos fichiers") {
+            return Error::new(
+                ErrorKind::FailedQuota,
+                "the daily failed-search allowance is exhausted",
+            );
+        }
+        // Every documented 429 text, French or English, names threads.
+        if lower.contains("threads") {
+            return Error::new(
+                ErrorKind::RateLimited,
+                "ScreenScraper's concurrent or per-minute limit was reached",
+            );
+        }
         if lower.contains("introuv") || lower.contains("non trouv") {
             return Error::new(ErrorKind::NotFound, "no matching game");
         }
@@ -1051,16 +1076,37 @@ fn text_error(text: &str) -> Error {
             );
         }
         // Any other error text on a successful status answers this one
-        // request: the run continues with the next game.
+        // request: the run continues with the next game, and the log keeps
+        // the server's words so an undocumented refusal stays diagnosable.
         return Error::new(
             ErrorKind::InvalidRequest,
-            "ScreenScraper returned an error response for this request",
+            format!(
+                "ScreenScraper returned an error response for this request: {}",
+                excerpt(text)
+            ),
         );
     }
     Error::new(
         ErrorKind::MalformedResponse,
-        "ScreenScraper returned a response that was not XML",
+        format!(
+            "ScreenScraper returned a response that was not XML: {}",
+            excerpt(text)
+        ),
     )
+}
+
+/// One bounded line of a server text for the log. The documented error
+/// texts are short sentences; a longer body is cut so a page cannot
+/// flood the log.
+fn excerpt(text: &str) -> String {
+    const LIMIT: usize = 120;
+    let line = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if line.chars().count() <= LIMIT {
+        line
+    } else {
+        let cut: String = line.chars().take(LIMIT).collect();
+        format!("{cut}...")
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2062,6 +2108,9 @@ mod tests {
 
     #[test]
     fn content_type_cannot_turn_html_into_xml() {
+        // An HTML page is never parsed as the account answer, and it is
+        // reported as the service being unavailable rather than as a
+        // malformed answer to one request.
         let error = client(HttpResponse {
             status: 200,
             content_type: Some("text/html".into()),
@@ -2069,7 +2118,7 @@ mod tests {
         })
         .account()
         .unwrap_err();
-        assert_eq!(error.kind, ErrorKind::MalformedResponse);
+        assert_eq!(error.kind, ErrorKind::Unavailable);
     }
 
     #[test]
@@ -2299,6 +2348,26 @@ mod tests {
                 "Erreur : Votre quota de scrape est dépassé pour aujourd'hui !",
                 ErrorKind::DailyQuota,
             ),
+            (
+                "Erreur : Faite du tri dans vos fichiers roms et repassez demain !",
+                ErrorKind::FailedQuota,
+            ),
+            (
+                "Erreur : Le nombre de threads autorisé pour le membre est atteint",
+                ErrorKind::RateLimited,
+            ),
+            (
+                "Erreur : Le nombre de threads par minute autorisé pour le membre est atteint",
+                ErrorKind::RateLimited,
+            ),
+            (
+                "Erreur : The maximum threads allowed to leecher users is already used",
+                ErrorKind::RateLimited,
+            ),
+            (
+                "Erreur : The maximum threads is already used",
+                ErrorKind::RateLimited,
+            ),
             ("Erreur : Jeu non trouvée !", ErrorKind::NotFound),
             (
                 "<html>not an error text</html>",
@@ -2326,6 +2395,67 @@ mod tests {
         .by_name(3, "Game")
         .unwrap_err();
         assert_eq!(closed.kind, ErrorKind::Unavailable);
+        // A limit or an exhausted failed-search allowance delivered as a
+        // 2xx text must keep its meaning: the batch stops instead of
+        // repeating a lookup the server is refusing for every game.
+        let limited = client(HttpResponse {
+            status: 200,
+            content_type: Some("text/plain".into()),
+            body: "Erreur : The maximum threads is already used"
+                .as_bytes()
+                .to_vec(),
+        })
+        .by_name(3, "Game")
+        .unwrap_err();
+        assert_eq!(limited.kind, ErrorKind::RateLimited);
+        let exhausted = client(HttpResponse {
+            status: 200,
+            content_type: Some("text/plain".into()),
+            body: "Erreur : Faite du tri dans vos fichiers roms et repassez demain !"
+                .as_bytes()
+                .to_vec(),
+        })
+        .by_name(3, "Game")
+        .unwrap_err();
+        assert_eq!(exhausted.kind, ErrorKind::FailedQuota);
+        // A page that is not XML at all is not a match response for one
+        // game: it stops the run like any other outage.
+        let page = client(HttpResponse {
+            status: 200,
+            content_type: Some("text/html; charset=utf-8".into()),
+            body: b"<html>maintenance</html>".to_vec(),
+        })
+        .by_name(3, "Game")
+        .unwrap_err();
+        assert_eq!(page.kind, ErrorKind::Unavailable);
+        assert!(page.detail.contains("text/html"), "{}", page.detail);
+    }
+
+    #[test]
+    fn an_undocumented_error_text_is_kept_in_the_diagnosis_but_bounded() {
+        // A per-game refusal no longer stops the run, so the only place the
+        // server's actual words can be seen is the log detail. A long body
+        // is cut so a page cannot flood it.
+        let error = text_error("Erreur : Problème   dans\nla recherche");
+        assert_eq!(error.kind, ErrorKind::InvalidRequest);
+        assert!(
+            error
+                .detail
+                .ends_with(": Erreur : Problème dans la recherche"),
+            "{}",
+            error.detail
+        );
+        let long = format!("Erreur : {}", "é".repeat(500));
+        let detail = text_error(&long).detail;
+        assert!(detail.ends_with("..."), "{detail}");
+        assert!(detail.chars().count() < 200, "{detail}");
+        let plain = text_error("Service paused for maintenance");
+        assert_eq!(plain.kind, ErrorKind::MalformedResponse);
+        assert!(
+            plain.detail.ends_with(": Service paused for maintenance"),
+            "{}",
+            plain.detail
+        );
     }
 
     #[test]

--- a/src/scraper/api.rs
+++ b/src/scraper/api.rs
@@ -1075,19 +1075,34 @@ fn text_error(text: &str) -> Error {
                 "this Degauss scraper client was refused by ScreenScraper",
             );
         }
-        // Any other error text on a successful status answers this one
-        // request: the run continues with the next game, and the log keeps
-        // the server's words so an undocumented refusal stays diagnosable.
+        // The documented HTTP 400 texts (a rom name carrying a path or not
+        // conforming, a malformed hash field, a call missing its fields)
+        // concern this one request: the run continues with the next game.
+        if lower.contains("fichier rom")
+            || lower.contains("l'url")
+            || lower.contains("crc, md5 ou sha1")
+        {
+            return Error::new(
+                ErrorKind::InvalidRequest,
+                format!("ScreenScraper rejected this request: {}", excerpt(text)),
+            );
+        }
+        // An error text ScreenScraper has not documented cannot be tied to
+        // the one request, so it stops the run as before rather than
+        // costing one lookup per remaining game; the log keeps the
+        // server's words so the cause stays diagnosable.
         return Error::new(
-            ErrorKind::InvalidRequest,
+            ErrorKind::Unavailable,
             format!(
-                "ScreenScraper returned an error response for this request: {}",
+                "ScreenScraper returned an unrecognised error response: {}",
                 excerpt(text)
             ),
         );
     }
+    // Neither XML nor an error text is not an answer to the one request
+    // (an empty body, a maintenance notice), so the run stops.
     Error::new(
-        ErrorKind::MalformedResponse,
+        ErrorKind::Unavailable,
         format!(
             "ScreenScraper returned a response that was not XML: {}",
             excerpt(text)
@@ -2318,10 +2333,12 @@ mod tests {
     }
 
     #[test]
-    fn only_service_wide_error_texts_are_classified_as_outages() {
-        // A closure or a refused client concerns every game in the run; an
-        // unrecognised error about one request must not stop the batch by
-        // masquerading as an outage.
+    fn only_documented_per_request_error_texts_leave_the_run_going() {
+        // The documented 400 texts concern one request and must not stop
+        // the batch by masquerading as an outage. A closure, a refused
+        // client, a text ScreenScraper has not documented, or a body that
+        // is no answer at all concerns every remaining game and stops the
+        // run instead of costing one lookup per game.
         for (body, kind) in [
             (
                 "Erreur : API fermé pour les non membres ou les membres inactifs",
@@ -2335,6 +2352,23 @@ mod tests {
             (
                 "Erreur : Problème dans le nom du fichier rom",
                 ErrorKind::InvalidRequest,
+            ),
+            (
+                "Erreur dans le nom du fichier rom : celui-ci contient un chemin d'accés",
+                ErrorKind::InvalidRequest,
+            ),
+            (
+                "Erreur : Champ crc, md5 ou sha1 erroné",
+                ErrorKind::InvalidRequest,
+            ),
+            (
+                "Erreur : Il manque des champs obligatoires dans l'url",
+                ErrorKind::InvalidRequest,
+            ),
+            ("Erreur : problème avec l'url", ErrorKind::InvalidRequest),
+            (
+                "Erreur : Problème dans la recherche",
+                ErrorKind::Unavailable,
             ),
             (
                 "Erreur de login : Vérifier vos identifiants développeur !",
@@ -2369,10 +2403,8 @@ mod tests {
                 ErrorKind::RateLimited,
             ),
             ("Erreur : Jeu non trouvée !", ErrorKind::NotFound),
-            (
-                "<html>not an error text</html>",
-                ErrorKind::MalformedResponse,
-            ),
+            ("Service paused for maintenance", ErrorKind::Unavailable),
+            ("", ErrorKind::Unavailable),
         ] {
             assert_eq!(text_error(body).kind, kind, "{body}");
         }
@@ -2387,6 +2419,14 @@ mod tests {
         .unwrap_err();
         assert_eq!(rejected.kind, ErrorKind::InvalidRequest);
         assert!(!rejected.retryable());
+        let undocumented = client(HttpResponse {
+            status: 200,
+            content_type: Some("text/plain".into()),
+            body: "Erreur : Problème dans la recherche".as_bytes().to_vec(),
+        })
+        .by_name(3, "Game")
+        .unwrap_err();
+        assert_eq!(undocumented.kind, ErrorKind::Unavailable);
         let closed = client(HttpResponse {
             status: 200,
             content_type: Some("text/plain".into()),
@@ -2429,15 +2469,45 @@ mod tests {
         .unwrap_err();
         assert_eq!(page.kind, ErrorKind::Unavailable);
         assert!(page.detail.contains("text/html"), "{}", page.detail);
+        // So does a plain-text body that is no error text, whatever its
+        // content type says, and so does an empty answer.
+        for (content_type, body) in [
+            (Some("text/plain"), "Service paused for maintenance"),
+            (Some("application/xml"), ""),
+            (None, "Service paused for maintenance"),
+        ] {
+            let notice = client(HttpResponse {
+                status: 200,
+                content_type: content_type.map(str::to_string),
+                body: body.as_bytes().to_vec(),
+            })
+            .by_name(3, "Game")
+            .unwrap_err();
+            assert_eq!(
+                notice.kind,
+                ErrorKind::Unavailable,
+                "{content_type:?} {body:?}"
+            );
+        }
     }
 
     #[test]
     fn an_undocumented_error_text_is_kept_in_the_diagnosis_but_bounded() {
-        // A per-game refusal no longer stops the run, so the only place the
-        // server's actual words can be seen is the log detail. A long body
-        // is cut so a page cannot flood it.
+        // The interface shows only the kind's fixed message, so the log
+        // detail is the one place the server's actual words can be seen,
+        // for a per-game refusal and for the unrecognised text that stopped
+        // a run alike. A long body is cut so a page cannot flood it.
+        let rejected = text_error("Erreur : Problème   dans le nom\ndu fichier rom");
+        assert_eq!(rejected.kind, ErrorKind::InvalidRequest);
+        assert!(
+            rejected
+                .detail
+                .ends_with(": Erreur : Problème dans le nom du fichier rom"),
+            "{}",
+            rejected.detail
+        );
         let error = text_error("Erreur : Problème   dans\nla recherche");
-        assert_eq!(error.kind, ErrorKind::InvalidRequest);
+        assert_eq!(error.kind, ErrorKind::Unavailable);
         assert!(
             error
                 .detail
@@ -2450,7 +2520,7 @@ mod tests {
         assert!(detail.ends_with("..."), "{detail}");
         assert!(detail.chars().count() < 200, "{detail}");
         let plain = text_error("Service paused for maintenance");
-        assert_eq!(plain.kind, ErrorKind::MalformedResponse);
+        assert_eq!(plain.kind, ErrorKind::Unavailable);
         assert!(
             plain.detail.ends_with(": Service paused for maintenance"),
             "{}",

--- a/src/scraper/api.rs
+++ b/src/scraper/api.rs
@@ -1135,19 +1135,54 @@ fn unrecognised_error(text: &str) -> Error {
 
 /// One bounded line of a server text for the log. The documented error
 /// texts are short sentences; a longer body is cut so a page cannot
-/// flood the log.
+/// flood the log, and the cut line is redacted so a page that echoes the
+/// request address cannot put the credentials from its query in the log.
 fn excerpt(text: &str) -> String {
     const LIMIT: usize = 120;
     let mut chars = text
         .split_whitespace()
         .flat_map(|word| std::iter::once(' ').chain(word.chars()))
         .skip(1);
-    let line: String = chars.by_ref().take(LIMIT).collect();
+    let line = redact_credentials(&chars.by_ref().take(LIMIT).collect::<String>());
     if chars.next().is_some() {
         format!("{line}...")
     } else {
         line
     }
+}
+
+/// Replace the value of every credential query parameter Degauss sends
+/// (`devid`, `devpassword`, `ssid`, `sspassword`) with "[redacted]". The
+/// value runs to the next `&`, whitespace or markup delimiter, or to the
+/// end of the line, so a value the cut left half in place is blanked too.
+fn redact_credentials(line: &str) -> String {
+    const KEYS: [&str; 4] = ["devid", "devpassword", "ssid", "sspassword"];
+    let lower = line.to_ascii_lowercase();
+    let mut redacted = String::with_capacity(line.len());
+    let mut index = 0;
+    while let Some(next) = line[index..].chars().next() {
+        let key = KEYS.iter().copied().find(|key| {
+            let at_boundary = index == 0 || !lower.as_bytes()[index - 1].is_ascii_alphanumeric();
+            at_boundary
+                && lower[index..].starts_with(key)
+                && lower[index + key.len()..].starts_with('=')
+        });
+        let Some(key) = key else {
+            redacted.push(next);
+            index += next.len_utf8();
+            continue;
+        };
+        let value_start = index + key.len() + 1;
+        let value_end = line[value_start..]
+            .find(|character: char| {
+                character == '&' || character.is_whitespace() || "\"'<>".contains(character)
+            })
+            .map_or(line.len(), |offset| value_start + offset);
+        redacted.push_str(&line[index..value_start]);
+        redacted.push_str("[redacted]");
+        index = value_end;
+    }
+    redacted
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1231,10 +1266,17 @@ fn parse(
     let mut saw_account = false;
     let mut game: Option<RawGame> = None;
     let mut capture: Option<Capture> = None;
+    // Every ScreenScraper answer is a `<Data>` document. A body with any
+    // other root (a maintenance, proxy or challenge page, whatever content
+    // type it was served with) is not an answer to the one request, so it
+    // is the service being unavailable; only a `<Data>` answer whose
+    // content is unusable is a malformed response for that request.
+    let mut saw_data_root = false;
 
     loop {
         match reader.read_event() {
             Ok(Event::Eof) => break,
+            Err(_) if !saw_data_root => return Err(not_an_answer("invalid XML")),
             Err(_) => {
                 return Err(Error::new(
                     ErrorKind::MalformedResponse,
@@ -1246,6 +1288,9 @@ fn parse(
             }
             Ok(Event::Start(element)) => {
                 let tag = element.name().as_ref().to_ascii_lowercase();
+                if !saw_data_root {
+                    saw_data_root = require_data_root(&tag)?;
+                }
                 let attributes = xml_attributes(&element)?;
                 let parent = stack.last().map(String::as_str);
                 let direct_game_rom = parent == Some("rom")
@@ -1341,6 +1386,10 @@ fn parse(
                 stack.push(element.name().as_ref().to_ascii_lowercase());
             }
             Ok(Event::Empty(element)) => {
+                if !saw_data_root {
+                    saw_data_root =
+                        require_data_root(&element.name().as_ref().to_ascii_lowercase())?;
+                }
                 xml_attributes(&element)?;
                 if element.name().as_ref().eq_ignore_ascii_case("jeux") {
                     parsed.saw_games_container = true;
@@ -1401,6 +1450,9 @@ fn parse(
             _ => {}
         }
     }
+    if !saw_data_root {
+        return Err(not_an_answer("no root element"));
+    }
     if !stack.is_empty() || game.is_some() || capture.is_some() {
         return Err(Error::new(
             ErrorKind::MalformedResponse,
@@ -1411,6 +1463,22 @@ fn parse(
         parsed.account = Some(account);
     }
     Ok(parsed)
+}
+
+/// True for ScreenScraper's `<Data>` root; any other root element is a
+/// page the service did not answer with.
+fn require_data_root(tag: &str) -> Result<bool> {
+    if tag == "data" {
+        return Ok(true);
+    }
+    Err(not_an_answer(&format!("root element <{}>", excerpt(tag))))
+}
+
+fn not_an_answer(what: &str) -> Error {
+    Error::new(
+        ErrorKind::Unavailable,
+        format!("ScreenScraper returned a page instead of an answer ({what})"),
+    )
 }
 
 fn xml_attributes(element: &BytesStart<'_>) -> Result<Vec<(String, String)>> {
@@ -2160,6 +2228,114 @@ mod tests {
         .account()
         .unwrap_err();
         assert_eq!(error.kind, ErrorKind::Unavailable);
+    }
+
+    #[test]
+    fn a_page_without_the_data_root_is_an_outage_whatever_its_content_type() {
+        // A maintenance, proxy or challenge page can arrive with no
+        // Content-Type header or with an XML one; its body starts with '<'
+        // like an answer, so the content type alone cannot tell it apart.
+        // Without the root check it would count as one game's unreadable
+        // match and a batch would spend one lookup per remaining game
+        // against a service that is not answering.
+        let hashes = Hashes {
+            size: 3,
+            crc32: "352441C2".into(),
+            md5: "900150983CD24FB0D6963F7D28E17F72".into(),
+            sha1: "A9993E364706816ABA3E25717850C26C9CD0D89D".into(),
+        };
+        for (content_type, body) in [
+            (None, "<html><body>Maintenance</body></html>"),
+            (
+                Some("application/xml"),
+                "<html><body>Maintenance</body></html>",
+            ),
+            (None, "<!DOCTYPE html><html><body><p>Maintenance</html>"),
+            (
+                Some("text/xml"),
+                "<?xml version='1.0'?><Response>busy</Response>",
+            ),
+            (None, "<!-- nothing -->"),
+            (None, "<<<"),
+        ] {
+            let response = HttpResponse {
+                status: 200,
+                content_type: content_type.map(str::to_string),
+                body: body.as_bytes().to_vec(),
+            };
+            let searched = client(response.clone()).by_name(3, "Game").unwrap_err();
+            assert_eq!(searched.kind, ErrorKind::Unavailable, "{body}");
+            assert!(
+                !searched.detail.contains("Maintenance"),
+                "{}",
+                searched.detail
+            );
+            assert_eq!(
+                client(response.clone())
+                    .by_hash(3, "Game.rom", &hashes)
+                    .unwrap_err()
+                    .kind,
+                ErrorKind::Unavailable,
+                "{body}"
+            );
+            assert_eq!(
+                client(response).account().unwrap_err().kind,
+                ErrorKind::Unavailable,
+                "{body}"
+            );
+        }
+        // A `<Data>` answer that is cut short or carries no game list is
+        // still that one request's unreadable answer.
+        for body in [
+            "<Data><jeux><jeu id='42'><noms>",
+            "<Data><message>no game list here</message></Data>",
+        ] {
+            assert_eq!(
+                client(HttpResponse {
+                    status: 200,
+                    content_type: None,
+                    body: body.as_bytes().to_vec(),
+                })
+                .by_name(3, "Game")
+                .unwrap_err()
+                .kind,
+                ErrorKind::MalformedResponse,
+                "{body}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_reflected_request_address_is_redacted_from_the_diagnosis() {
+        // `Client::auth` carries the developer and account credentials in
+        // the query string, and the excerpt of a rejection, of an
+        // unrecognised error text and of a plain page reaches the local
+        // log. A page that reflects the request address must not put those
+        // values there, including a value the cut leaves half in place.
+        let echo = "?devid=dm1&devpassword=ds1&ssid=um1&sspassword=us1&romnom=G.rom";
+        for text in [
+            format!("Erreur : Problème dans le nom du fichier rom {echo}"),
+            format!("Erreur : Problème dans la recherche {echo}"),
+            format!("Bad request {echo}"),
+        ] {
+            let detail = text_error(&text).detail;
+            for marker in ["=dm1", "=ds1", "=um1", "=us1"] {
+                assert!(!detail.contains(marker), "{detail}");
+            }
+            assert!(
+                detail.ends_with(
+                    "?devid=[redacted]&devpassword=[redacted]&ssid=[redacted]&sspassword=[redacted]&romnom=G.rom"
+                ),
+                "{detail}"
+            );
+        }
+        let straddling = format!("{} sspassword=user-secret-marker", "x".repeat(105));
+        let cut = excerpt(&straddling);
+        assert!(cut.ends_with(" sspassword=[redacted]..."), "{cut}");
+        assert_eq!(
+            redact_credentials("<a href='x.php?ssid=user-marker'>ssid=user-marker</a> myssid=kept"),
+            "<a href='x.php?ssid=[redacted]'>ssid=[redacted]</a> myssid=kept"
+        );
     }
 
     #[test]

--- a/src/scraper/api.rs
+++ b/src/scraper/api.rs
@@ -1469,11 +1469,17 @@ fn parse(
                 }
             }
             Ok(Event::Text(value)) => {
+                if !saw_data_root && !value.xml10_content().trim().is_empty() {
+                    return Err(not_an_answer("text before the root element"));
+                }
                 if let Some(capture) = capture.as_mut() {
                     capture.text.push_str(&value.xml10_content());
                 }
             }
             Ok(Event::CData(value)) => {
+                if !saw_data_root {
+                    return Err(not_an_answer("text before the root element"));
+                }
                 if let Some(capture) = capture.as_mut() {
                     capture.text.push_str(value.as_ref());
                 }
@@ -2338,6 +2344,21 @@ mod tests {
             (None, &b"<<<"[..]),
             (None, &b"<html>Maint\xe9nance</html>"[..]),
             (Some("application/xml"), &b"\xff\xfe<Data/>"[..]),
+            // A notice placed between the XML declaration and the `<Data>`
+            // root is text the service never emits; without the check it
+            // would pass as a miss for every game.
+            (
+                None,
+                &b"<?xml version=\"1.0\"?>Maintenance<Data><jeux/></Data>"[..],
+            ),
+            (
+                Some("text/xml"),
+                &b"<?xml version=\"1.0\"?>\n  Maintenance\n<Data><jeux/></Data>"[..],
+            ),
+            (
+                None,
+                &b"<?xml version=\"1.0\"?><![CDATA[Maintenance]]><Data><jeux/></Data>"[..],
+            ),
         ] {
             let response = HttpResponse {
                 status: 200,
@@ -2366,6 +2387,18 @@ mod tests {
                 "{body}"
             );
         }
+        // A byte order mark and whitespace between the declaration and the
+        // root are ordinary XML layout, and the empty game list behind them
+        // is a server miss.
+        let response = client(HttpResponse {
+            status: 200,
+            content_type: Some("text/xml".into()),
+            body: b"\xef\xbb\xbf<?xml version=\"1.0\"?>\n  \n<Data>\n  <jeux/>\n</Data>\n".to_vec(),
+        })
+        .by_name(3, "Game")
+        .unwrap();
+        assert_eq!(response.lookup, Lookup::NotFound);
+        assert!(response.server_miss);
         // A `<Data>` answer that is cut short or carries no game list is
         // still that one request's unreadable answer.
         for body in [

--- a/src/scraper/api.rs
+++ b/src/scraper/api.rs
@@ -967,26 +967,24 @@ fn status(code: u16) -> Result<()> {
 /// login diagnosis to a generic HTTP status. In particular, the service can
 /// use HTTP 403 for either developer credentials or an end-user login and
 /// states which pair failed only in its plain-text response. HTTP 400 no
-/// longer stops the run, so a documented service-wide text under it (a
-/// closure, an exhausted allowance, a refused client) keeps the text's
-/// classification instead of passing as one game's rejection.
+/// longer stops the run, so a documented text under it keeps the text's
+/// classification: a service-wide text (a closure, a limit, an exhausted
+/// allowance, a refused client) stops the run instead of passing as one
+/// game's rejection, a per-request text keeps the server's words in its
+/// detail and a not-found text is that game's miss. An unrecognised text
+/// under HTTP 400 keeps the status's per-game meaning, with the server's
+/// words in the detail so the log shows what was rejected.
 fn response_status(response: &HttpResponse) -> Result<()> {
     if let Ok(text) = std::str::from_utf8(&response.body) {
         let trimmed = text.trim_start_matches('\u{feff}').trim_start();
         let lower = trimmed.to_lowercase();
         if lower.starts_with("erreur") {
             let documented = documented_error(&lower, trimmed);
-            let service_wide_under_400 = response.status == 400
-                && documented.as_ref().is_some_and(|error| {
-                    matches!(
-                        error.kind,
-                        ErrorKind::Configuration | ErrorKind::DailyQuota | ErrorKind::Unavailable
-                    )
-                });
+            let documented_under_400 = response.status == 400 && documented.is_some();
             let body_error = documented.unwrap_or_else(|| unrecognised_error(trimmed));
             if response.status < 300
                 || body_error.kind == ErrorKind::Authentication
-                || service_wide_under_400
+                || documented_under_400
             {
                 crate::note(match authentication_source(trimmed) {
                     Some(AuthenticationSource::Application) => {
@@ -998,6 +996,15 @@ fn response_status(response: &HttpResponse) -> Result<()> {
                     None => "scraper      ScreenScraper returned a body-level error",
                 });
                 return Err(body_error);
+            }
+            if response.status == 400 {
+                return Err(Error::new(
+                    ErrorKind::InvalidRequest,
+                    format!(
+                        "ScreenScraper rejected the request parameters (HTTP 400): {}",
+                        excerpt(trimmed)
+                    ),
+                ));
             }
         }
     }
@@ -1086,6 +1093,22 @@ fn documented_error(lower: &str, text: &str) -> Option<Error> {
         return Some(Error::new(
             ErrorKind::Unavailable,
             "ScreenScraper reported that the API is closed",
+        ));
+    }
+    // The documented HTTP 429 texts (every one names "threads") and the
+    // HTTP 431 text describe the account's limits, not the request. Their
+    // HTTP statuses carry the retryable and allowance kinds; the text on
+    // its own stops the run like any other outage, wherever it arrives.
+    if lower.contains("threads") {
+        return Some(Error::new(
+            ErrorKind::Unavailable,
+            "ScreenScraper reported that its thread limit is reached",
+        ));
+    }
+    if lower.contains("faite du tri") || lower.contains("repassez demain") {
+        return Some(Error::new(
+            ErrorKind::Unavailable,
+            "the ScreenScraper failed-search allowance is exhausted",
         ));
     }
     // The blacklist text is the one HTTP 426 carries: the same kind, so a
@@ -2711,10 +2734,12 @@ mod tests {
     #[test]
     fn a_service_wide_text_under_http_400_still_stops_the_run() {
         // HTTP 400 is one game's rejection, so it no longer stops the run.
-        // A documented closure, allowance or refused-client text delivered
-        // with that status would otherwise cost one lookup per remaining
-        // game; a per-request text, a not-found text, or one ScreenScraper
-        // has not documented keeps the status's per-game meaning.
+        // A documented closure, limit, allowance or refused-client text
+        // delivered with that status would otherwise cost one lookup per
+        // remaining game. A per-request text and one ScreenScraper has not
+        // documented keep the status's per-game meaning, and the log detail
+        // keeps the server's words either way, because the fixed HTTP 400
+        // message alone would not say which rejection was sent.
         for (body, kind) in [
             ("Erreur : API totalement fermé", ErrorKind::Unavailable),
             (
@@ -2726,6 +2751,18 @@ mod tests {
                 ErrorKind::DailyQuota,
             ),
             (
+                "Erreur : Le nombre de threads par minute autorisé pour le membre est atteint",
+                ErrorKind::Unavailable,
+            ),
+            (
+                "Erreur : The maximum threads is already used",
+                ErrorKind::Unavailable,
+            ),
+            (
+                "Erreur : Faite du tri dans vos fichiers roms et repassez demain !",
+                ErrorKind::Unavailable,
+            ),
+            (
                 "Erreur : Il manque des champs obligatoires dans l'url",
                 ErrorKind::Configuration,
             ),
@@ -2733,7 +2770,6 @@ mod tests {
                 "Erreur : Problème dans le nom du fichier rom",
                 ErrorKind::InvalidRequest,
             ),
-            ("Erreur : Jeu non trouvée !", ErrorKind::InvalidRequest),
             (
                 "Erreur : Problème dans la recherche",
                 ErrorKind::InvalidRequest,
@@ -2747,7 +2783,26 @@ mod tests {
             .by_name(3, "Game")
             .unwrap_err();
             assert_eq!(error.kind, kind, "{body}");
+            if kind == ErrorKind::InvalidRequest {
+                assert!(
+                    error.detail.ends_with(&format!(": {body}")),
+                    "{body}: {}",
+                    error.detail
+                );
+            }
         }
+        // A documented not-found text keeps its own meaning under HTTP 400
+        // as it does on a successful status: the game is a server miss,
+        // not a rejection.
+        let missed = client(HttpResponse {
+            status: 400,
+            content_type: Some("text/plain".into()),
+            body: "Erreur : Jeu non trouvée !".as_bytes().to_vec(),
+        })
+        .by_name(3, "Game")
+        .unwrap();
+        assert_eq!(missed.lookup, Lookup::NotFound);
+        assert!(missed.server_miss);
         // Other statuses keep their own meaning over a body text, so a
         // rate limit stays retryable whatever the text says.
         let limited = client(HttpResponse {

--- a/src/scraper/api.rs
+++ b/src/scraper/api.rs
@@ -917,8 +917,11 @@ pub struct LookupResponse {
 fn status(code: u16) -> Result<()> {
     match code {
         200..=299 => Ok(()),
+        // ScreenScraper documents 400 only for problems with the one
+        // request (a rom name carrying a path, a bad hash, missing fields),
+        // so it stops that game rather than the run.
         400 => Err(Error::new(
-            ErrorKind::Configuration,
+            ErrorKind::InvalidRequest,
             "ScreenScraper rejected the request parameters (HTTP 400)",
         )),
         401 | 423 => Err(Error::new(
@@ -1033,9 +1036,25 @@ fn text_error(text: &str) -> Error {
         if lower.contains("introuv") || lower.contains("non trouv") {
             return Error::new(ErrorKind::NotFound, "no matching game");
         }
+        // The documented closure texts ("API fermé pour les non membres",
+        // "API totalement fermé") describe the service, not the request.
+        if lower.contains("ferm") {
+            return Error::new(
+                ErrorKind::Unavailable,
+                "ScreenScraper reported that the API is closed",
+            );
+        }
+        if lower.contains("blacklist") {
+            return Error::new(
+                ErrorKind::Configuration,
+                "this Degauss scraper client was refused by ScreenScraper",
+            );
+        }
+        // Any other error text on a successful status answers this one
+        // request: the run continues with the next game.
         return Error::new(
-            ErrorKind::Unavailable,
-            "ScreenScraper returned an error response",
+            ErrorKind::InvalidRequest,
+            "ScreenScraper returned an error response for this request",
         );
     }
     Error::new(
@@ -1734,7 +1753,7 @@ mod tests {
     #[test]
     fn every_documented_status_has_a_specific_meaning() {
         for (code, kind) in [
-            (400, ErrorKind::Configuration),
+            (400, ErrorKind::InvalidRequest),
             (401, ErrorKind::Unavailable),
             (403, ErrorKind::Authentication),
             (404, ErrorKind::NotFound),
@@ -2247,6 +2266,66 @@ mod tests {
         .unwrap();
         assert_eq!(result.lookup, Lookup::NotFound);
         assert!(result.server_miss);
+    }
+
+    #[test]
+    fn only_service_wide_error_texts_are_classified_as_outages() {
+        // A closure or a refused client concerns every game in the run; an
+        // unrecognised error about one request must not stop the batch by
+        // masquerading as an outage.
+        for (body, kind) in [
+            (
+                "Erreur : API fermé pour les non membres ou les membres inactifs",
+                ErrorKind::Unavailable,
+            ),
+            ("Erreur : API totalement fermé", ErrorKind::Unavailable),
+            (
+                "Erreur : Le logiciel de scrape utilisé a été blacklisté",
+                ErrorKind::Configuration,
+            ),
+            (
+                "Erreur : Problème dans le nom du fichier rom",
+                ErrorKind::InvalidRequest,
+            ),
+            (
+                "Erreur de login : Vérifier vos identifiants développeur !",
+                ErrorKind::Authentication,
+            ),
+            (
+                "Erreur de login : Vérifier les identifiants utilisateurs !",
+                ErrorKind::Authentication,
+            ),
+            (
+                "Erreur : Votre quota de scrape est dépassé pour aujourd'hui !",
+                ErrorKind::DailyQuota,
+            ),
+            ("Erreur : Jeu non trouvée !", ErrorKind::NotFound),
+            (
+                "<html>not an error text</html>",
+                ErrorKind::MalformedResponse,
+            ),
+        ] {
+            assert_eq!(text_error(body).kind, kind, "{body}");
+        }
+        let rejected = client(HttpResponse {
+            status: 200,
+            content_type: Some("text/plain".into()),
+            body: "Erreur : Problème dans le nom du fichier rom"
+                .as_bytes()
+                .to_vec(),
+        })
+        .by_name(3, "Game")
+        .unwrap_err();
+        assert_eq!(rejected.kind, ErrorKind::InvalidRequest);
+        assert!(!rejected.retryable());
+        let closed = client(HttpResponse {
+            status: 200,
+            content_type: Some("text/plain".into()),
+            body: "Erreur : API totalement fermé".as_bytes().to_vec(),
+        })
+        .by_name(3, "Game")
+        .unwrap_err();
+        assert_eq!(closed.kind, ErrorKind::Unavailable);
     }
 
     #[test]

--- a/src/scraper/api.rs
+++ b/src/scraper/api.rs
@@ -563,8 +563,8 @@ impl Client {
         let response = self
             .transport
             .get("ssuserInfos.php", &self.auth(), MAX_XML_BYTES)?;
-        response_status(&response)?;
-        content_is_xml(&response)?;
+        response_status(&response, Answer::Account)?;
+        content_is_xml(&response, Answer::Account)?;
         parse(
             &response.body,
             self.region.as_deref(),
@@ -624,7 +624,7 @@ impl Client {
             ("sha1".into(), hashes.sha1.clone()),
         ]);
         let response = self.transport.get("jeuInfos.php", &params, MAX_XML_BYTES)?;
-        match response_status(&response) {
+        match response_status(&response, Answer::Lookup) {
             Err(error) if error.kind == ErrorKind::NotFound => {
                 return Ok(LookupResponse {
                     lookup: Lookup::NotFound,
@@ -636,7 +636,7 @@ impl Client {
             Err(error) => return Err(error),
             Ok(()) => {}
         }
-        if let Err(error) = content_is_xml(&response) {
+        if let Err(error) = content_is_xml(&response, Answer::Lookup) {
             if error.kind == ErrorKind::NotFound {
                 return Ok(LookupResponse {
                     lookup: Lookup::NotFound,
@@ -711,7 +711,7 @@ impl Client {
         let response = self
             .transport
             .get("jeuRecherche.php", &params, MAX_XML_BYTES)?;
-        match response_status(&response) {
+        match response_status(&response, Answer::Lookup) {
             Err(error) if error.kind == ErrorKind::NotFound => {
                 return Ok(LookupResponse {
                     lookup: Lookup::NotFound,
@@ -723,7 +723,7 @@ impl Client {
             Err(error) => return Err(error),
             Ok(()) => {}
         }
-        if let Err(error) = content_is_xml(&response) {
+        if let Err(error) = content_is_xml(&response, Answer::Lookup) {
             if error.kind == ErrorKind::NotFound {
                 return Ok(LookupResponse {
                     lookup: Lookup::NotFound,
@@ -790,7 +790,7 @@ impl Client {
 
     pub fn media(&self, media: &Media, limit: u64) -> Result<HttpResponse> {
         let response = self.transport.get_media(&media.url, limit, None)?;
-        response_status(&response)?;
+        response_status(&response, Answer::Media)?;
         if std::str::from_utf8(&response.body)
             .ok()
             .is_some_and(|text| text.trim().eq_ignore_ascii_case("NOMEDIA"))
@@ -914,16 +914,24 @@ pub struct LookupResponse {
     pub server_miss: bool,
 }
 
+/// What a response answers, which decides whose problem a rejection is:
+/// a lookup's concerns the one game, the account check runs before any
+/// game, and a media transfer answers with an image rather than text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Answer {
+    /// `jeuInfos.php` or `jeuRecherche.php` for one game.
+    Lookup,
+    /// `ssuserInfos.php` before the run.
+    Account,
+    /// An image download for a matched game.
+    Media,
+}
+
+/// The meaning of an HTTP status other than 400, which `rejected_request`
+/// classifies from the body.
 fn status(code: u16) -> Result<()> {
     match code {
         200..=299 => Ok(()),
-        // ScreenScraper documents 400 only for problems with the one
-        // request (a rom name carrying a path, a bad hash, missing fields),
-        // so it stops that game rather than the run.
-        400 => Err(Error::new(
-            ErrorKind::InvalidRequest,
-            "ScreenScraper rejected the request parameters (HTTP 400)",
-        )),
         401 | 423 => Err(Error::new(
             ErrorKind::Unavailable,
             format!("ScreenScraper is temporarily closed (HTTP {code})"),
@@ -972,16 +980,18 @@ fn status(code: u16) -> Result<()> {
 /// allowance, a refused client) stops the run instead of passing as one
 /// game's rejection, a per-request text keeps the server's words in its
 /// detail and a not-found text is that game's miss. An unrecognised text
-/// under HTTP 400 keeps the status's per-game meaning, with the server's
-/// words in the detail so the log shows what was rejected.
-fn response_status(response: &HttpResponse) -> Result<()> {
-    if let Ok(text) = std::str::from_utf8(&response.body) {
-        let trimmed = text.trim_start_matches('\u{feff}').trim_start();
+/// under HTTP 400 keeps the status's meaning for `answer`, with the
+/// server's words in the detail so the log shows what was rejected.
+fn response_status(response: &HttpResponse, answer: Answer) -> Result<()> {
+    let text = std::str::from_utf8(&response.body)
+        .ok()
+        .map(|text| text.trim_start_matches('\u{feff}').trim_start());
+    if let Some(trimmed) = text {
         let lower = trimmed.to_lowercase();
         if lower.starts_with("erreur") {
             let documented = documented_error(&lower, trimmed);
             let documented_under_400 = response.status == 400 && documented.is_some();
-            let body_error = documented.unwrap_or_else(|| unrecognised_error(trimmed));
+            let body_error = documented.unwrap_or_else(|| unrecognised_error(trimmed, answer));
             if response.status < 300
                 || body_error.kind == ErrorKind::Authentication
                 || documented_under_400
@@ -997,29 +1007,67 @@ fn response_status(response: &HttpResponse) -> Result<()> {
                 });
                 return Err(body_error);
             }
-            if response.status == 400 {
-                return Err(Error::new(
-                    ErrorKind::InvalidRequest,
-                    format!(
-                        "ScreenScraper rejected the request parameters (HTTP 400): {}",
-                        excerpt(trimmed)
-                    ),
-                ));
-            }
         }
     }
-    status(response.status)
+    match response.status {
+        400 => Err(rejected_request(response, text, answer)),
+        code => status(code),
+    }
 }
 
-fn content_is_xml(response: &HttpResponse) -> Result<()> {
+/// HTTP 400. ScreenScraper documents it only for problems with the one
+/// request (a rom name carrying a path, a bad hash, missing fields) and
+/// answers it with an error text, so on a lookup or a media transfer it
+/// stops that game rather than the run, with the server's words in the
+/// detail; the account check sends only the credential fields, so a 400
+/// there is a setup fault, as before. The XML endpoints answer HTTP 400
+/// with text: a page, an empty body or a body that is not text under that
+/// status is an intermediary's answer, not ScreenScraper's, and stops the
+/// run as it would on a successful status. An image transfer answers with
+/// bytes, so that rule does not apply to it.
+fn rejected_request(response: &HttpResponse, text: Option<&str>, answer: Answer) -> Error {
+    let text = text.map(str::trim).filter(|text| !text.is_empty());
+    let kind = match answer {
+        Answer::Account => ErrorKind::Configuration,
+        Answer::Lookup | Answer::Media => ErrorKind::InvalidRequest,
+    };
+    if answer != Answer::Media {
+        if let Some(content_type) = page_content_type(response) {
+            return not_an_answer(&format!(
+                "content type {} under HTTP 400",
+                excerpt(content_type)
+            ));
+        }
+        if text.is_none() {
+            return not_an_answer("no error text under HTTP 400");
+        }
+    }
+    let rejected = "ScreenScraper rejected the request parameters (HTTP 400)";
+    Error::new(
+        kind,
+        match text {
+            Some(text) => format!("{rejected}: {}", excerpt(text)),
+            None => rejected.into(),
+        },
+    )
+}
+
+/// The content type of a body that is neither XML nor plain text: a
+/// maintenance or intermediary page rather than a ScreenScraper answer.
+fn page_content_type(response: &HttpResponse) -> Option<&str> {
+    response.content_type.as_deref().filter(|value| {
+        let value = value.to_ascii_lowercase();
+        !value.contains("xml") && !value.starts_with("text/plain")
+    })
+}
+
+fn content_is_xml(response: &HttpResponse, answer: Answer) -> Result<()> {
     // ScreenScraper answers with XML or a plain-text error. Any other
     // content type (a maintenance or intermediary page) is not an answer
     // to the one request, so it counts as the service being unavailable
-    // rather than as one game's unreadable match.
-    if let Some(content_type) = response.content_type.as_deref().filter(|value| {
-        let value = value.to_ascii_lowercase();
-        !value.contains("xml") && !value.starts_with("text/plain")
-    }) {
+    // rather than as one game's unreadable match. So does a body that is
+    // not text at all: no `<Data>` answer can be read from it.
+    if let Some(content_type) = page_content_type(response) {
         return Err(Error::new(
             ErrorKind::Unavailable,
             format!(
@@ -1028,20 +1076,15 @@ fn content_is_xml(response: &HttpResponse) -> Result<()> {
             ),
         ));
     }
-    let text = std::str::from_utf8(&response.body).map_err(|_| {
-        Error::new(
-            ErrorKind::MalformedResponse,
-            "ScreenScraper returned non-UTF-8 XML",
-        )
-    })?;
+    let text = std::str::from_utf8(&response.body).map_err(|_| not_an_answer("non-UTF-8 body"))?;
     let trimmed = text.trim_start_matches('\u{feff}').trim_start();
     if !trimmed.starts_with('<') {
-        return Err(text_error(trimmed));
+        return Err(text_error(trimmed, answer));
     }
     Ok(())
 }
 
-fn text_error(text: &str) -> Error {
+fn text_error(text: &str, answer: Answer) -> Error {
     if text.trim().is_empty() {
         return Error::new(
             ErrorKind::Unavailable,
@@ -1050,7 +1093,7 @@ fn text_error(text: &str) -> Error {
     }
     let lower = text.to_lowercase();
     if lower.starts_with("erreur") {
-        return documented_error(&lower, text).unwrap_or_else(|| unrecognised_error(text));
+        return documented_error(&lower, text).unwrap_or_else(|| unrecognised_error(text, answer));
     }
     // Neither XML nor an error text is not an answer to the one request
     // (a maintenance notice), so the run stops.
@@ -1142,18 +1185,29 @@ fn documented_error(lower: &str, text: &str) -> Option<Error> {
     None
 }
 
-/// An error text ScreenScraper has not documented cannot be tied to the
-/// one request, so it stops the run as before rather than costing one
-/// lookup per remaining game; the log keeps the server's words so the
-/// cause stays diagnosable.
-fn unrecognised_error(text: &str) -> Error {
-    Error::new(
-        ErrorKind::Unavailable,
-        format!(
-            "ScreenScraper returned an unrecognised error response: {}",
-            excerpt(text)
+/// An error text ScreenScraper has not documented. On a lookup it is that
+/// game's rejection, the invalid search the batch must continue past,
+/// with the server's words in the detail; a service-wide text present
+/// when the run starts still stops it at the account check, which runs
+/// before any game, and a media transfer is not a search, so both keep
+/// the outage classification.
+fn unrecognised_error(text: &str, answer: Answer) -> Error {
+    match answer {
+        Answer::Lookup => Error::new(
+            ErrorKind::InvalidRequest,
+            format!(
+                "ScreenScraper rejected this request (unrecognised error text): {}",
+                excerpt(text)
+            ),
         ),
-    )
+        Answer::Account | Answer::Media => Error::new(
+            ErrorKind::Unavailable,
+            format!(
+                "ScreenScraper returned an unrecognised error response: {}",
+                excerpt(text)
+            ),
+        ),
+    }
 }
 
 /// One bounded line of a server text for the log. The documented error
@@ -1930,6 +1984,8 @@ mod tests {
 
     #[test]
     fn every_documented_status_has_a_specific_meaning() {
+        // HTTP 400 is classified from its body, so every status goes
+        // through `response_status` with a text that is no error text.
         for (code, kind) in [
             (400, ErrorKind::InvalidRequest),
             (401, ErrorKind::Unavailable),
@@ -1942,7 +1998,15 @@ mod tests {
             (431, ErrorKind::FailedQuota),
             (503, ErrorKind::Server),
         ] {
-            let error = status(code).unwrap_err();
+            let error = response_status(
+                &HttpResponse {
+                    status: code,
+                    content_type: Some("text/plain".into()),
+                    body: b"Rejected".to_vec(),
+                },
+                Answer::Lookup,
+            )
+            .unwrap_err();
             assert_eq!(error.kind, kind);
             assert!(
                 error.detail.contains(&code.to_string()),
@@ -2260,7 +2324,8 @@ mod tests {
         // like an answer, so the content type alone cannot tell it apart.
         // Without the root check it would count as one game's unreadable
         // match and a batch would spend one lookup per remaining game
-        // against a service that is not answering.
+        // against a service that is not answering. A body that is not
+        // text at all carries no `<Data>` root either.
         let hashes = Hashes {
             size: 3,
             crc32: "352441C2".into(),
@@ -2268,24 +2333,30 @@ mod tests {
             sha1: "A9993E364706816ABA3E25717850C26C9CD0D89D".into(),
         };
         for (content_type, body) in [
-            (None, "<html><body>Maintenance</body></html>"),
+            (None, &b"<html><body>Maintenance</body></html>"[..]),
             (
                 Some("application/xml"),
-                "<html><body>Maintenance</body></html>",
+                &b"<html><body>Maintenance</body></html>"[..],
             ),
-            (None, "<!DOCTYPE html><html><body><p>Maintenance</html>"),
+            (
+                None,
+                &b"<!DOCTYPE html><html><body><p>Maintenance</html>"[..],
+            ),
             (
                 Some("text/xml"),
-                "<?xml version='1.0'?><Response>busy</Response>",
+                &b"<?xml version='1.0'?><Response>busy</Response>"[..],
             ),
-            (None, "<!-- nothing -->"),
-            (None, "<<<"),
+            (None, &b"<!-- nothing -->"[..]),
+            (None, &b"<<<"[..]),
+            (None, &b"<html>Maint\xe9nance</html>"[..]),
+            (Some("application/xml"), &b"\xff\xfe<Data/>"[..]),
         ] {
             let response = HttpResponse {
                 status: 200,
                 content_type: content_type.map(str::to_string),
-                body: body.as_bytes().to_vec(),
+                body: body.to_vec(),
             };
+            let body = String::from_utf8_lossy(body);
             let searched = client(response.clone()).by_name(3, "Game").unwrap_err();
             assert_eq!(searched.kind, ErrorKind::Unavailable, "{body}");
             assert!(
@@ -2341,7 +2412,7 @@ mod tests {
             format!("Erreur : Problème dans la recherche {echo}"),
             format!("Bad request {echo}"),
         ] {
-            let detail = text_error(&text).detail;
+            let detail = text_error(&text, Answer::Lookup).detail;
             for marker in ["=dm1", "=ds1", "=um1", "=us1"] {
                 assert!(!detail.contains(marker), "{detail}");
             }
@@ -2559,15 +2630,16 @@ mod tests {
 
     #[test]
     fn only_documented_per_request_error_texts_leave_the_run_going() {
-        // The documented 400 texts about one rom name or hash field concern
-        // one request and must not stop the batch by masquerading as an
+        // The documented 400 texts about one rom name or hash field, and a
+        // text ScreenScraper has not documented answering a game's lookup
+        // (the invalid search the batch must continue past), concern one
+        // request and must not stop the batch by masquerading as an
         // outage. The documented 400 texts about the request address concern
         // every game, because Degauss sends the same fields for each. A
         // closure, a refused client (the blacklist text is classified like
-        // HTTP 426, which carries it), a text ScreenScraper has not
-        // documented, or a body that is no answer at all concerns every
-        // remaining game and stops the run instead of costing one lookup
-        // per game.
+        // HTTP 426, which carries it), or a body that is no answer at all
+        // concerns every remaining game and stops the run instead of
+        // costing one lookup per game.
         for (body, kind) in [
             (
                 "Erreur : API fermé pour les non membres ou les membres inactifs",
@@ -2597,7 +2669,7 @@ mod tests {
             ("Erreur : problème avec l'url", ErrorKind::Configuration),
             (
                 "Erreur : Problème dans la recherche",
-                ErrorKind::Unavailable,
+                ErrorKind::InvalidRequest,
             ),
             (
                 "Erreur de login : Vérifier vos identifiants développeur !",
@@ -2635,7 +2707,7 @@ mod tests {
             ("Service paused for maintenance", ErrorKind::Unavailable),
             ("", ErrorKind::Unavailable),
         ] {
-            assert_eq!(text_error(body).kind, kind, "{body}");
+            assert_eq!(text_error(body, Answer::Lookup).kind, kind, "{body}");
         }
         let rejected = client(HttpResponse {
             status: 200,
@@ -2658,14 +2730,38 @@ mod tests {
         .by_name(3, "Game")
         .unwrap_err();
         assert_eq!(incomplete.kind, ErrorKind::Configuration);
-        let undocumented = client(HttpResponse {
+        let undocumented = HttpResponse {
             status: 200,
             content_type: Some("text/plain".into()),
             body: "Erreur : Problème dans la recherche".as_bytes().to_vec(),
-        })
-        .by_name(3, "Game")
-        .unwrap_err();
-        assert_eq!(undocumented.kind, ErrorKind::Unavailable);
+        };
+        assert_eq!(
+            client(undocumented.clone())
+                .by_name(3, "Game")
+                .unwrap_err()
+                .kind,
+            ErrorKind::InvalidRequest
+        );
+        // The same text before the run, at the account check, or on an
+        // image transfer cannot be one game's invalid search: an outage.
+        assert_eq!(
+            client(undocumented.clone()).account().unwrap_err().kind,
+            ErrorKind::Unavailable
+        );
+        assert_eq!(
+            client(undocumented)
+                .media(
+                    &Media {
+                        url: "https://media.screenscraper.fr/box.png".into(),
+                        format: None,
+                    },
+                    1024,
+                )
+                .err()
+                .expect("an undocumented error text on a media transfer was accepted")
+                .kind,
+            ErrorKind::Unavailable
+        );
         let closed = client(HttpResponse {
             status: 200,
             content_type: Some("text/plain".into()),
@@ -2816,12 +2912,107 @@ mod tests {
     }
 
     #[test]
+    fn a_page_under_http_400_stops_the_run_and_a_text_names_the_rejection() {
+        // ScreenScraper answers HTTP 400 with an error text. An HTML page,
+        // an empty body or a body that is not text under that status comes
+        // from an intermediary, as it would on a successful status, and
+        // must not cost one lookup per remaining game while the log stays
+        // silent about the cause. A text that is not one of the documented
+        // error texts is still that game's rejection, with the server's
+        // words in the log detail.
+        let hashes = Hashes {
+            size: 3,
+            crc32: "352441C2".into(),
+            md5: "900150983CD24FB0D6963F7D28E17F72".into(),
+            sha1: "A9993E364706816ABA3E25717850C26C9CD0D89D".into(),
+        };
+        for (content_type, body, what) in [
+            (
+                Some("text/html"),
+                &b"<html><body>Bad request</body></html>"[..],
+                "content type text/html",
+            ),
+            (Some("application/xml"), &b""[..], "no error text"),
+            (Some("text/plain"), &b" \n"[..], "no error text"),
+            (None, &b"Bad requ\xe9st"[..], "no error text"),
+        ] {
+            let response = HttpResponse {
+                status: 400,
+                content_type: content_type.map(str::to_string),
+                body: body.to_vec(),
+            };
+            let body = String::from_utf8_lossy(body);
+            for error in [
+                client(response.clone()).by_name(3, "Game").unwrap_err(),
+                client(response.clone())
+                    .by_hash(3, "Game.rom", &hashes)
+                    .unwrap_err(),
+                client(response.clone()).account().unwrap_err(),
+            ] {
+                assert_eq!(
+                    error.kind,
+                    ErrorKind::Unavailable,
+                    "{content_type:?} {body:?}"
+                );
+                assert!(
+                    error.detail.contains(what) && error.detail.contains("HTTP 400"),
+                    "{}",
+                    error.detail
+                );
+            }
+        }
+        let response = HttpResponse {
+            status: 400,
+            content_type: Some("text/plain".into()),
+            body: b"Bad request".to_vec(),
+        };
+        let rejected = client(response.clone()).by_name(3, "Game").unwrap_err();
+        assert_eq!(rejected.kind, ErrorKind::InvalidRequest);
+        assert!(
+            rejected.detail.ends_with("(HTTP 400): Bad request"),
+            "{}",
+            rejected.detail
+        );
+        // The account check sends only the credential fields, so a
+        // rejection there is a setup fault as it always was.
+        let setup = client(response).account().unwrap_err();
+        assert_eq!(setup.kind, ErrorKind::Configuration);
+        assert!(
+            setup.detail.ends_with("(HTTP 400): Bad request"),
+            "{}",
+            setup.detail
+        );
+        // An image transfer answers with bytes: a rejection there is that
+        // game's picture failure whatever the body holds.
+        for body in [&b"<html>Bad request</html>"[..], &b""[..], &b"\x89PNG"[..]] {
+            let error = client(HttpResponse {
+                status: 400,
+                content_type: Some("text/html".into()),
+                body: body.to_vec(),
+            })
+            .media(
+                &Media {
+                    url: "https://media.screenscraper.fr/box.png".into(),
+                    format: None,
+                },
+                1024,
+            )
+            .err()
+            .expect("HTTP 400 on a media transfer was accepted");
+            assert_eq!(error.kind, ErrorKind::InvalidRequest, "{body:?}");
+        }
+    }
+
+    #[test]
     fn an_undocumented_error_text_is_kept_in_the_diagnosis_but_bounded() {
         // The interface shows only the kind's fixed message, so the log
         // detail is the one place the server's actual words can be seen,
         // for a per-game refusal and for the unrecognised text that stopped
         // a run alike. A long body is cut so a page cannot flood it.
-        let rejected = text_error("Erreur : Problème   dans le nom\ndu fichier rom");
+        let rejected = text_error(
+            "Erreur : Problème   dans le nom\ndu fichier rom",
+            Answer::Lookup,
+        );
         assert_eq!(rejected.kind, ErrorKind::InvalidRequest);
         assert!(
             rejected
@@ -2830,20 +3021,25 @@ mod tests {
             "{}",
             rejected.detail
         );
-        let error = text_error("Erreur : Problème   dans\nla recherche");
-        assert_eq!(error.kind, ErrorKind::Unavailable);
-        assert!(
-            error
-                .detail
-                .ends_with(": Erreur : Problème dans la recherche"),
-            "{}",
-            error.detail
-        );
+        for (answer, kind) in [
+            (Answer::Lookup, ErrorKind::InvalidRequest),
+            (Answer::Account, ErrorKind::Unavailable),
+        ] {
+            let error = text_error("Erreur : Problème   dans\nla recherche", answer);
+            assert_eq!(error.kind, kind, "{answer:?}");
+            assert!(
+                error
+                    .detail
+                    .ends_with(": Erreur : Problème dans la recherche"),
+                "{}",
+                error.detail
+            );
+        }
         let long = format!("Erreur : {}", "é".repeat(500));
-        let detail = text_error(&long).detail;
+        let detail = text_error(&long, Answer::Lookup).detail;
         assert!(detail.ends_with("..."), "{detail}");
         assert!(detail.chars().count() < 200, "{detail}");
-        let plain = text_error("Service paused for maintenance");
+        let plain = text_error("Service paused for maintenance", Answer::Lookup);
         assert_eq!(plain.kind, ErrorKind::Unavailable);
         assert!(
             plain.detail.ends_with(": Service paused for maintenance"),
@@ -2853,7 +3049,7 @@ mod tests {
         // An empty answer has no words to keep: the detail names the
         // emptiness instead of ending in a bare colon.
         for empty in ["", " \n\t"] {
-            let error = text_error(empty);
+            let error = text_error(empty, Answer::Lookup);
             assert_eq!(error.kind, ErrorKind::Unavailable);
             assert_eq!(error.detail, "ScreenScraper returned an empty response");
         }

--- a/src/scraper/gamelist_edit.rs
+++ b/src/scraper/gamelist_edit.rs
@@ -48,9 +48,10 @@ pub enum Eligibility {
 pub enum FillCompleteness {
     /// One explicitly chosen game: any empty field is worth a lookup.
     EveryField,
-    /// Folder, system and all-systems batches: any stored field completes
-    /// the entry, so optional fields ScreenScraper never supplies do not
-    /// send the same game back on every run.
+    /// Folder, system and all-systems batches: any non-empty field, local
+    /// or inherited from the parent entry, completes the entry, so optional
+    /// fields ScreenScraper never supplies do not send the same game back
+    /// on every run.
     AnyField,
 }
 

--- a/src/scraper/gamelist_edit.rs
+++ b/src/scraper/gamelist_edit.rs
@@ -410,24 +410,6 @@ pub fn needs(
 }
 
 #[cfg(test)]
-pub fn needs_in_batch(
-    gamelist_path: &Path,
-    folder: &Path,
-    relative_game_path: &str,
-    image_policy: ImagePolicy,
-    metadata_policy: MetadataPolicy,
-) -> Result<Needs> {
-    needs_with_completeness(
-        gamelist_path,
-        folder,
-        relative_game_path,
-        image_policy,
-        metadata_policy,
-        FillCompleteness::AnyField,
-    )
-}
-
-#[cfg(test)]
 fn needs_with_completeness(
     gamelist_path: &Path,
     folder: &Path,
@@ -2409,12 +2391,13 @@ mod tests {
         // Seven optional fields are blank. A folder, system or all-systems
         // run must not send this game back to ScreenScraper every time.
         assert_eq!(
-            needs_in_batch(
+            needs_with_completeness(
                 &path,
                 &folder,
                 "./Game.rom",
                 ImagePolicy::MissingOnly,
                 MetadataPolicy::FillMissing,
+                FillCompleteness::AnyField,
             )
             .unwrap(),
             Needs::default()
@@ -2444,12 +2427,13 @@ mod tests {
         std::fs::write(folder.join("art.png"), b"image").unwrap();
         let batch = |xml: &str| {
             std::fs::write(&path, xml).unwrap();
-            needs_in_batch(
+            needs_with_completeness(
                 &path,
                 &folder,
                 "./Game.rom",
                 ImagePolicy::MissingOnly,
                 MetadataPolicy::FillMissing,
+                FillCompleteness::AnyField,
             )
             .unwrap()
         };

--- a/src/scraper/gamelist_edit.rs
+++ b/src/scraper/gamelist_edit.rs
@@ -43,6 +43,22 @@ pub enum Eligibility {
     Alias { representative: usize },
 }
 
+/// How Fill missing decides that an entry's stored metadata is complete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FillCompleteness {
+    /// One explicitly chosen game: any empty field is worth a lookup.
+    EveryField,
+    /// Folder, system and all-systems batches: any stored field completes
+    /// the entry, so optional fields ScreenScraper never supplies do not
+    /// send the same game back on every run.
+    AnyField,
+}
+
+impl FillCompleteness {
+    #[cfg(test)]
+    pub const ALL: [Self; 2] = [Self::EveryField, Self::AnyField];
+}
+
 impl Needs {
     pub fn any(self) -> bool {
         self.image || self.metadata
@@ -174,6 +190,7 @@ pub fn needs_many(
     relative_game_paths: &[String],
     image_policy: ImagePolicy,
     metadata_policy: MetadataPolicy,
+    completeness: FillCompleteness,
 ) -> Result<Vec<Result<Needs>>> {
     let fallback: Vec<bool> = relative_game_paths
         .iter()
@@ -186,6 +203,7 @@ pub fn needs_many(
         &fallback,
         image_policy,
         metadata_policy,
+        completeness,
     )
 }
 
@@ -197,6 +215,7 @@ pub fn needs_many_with_fallback(
     metadata_fallback: &[bool],
     image_policy: ImagePolicy,
     metadata_policy: MetadataPolicy,
+    completeness: FillCompleteness,
 ) -> Result<Vec<Result<Needs>>> {
     Ok(needs_many_controlled(
         gamelist_path,
@@ -205,6 +224,7 @@ pub fn needs_many_with_fallback(
         metadata_fallback,
         image_policy,
         metadata_policy,
+        completeness,
         &mut |_| Ok(()),
     )?
     .into_iter()
@@ -219,6 +239,7 @@ pub fn needs_many_with_fallback(
     .collect::<Vec<_>>())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn needs_many_controlled(
     gamelist_path: &Path,
     folder: &Path,
@@ -226,6 +247,7 @@ pub fn needs_many_controlled(
     metadata_fallback: &[bool],
     image_policy: ImagePolicy,
     metadata_policy: MetadataPolicy,
+    completeness: FillCompleteness,
     progress: &mut impl FnMut(usize) -> Result<()>,
 ) -> Result<Vec<Result<Eligibility>>> {
     progress(0)?;
@@ -327,7 +349,13 @@ pub fn needs_many_controlled(
                     MetadataPolicy::Off => false,
                     MetadataPolicy::ReplaceExisting => true,
                     MetadataPolicy::FillMissing => {
-                        let mut missing = false;
+                        // Every field absent: a lookup is needed under both
+                        // rules. Every field present: none is. In between,
+                        // the rule decides.
+                        let mut needed = match completeness {
+                            FillCompleteness::EveryField => false,
+                            FillCompleteness::AnyField => true,
+                        };
                         for name in FIELDS {
                             let own = game
                                 .fields
@@ -342,12 +370,19 @@ pub fn needs_many_controlled(
                                         .filter(|field| !field.value.trim().is_empty())
                                 }),
                             };
-                            if effective.is_none() {
-                                missing = true;
-                                break;
+                            match completeness {
+                                FillCompleteness::EveryField if effective.is_none() => {
+                                    needed = true;
+                                    break;
+                                }
+                                FillCompleteness::AnyField if effective.is_some() => {
+                                    needed = false;
+                                    break;
+                                }
+                                _ => {}
                             }
                         }
-                        missing
+                        needed
                     }
                 };
                 Ok(Eligibility::Needs(Needs { image, metadata }))
@@ -364,12 +399,50 @@ pub fn needs(
     image_policy: ImagePolicy,
     metadata_policy: MetadataPolicy,
 ) -> Result<Needs> {
+    needs_with_completeness(
+        gamelist_path,
+        folder,
+        relative_game_path,
+        image_policy,
+        metadata_policy,
+        FillCompleteness::EveryField,
+    )
+}
+
+#[cfg(test)]
+pub fn needs_in_batch(
+    gamelist_path: &Path,
+    folder: &Path,
+    relative_game_path: &str,
+    image_policy: ImagePolicy,
+    metadata_policy: MetadataPolicy,
+) -> Result<Needs> {
+    needs_with_completeness(
+        gamelist_path,
+        folder,
+        relative_game_path,
+        image_policy,
+        metadata_policy,
+        FillCompleteness::AnyField,
+    )
+}
+
+#[cfg(test)]
+fn needs_with_completeness(
+    gamelist_path: &Path,
+    folder: &Path,
+    relative_game_path: &str,
+    image_policy: ImagePolicy,
+    metadata_policy: MetadataPolicy,
+    completeness: FillCompleteness,
+) -> Result<Needs> {
     needs_many(
         gamelist_path,
         folder,
         &[relative_game_path.to_string()],
         image_policy,
         metadata_policy,
+        completeness,
     )?
     .pop()
     .unwrap_or_else(|| Err(Error::local("the gamelist inspection returned no result")))
@@ -1716,6 +1789,7 @@ mod tests {
                 &[true],
                 super::ImagePolicy::MissingOnly,
                 super::MetadataPolicy::FillMissing,
+                super::FillCompleteness::EveryField,
                 &mut |_| Ok(()),
             )
             .unwrap();
@@ -2323,6 +2397,105 @@ mod tests {
     }
 
     #[test]
+    fn a_batch_treats_any_stored_field_as_complete_while_one_game_fills_every_field() {
+        let folder = temp("batch-completeness");
+        let path = folder.join("gamelist.xml");
+        std::fs::write(folder.join("art.png"), b"image").unwrap();
+        std::fs::write(
+            &path,
+            "<gameList><game><path>./Game.rom</path><name>Name</name><image>./art.png</image></game></gameList>",
+        )
+        .unwrap();
+        // Seven optional fields are blank. A folder, system or all-systems
+        // run must not send this game back to ScreenScraper every time.
+        assert_eq!(
+            needs_in_batch(
+                &path,
+                &folder,
+                "./Game.rom",
+                ImagePolicy::MissingOnly,
+                MetadataPolicy::FillMissing,
+            )
+            .unwrap(),
+            Needs::default()
+        );
+        // Choosing the one game is permission to complete it field by field.
+        assert_eq!(
+            needs(
+                &path,
+                &folder,
+                "./Game.rom",
+                ImagePolicy::MissingOnly,
+                MetadataPolicy::FillMissing,
+            )
+            .unwrap(),
+            Needs {
+                image: false,
+                metadata: true
+            }
+        );
+        let _ = std::fs::remove_dir_all(folder);
+    }
+
+    #[test]
+    fn batch_image_and_metadata_needs_are_independent() {
+        let folder = temp("batch-independent-needs");
+        let path = folder.join("gamelist.xml");
+        std::fs::write(folder.join("art.png"), b"image").unwrap();
+        let batch = |xml: &str| {
+            std::fs::write(&path, xml).unwrap();
+            needs_in_batch(
+                &path,
+                &folder,
+                "./Game.rom",
+                ImagePolicy::MissingOnly,
+                MetadataPolicy::FillMissing,
+            )
+            .unwrap()
+        };
+        assert_eq!(
+            batch(
+                "<gameList><game><path>./Game.rom</path><image>./art.png</image></game></gameList>"
+            ),
+            Needs {
+                image: false,
+                metadata: true
+            },
+            "an image with no metadata at all needs only metadata"
+        );
+        assert_eq!(
+            batch("<gameList><game><path>./Game.rom</path><name>Name</name><desc>Description</desc></game></gameList>"),
+            Needs {
+                image: true,
+                metadata: false
+            },
+            "metadata without an image needs only the image"
+        );
+        assert_eq!(
+            batch("<gameList><game><path>./Game.rom</path><name>Name</name><image>./gone.png</image></game></gameList>"),
+            Needs {
+                image: true,
+                metadata: false
+            },
+            "a dangling image reference is a missing image"
+        );
+        assert_eq!(
+            batch("<gameList><game><path>./Game.rom</path><name>  </name><image>./art.png</image></game></gameList>"),
+            Needs {
+                image: false,
+                metadata: true
+            },
+            "a whitespace-only field is not stored metadata"
+        );
+        assert_eq!(
+            batch("<gameList><game id=\"p\"><genre>Action</genre></game><game parentid=\"p\"><path>./Game.rom</path><image>./art.png</image></game></gameList>"),
+            Needs::default(),
+            "a field inherited from the parent entry counts as stored"
+        );
+        let _ = std::fs::remove_dir_all(folder);
+    }
+
+    #[test]
     fn external_parent_metadata_and_root_relative_art_skip_only_the_matching_zip_member() {
         let folder = temp("complete-inherited-zip");
         let path = folder.join("gamelist.xml");
@@ -2337,6 +2510,7 @@ mod tests {
             &[false, false],
             ImagePolicy::MissingOnly,
             MetadataPolicy::FillMissing,
+            FillCompleteness::EveryField,
         )
         .unwrap();
         let mut results = results.into_iter();
@@ -2363,7 +2537,8 @@ mod tests {
                 &paths[..1],
                 &[false],
                 ImagePolicy::MissingOnly,
-                MetadataPolicy::FillMissing
+                MetadataPolicy::FillMissing,
+                FillCompleteness::EveryField,
             )
             .unwrap()
             .remove(0)
@@ -2392,29 +2567,45 @@ mod tests {
         )
         .unwrap();
 
-        for image_policy in ImagePolicy::ALL {
-            for metadata_policy in MetadataPolicy::ALL {
-                let complete =
-                    needs(&path, &folder, "./Game.rom", image_policy, metadata_policy).unwrap();
-                assert_eq!(
-                    complete,
-                    Needs {
-                        image: image_policy == ImagePolicy::ReplaceExisting,
-                        metadata: metadata_policy == MetadataPolicy::ReplaceExisting,
-                    },
-                    "complete entry with {image_policy:?} and {metadata_policy:?}"
-                );
+        for completeness in FillCompleteness::ALL {
+            for image_policy in ImagePolicy::ALL {
+                for metadata_policy in MetadataPolicy::ALL {
+                    let complete = needs_with_completeness(
+                        &path,
+                        &folder,
+                        "./Game.rom",
+                        image_policy,
+                        metadata_policy,
+                        completeness,
+                    )
+                    .unwrap();
+                    assert_eq!(
+                        complete,
+                        Needs {
+                            image: image_policy == ImagePolicy::ReplaceExisting,
+                            metadata: metadata_policy == MetadataPolicy::ReplaceExisting,
+                        },
+                        "complete entry with {image_policy:?}, {metadata_policy:?} and {completeness:?}"
+                    );
 
-                let absent =
-                    needs(&path, &folder, "./Other.rom", image_policy, metadata_policy).unwrap();
-                assert_eq!(
-                    absent,
-                    Needs {
-                        image: image_policy != ImagePolicy::Off,
-                        metadata: metadata_policy != MetadataPolicy::Off,
-                    },
-                    "absent entry with {image_policy:?} and {metadata_policy:?}"
-                );
+                    let absent = needs_with_completeness(
+                        &path,
+                        &folder,
+                        "./Other.rom",
+                        image_policy,
+                        metadata_policy,
+                        completeness,
+                    )
+                    .unwrap();
+                    assert_eq!(
+                        absent,
+                        Needs {
+                            image: image_policy != ImagePolicy::Off,
+                            metadata: metadata_policy != MetadataPolicy::Off,
+                        },
+                        "absent entry with {image_policy:?}, {metadata_policy:?} and {completeness:?}"
+                    );
+                }
             }
         }
         let _ = std::fs::remove_dir_all(folder);

--- a/src/scraper/mod.rs
+++ b/src/scraper/mod.rs
@@ -101,7 +101,8 @@ pub enum ErrorKind {
     FailedQuota,
     NotFound,
     /// ScreenScraper refused this one request (a rejected search term,
-    /// parameter or media address). Unlike an outage, the next game can
+    /// parameter or media address, or an error text it does not document
+    /// answering one game's lookup). Unlike an outage, the next game can
     /// still be looked up.
     InvalidRequest,
     MalformedResponse,

--- a/src/scraper/mod.rs
+++ b/src/scraper/mod.rs
@@ -73,7 +73,7 @@ impl Error {
             ErrorKind::DailyQuota => "Daily request allowance exhausted",
             ErrorKind::FailedQuota => "Failed-search allowance exhausted",
             ErrorKind::NotFound => "No matching game was found",
-            ErrorKind::InvalidRequest => "ScreenScraper rejected this search",
+            ErrorKind::InvalidRequest => "ScreenScraper rejected this request",
             ErrorKind::MalformedResponse => "ScreenScraper response was unreadable",
             ErrorKind::Transport => "Network connection failed",
             ErrorKind::Timeout => "ScreenScraper timed out",
@@ -100,8 +100,9 @@ pub enum ErrorKind {
     DailyQuota,
     FailedQuota,
     NotFound,
-    /// ScreenScraper refused this one request (a rejected search term or
-    /// parameter). Unlike an outage, the next game can still be looked up.
+    /// ScreenScraper refused this one request (a rejected search term,
+    /// parameter or media address). Unlike an outage, the next game can
+    /// still be looked up.
     InvalidRequest,
     MalformedResponse,
     Transport,

--- a/src/scraper/mod.rs
+++ b/src/scraper/mod.rs
@@ -17,6 +17,7 @@ pub use targets::{Scope, Target};
 pub use worker::{
     start, start_preview, start_search, start_selected, Event, Job, Phase, PreviewEvent,
     PreviewJob, PreviewRequest, Progress, Request, SearchEvent, SearchJob, SearchRequest,
+    UnresolvedGame,
 };
 
 /// Resolve the reviewed ScreenScraper platform id used by the production
@@ -72,6 +73,7 @@ impl Error {
             ErrorKind::DailyQuota => "Daily request allowance exhausted",
             ErrorKind::FailedQuota => "Failed-search allowance exhausted",
             ErrorKind::NotFound => "No matching game was found",
+            ErrorKind::InvalidRequest => "ScreenScraper rejected this search",
             ErrorKind::MalformedResponse => "ScreenScraper response was unreadable",
             ErrorKind::Transport => "Network connection failed",
             ErrorKind::Timeout => "ScreenScraper timed out",
@@ -98,6 +100,9 @@ pub enum ErrorKind {
     DailyQuota,
     FailedQuota,
     NotFound,
+    /// ScreenScraper refused this one request (a rejected search term or
+    /// parameter). Unlike an outage, the next game can still be looked up.
+    InvalidRequest,
     MalformedResponse,
     Transport,
     Timeout,
@@ -116,6 +121,7 @@ impl ErrorKind {
             ErrorKind::DailyQuota => "daily quota",
             ErrorKind::FailedQuota => "failed-search quota",
             ErrorKind::NotFound => "not found",
+            ErrorKind::InvalidRequest => "invalid request",
             ErrorKind::MalformedResponse => "bad server response",
             ErrorKind::Transport => "network",
             ErrorKind::Timeout => "timeout",

--- a/src/scraper/worker.rs
+++ b/src/scraper/worker.rs
@@ -1505,12 +1505,12 @@ fn limited_lookup(
 ) -> Result<super::api::LookupResponse> {
     let reservation = limits.reserve_possible_failure()?;
     let result = operation();
-    if let Ok(response) = &result {
-        reservation.finish(response.server_miss);
-    }
     // ScreenScraper counts a KO only for a negative answer (rom or game
     // not found), so a rejected or unreadable lookup releases its slot
     // uncounted.
+    if let Ok(response) = &result {
+        reservation.finish(response.server_miss);
+    }
     result
 }
 
@@ -1902,12 +1902,9 @@ fn current_label(target: &Target) -> String {
     format!("{}: {}", target.system_name, target.title)
 }
 
-/// Search ScreenScraper by title. A file named only by its extension and
-/// dump tags leaves nothing to send once those are removed: no search is
-/// made and `None` is returned, so the game is counted as not found with
-/// its own reason (logged once by `stage`), without a request or a
-/// failed-search reservation being spent and without a setup fault
-/// stopping the run.
+/// Search ScreenScraper by title. A name that leaves nothing to search for
+/// once its extension and dump tags are removed sends no request and
+/// returns `None`: `stage` counts that game as not found.
 fn search_by_title(
     target: &Target,
     current: &str,
@@ -2334,14 +2331,9 @@ fn safe_component(value: &str) -> String {
     }
 }
 
-/// Whether one game's failure stops the batch. A request ScreenScraper
-/// rejected (by HTTP 400, by a documented bad-request text or by an error
-/// text it does not document answering that game's lookup), or a match
-/// response it served unreadable, concerns that game alone; transport,
-/// login, rate limit, quota and service outages (which include an answer
-/// that is not XML at all, or a page whose root element is not
-/// ScreenScraper's `<Data>`, whatever its content type or status) concern
-/// every game still queued.
+/// Whether one game's failure stops the batch: a request ScreenScraper
+/// rejected or answered unreadably concerns that game alone; transport,
+/// login, limit and service outages concern every game still queued.
 fn fatal_for_run(error: &Error) -> bool {
     !matches!(
         error.kind,

--- a/src/scraper/worker.rs
+++ b/src/scraper/worker.rs
@@ -91,12 +91,12 @@ pub struct Progress {
     /// server response or interrupting an unattended scrape.
     pub manual_matches: Vec<Match>,
     /// Every game the run attempted and could not resolve, with the
-    /// reason: no match, several matches, no image to fetch, or a failed
-    /// lookup, download or write. A game whose image failed but whose
-    /// metadata was written is listed with the image error; games not
-    /// reached before a failure or cancellation are not listed. The report
-    /// names them after an unattended batch. Carried only by the terminal
-    /// event; progress snapshots leave it empty.
+    /// reason: no match, no searchable title, several matches, no image to
+    /// fetch, or a failed lookup, download or write. A game whose image
+    /// failed but whose metadata was written is listed with the image
+    /// error; games not reached before a failure or cancellation are not
+    /// listed. The report names them after an unattended batch. Carried
+    /// only by the terminal event; progress snapshots leave it empty.
     pub unresolved_games: Vec<UnresolvedGame>,
 }
 
@@ -1623,6 +1623,12 @@ enum WorkerMessage {
     Done,
 }
 
+/// Report reasons for a game counted as not found: ScreenScraper answered
+/// the lookup with no exact match, or no title search was sent because
+/// nothing remained to search for.
+const NO_MATCH: &str = "no match";
+const NO_SEARCHABLE_TITLE: &str = "no searchable title";
+
 struct Prepared {
     target: Target,
     needs: Needs,
@@ -1631,7 +1637,8 @@ struct Prepared {
     media_error: Option<Error>,
     no_media: bool,
     ambiguous: Option<usize>,
-    not_found: bool,
+    /// The report reason when the game was counted as not found.
+    not_found: Option<&'static str>,
     alternatives: Vec<Match>,
 }
 
@@ -1702,12 +1709,12 @@ fn prepare(
     let current = current_label(&target);
     let lookup = if let Some(matched) = selected {
         activity_text(events, &current, "Using selected match");
-        super::api::LookupResponse {
+        Some(super::api::LookupResponse {
             lookup: Lookup::Found(Box::new(matched)),
             alternatives: Vec::new(),
             account: None,
             server_miss: false,
-        }
+        })
     } else if let Some(path) = target.match_path.as_deref() {
         activity_text(events, &current, "Hashing ROM");
         match hashes::file(path, settings.hash_limit_bytes(), cancelled)? {
@@ -1731,7 +1738,7 @@ fn prepare(
                     Lookup::NotFound => search_by_title(
                         &target, &current, media_type, client, limits, cancelled, events,
                     )?,
-                    _ => result,
+                    _ => Some(result),
                 }
             }
             None => search_by_title(
@@ -1744,6 +1751,19 @@ fn prepare(
         )?
     };
 
+    let Some(lookup) = lookup else {
+        return Ok(Prepared {
+            target,
+            needs,
+            matched: None,
+            media: None,
+            media_error: None,
+            no_media: false,
+            ambiguous: None,
+            not_found: Some(NO_SEARCHABLE_TITLE),
+            alternatives: Vec::new(),
+        });
+    };
     let alternatives = if retain_alternatives {
         lookup.alternatives
     } else {
@@ -1758,7 +1778,7 @@ fn prepare(
             media_error: None,
             no_media: false,
             ambiguous: None,
-            not_found: true,
+            not_found: Some(NO_MATCH),
             alternatives,
         }),
         Lookup::Ambiguous(count) => Ok(Prepared {
@@ -1769,7 +1789,7 @@ fn prepare(
             media_error: None,
             no_media: false,
             ambiguous: Some(count),
-            not_found: false,
+            not_found: None,
             alternatives,
         }),
         Lookup::Found(matched) => {
@@ -1815,7 +1835,7 @@ fn prepare(
                 media_error,
                 no_media,
                 ambiguous: None,
-                not_found: false,
+                not_found: None,
                 alternatives: Vec::new(),
             })
         }
@@ -1866,10 +1886,10 @@ fn current_label(target: &Target) -> String {
 }
 
 /// Search ScreenScraper by title. A file named only by its extension and
-/// dump tags leaves nothing to send once those are removed; that is one
-/// game without a match, recorded like a server miss without a request or
-/// a failed-search reservation being spent, not a setup fault that should
-/// stop the run.
+/// dump tags leaves nothing to send once those are removed: no search is
+/// made and `None` is returned, so the game is counted as not found with
+/// its own reason, without a request or a failed-search reservation being
+/// spent and without a setup fault stopping the run.
 fn search_by_title(
     target: &Target,
     current: &str,
@@ -1878,18 +1898,13 @@ fn search_by_title(
     limits: &LimitedTransport,
     cancelled: &AtomicBool,
     events: &SyncSender<WorkerMessage>,
-) -> Result<super::api::LookupResponse> {
+) -> Result<Option<super::api::LookupResponse>> {
     if target.query.trim().is_empty() {
         log_scraper_detail(
             current,
             "no title remains to search for once the extension and dump tags are removed",
         );
-        return Ok(super::api::LookupResponse {
-            lookup: Lookup::NotFound,
-            alternatives: Vec::new(),
-            account: None,
-            server_miss: false,
-        });
+        return Ok(None);
     }
     activity_text(events, current, "Matching by name");
     retry(
@@ -1905,6 +1920,7 @@ fn search_by_title(
             })
         },
     )
+    .map(Some)
 }
 
 fn retry_status(error: &Error, delay: Duration) -> String {
@@ -1945,13 +1961,13 @@ struct Pending {
 
 fn stage(prepared: Prepared, progress: &mut Progress) -> Result<Option<Pending>> {
     let target_label = current_label(&prepared.target);
-    if prepared.not_found {
+    if let Some(reason) = prepared.not_found {
         log_scraper_detail(&target_label, "no exact ScreenScraper match; skipped");
         if !prepared.alternatives.is_empty() {
             progress.manual_matches = prepared.alternatives;
         }
         progress.not_found += 1;
-        progress.unresolved(&target_label, "no match");
+        progress.unresolved(&target_label, reason);
         return Ok(None);
     }
     if let Some(count) = prepared.ambiguous {
@@ -3288,10 +3304,11 @@ mod tests {
 
     #[test]
     fn a_rejected_individual_search_is_recorded_and_the_batch_continues() {
-        // One game ScreenScraper refuses, by HTTP 400 or by an error text it
-        // does not document as an outage, is that game's problem whether the
-        // refusal answers the hash lookup or the title search: the run still
-        // processes the next game and names the rejected one.
+        // One game ScreenScraper refuses, by HTTP 400 or by one of the
+        // error texts it documents for a bad request, is that game's
+        // problem whether the refusal answers the hash lookup or the title
+        // search: the run still processes the next game and names the
+        // rejected one.
         for (status, content_type, body, at_title_search) in [
             (
                 400,
@@ -3302,7 +3319,7 @@ mod tests {
             (
                 200,
                 "text/plain",
-                "Erreur : Problème dans le nom du fichier rom",
+                "Erreur : Champ crc, md5 ou sha1 erroné",
                 false,
             ),
             (
@@ -3314,7 +3331,7 @@ mod tests {
             (
                 200,
                 "text/plain",
-                "Erreur : Problème dans la recherche",
+                "Erreur : Il manque des champs obligatoires dans l'url",
                 true,
             ),
         ] {
@@ -3439,10 +3456,10 @@ mod tests {
     #[test]
     fn a_file_named_only_by_dump_tags_is_recorded_and_the_batch_continues() {
         // A system with several extensions keeps the extension in the row
-        // name, so a file called only by its tags searches for an empty
-        // term once the extension and tags are removed. That is one game
-        // without a match, whether it reaches the title search after a hash
-        // miss or directly: the run counts it like a server miss, spends no
+        // name, so a file called only by its tags would search for an empty
+        // term once the extension and tags are removed. Whether it reaches
+        // the title search after a hash miss or directly, no search is
+        // made: the run counts the game as not found, spends no
         // failed-search allowance on it, and writes the next game instead
         // of stopping on a setup error.
         let root = temp("tagless-title");
@@ -3472,16 +3489,18 @@ mod tests {
         progress
             .unresolved_games
             .sort_by(|a, b| a.label.cmp(&b.label));
+        // The report names the real cause: no search was made, which is
+        // not the same as ScreenScraper reporting the game missing.
         assert_eq!(
             progress.unresolved_games,
             vec![
                 UnresolvedGame {
                     label: "Nintendo: (Proto).cue".into(),
-                    reason: "no match".into(),
+                    reason: "no searchable title".into(),
                 },
                 UnresolvedGame {
                     label: "Nintendo: (Unl).bin".into(),
-                    reason: "no match".into(),
+                    reason: "no searchable title".into(),
                 },
             ]
         );
@@ -3527,35 +3546,59 @@ mod tests {
 
     #[test]
     fn a_page_instead_of_xml_still_stops_the_batch() {
-        // An HTML answer is not a match response for one game but a sign
-        // that the service is not answering; walking the queue would spend
-        // one request per remaining game for nothing.
-        let root = temp("html-page-mid-batch");
-        std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
-        std::fs::write(root.join("Zebra.rom"), b"found").unwrap();
-        let Event::Failed { error, progress } = finish(
-            start_with_transport(
-                request(&root, settings(ImagePolicy::Off)),
-                Arc::new(RejectingMock {
-                    status: 200,
-                    content_type: "text/html",
-                    body: "<html><body>Maintenance</body></html>",
-                    at_title_search: false,
-                }),
-            )
-            .unwrap(),
-        ) else {
-            panic!("a non-XML page was treated as one game's problem");
-        };
-        assert_eq!(error.kind, ErrorKind::Unavailable);
-        assert_eq!(
-            progress.unresolved_games,
-            vec![UnresolvedGame {
-                label: "Nintendo: Rejected".into(),
-                reason: "ScreenScraper is unavailable".into(),
-            }]
-        );
-        let _ = std::fs::remove_dir_all(root);
+        // An HTML page, a plain notice, an empty body or an error text
+        // ScreenScraper has not documented is not a match response for one
+        // game but a sign that the service is not answering; walking the
+        // queue would spend one request per remaining game for nothing.
+        for (name, content_type, body, at_title_search) in [
+            (
+                "html-page",
+                "text/html",
+                "<html><body>Maintenance</body></html>",
+                false,
+            ),
+            (
+                "notice",
+                "text/plain",
+                "Service paused for maintenance",
+                true,
+            ),
+            ("empty", "application/xml", "", false),
+            (
+                "undocumented",
+                "text/plain",
+                "Erreur : Problème dans la recherche",
+                true,
+            ),
+        ] {
+            let root = temp(&format!("{name}-mid-batch"));
+            std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
+            std::fs::write(root.join("Zebra.rom"), b"found").unwrap();
+            let Event::Failed { error, progress } = finish(
+                start_with_transport(
+                    request(&root, settings(ImagePolicy::Off)),
+                    Arc::new(RejectingMock {
+                        status: 200,
+                        content_type,
+                        body,
+                        at_title_search,
+                    }),
+                )
+                .unwrap(),
+            ) else {
+                panic!("a non-XML answer ({name}) was treated as one game's problem");
+            };
+            assert_eq!(error.kind, ErrorKind::Unavailable, "{name}");
+            assert_eq!(
+                progress.unresolved_games,
+                vec![UnresolvedGame {
+                    label: "Nintendo: Rejected".into(),
+                    reason: "ScreenScraper is unavailable".into(),
+                }],
+                "{name}"
+            );
+            let _ = std::fs::remove_dir_all(root);
+        }
     }
 
     #[test]

--- a/src/scraper/worker.rs
+++ b/src/scraper/worker.rs
@@ -96,9 +96,9 @@ pub struct Progress {
     /// a failed lookup, download or write. A game whose image failed or
     /// had none at ScreenScraper is listed even when its metadata was
     /// written; games not reached before a failure or cancellation are
-    /// not listed. The
-    /// report names them after an unattended batch. Carried only by the
-    /// terminal event; progress snapshots leave it empty.
+    /// not listed. The report names them after an unattended batch.
+    /// Carried only by the terminal event; progress snapshots leave it
+    /// empty.
     pub unresolved_games: Vec<UnresolvedGame>,
 }
 
@@ -2322,8 +2322,9 @@ fn safe_component(value: &str) -> String {
 /// Whether one game's failure stops the batch. A request ScreenScraper
 /// rejected, or a match response it served unreadable, concerns that game
 /// alone; transport, login, rate limit, quota and service outages (which
-/// include an answer that is not XML at all) concern every game still
-/// queued.
+/// include an answer that is not XML at all, or a page whose root element
+/// is not ScreenScraper's `<Data>`, whatever its content type) concern
+/// every game still queued.
 fn fatal_for_run(error: &Error) -> bool {
     !matches!(
         error.kind,
@@ -3311,11 +3312,22 @@ mod tests {
     /// Answers the lookup for `Rejected.rom` with a configured response
     /// and matches every other game. With `at_title_search` the hash lookup
     /// misses and the configured response answers the title search instead.
+    /// An empty `content_type` answers without a Content-Type header.
     struct RejectingMock {
         status: u16,
         content_type: &'static str,
         body: &'static str,
         at_title_search: bool,
+    }
+
+    impl RejectingMock {
+        fn configured(&self) -> HttpResponse {
+            HttpResponse {
+                status: self.status,
+                content_type: (!self.content_type.is_empty()).then(|| self.content_type.into()),
+                body: self.body.as_bytes().to_vec(),
+            }
+        }
     }
 
     impl Transport for RejectingMock {
@@ -3338,18 +3350,10 @@ mod tests {
                     "<Data><jeux/></Data>".to_string()
                 }
                 "jeuInfos.php" if parameter("romnom") == "Rejected.rom" => {
-                    return Ok(HttpResponse {
-                        status: self.status,
-                        content_type: Some(self.content_type.into()),
-                        body: self.body.as_bytes().to_vec(),
-                    });
+                    return Ok(self.configured());
                 }
                 "jeuRecherche.php" if parameter("recherche") == "Rejected" && self.at_title_search => {
-                    return Ok(HttpResponse {
-                        status: self.status,
-                        content_type: Some(self.content_type.into()),
-                        body: self.body.as_bytes().to_vec(),
-                    });
+                    return Ok(self.configured());
                 }
                 "jeuInfos.php" => {
                     let md5 = parameter("md5");
@@ -3618,16 +3622,29 @@ mod tests {
 
     #[test]
     fn a_page_instead_of_xml_still_stops_the_batch() {
-        // An HTML page, a plain notice, an empty body or an error text
-        // ScreenScraper has not documented is not a match response for one
-        // game but a sign that the service is not answering; walking the
-        // queue would spend one request per remaining game for nothing.
+        // An HTML page (whatever content type it is served with, or none),
+        // a plain notice, an empty body or an error text ScreenScraper has
+        // not documented is not a match response for one game but a sign
+        // that the service is not answering; walking the queue would spend
+        // one request per remaining game for nothing.
         for (name, content_type, body, at_title_search) in [
             (
                 "html-page",
                 "text/html",
                 "<html><body>Maintenance</body></html>",
                 false,
+            ),
+            (
+                "untyped-html-page",
+                "",
+                "<html><body>Maintenance</body></html>",
+                false,
+            ),
+            (
+                "xml-labelled-html-page",
+                "application/xml",
+                "<!DOCTYPE html><html><body><p>Maintenance</html>",
+                true,
             ),
             (
                 "notice",

--- a/src/scraper/worker.rs
+++ b/src/scraper/worker.rs
@@ -1788,7 +1788,15 @@ fn prepare(
                                 Err(error) => (None, Some(error), false),
                             },
                             Err(error) if error.kind == ErrorKind::NotFound => (None, None, true),
-                            Err(error) if error.kind == ErrorKind::MalformedResponse => {
+                            // An unusable or refused image answer is that
+                            // image's problem; the match already fetched
+                            // still provides the metadata.
+                            Err(error)
+                                if matches!(
+                                    error.kind,
+                                    ErrorKind::MalformedResponse | ErrorKind::InvalidRequest
+                                ) =>
+                            {
                                 (None, Some(error), false)
                             }
                             Err(error) => return Err(error),
@@ -2282,8 +2290,9 @@ fn safe_component(value: &str) -> String {
 
 /// Whether one game's failure stops the batch. A request ScreenScraper
 /// rejected, or a match response it served unreadable, concerns that game
-/// alone; transport, login, quota and service outages concern every game
-/// still queued.
+/// alone; transport, login, rate limit, quota and service outages (which
+/// include an answer that is not XML at all) concern every game still
+/// queued.
 fn fatal_for_run(error: &Error) -> bool {
     !matches!(
         error.kind,
@@ -2549,6 +2558,37 @@ mod tests {
                 std::slice::from_ref(&ordinary),
                 &HashSet::new()
             ));
+        }
+    }
+
+    #[test]
+    fn only_one_games_failures_leave_the_rest_of_the_batch_running() {
+        // The issue keeps transport, login, rate limit, allowance and service
+        // failures fatal to the batch; a game the server refused, could not
+        // find or answered unreadably, and a local file problem, concern
+        // that game alone. Dropping a kind from either side changes which
+        // games a run reaches.
+        for (kind, fatal) in [
+            (ErrorKind::Configuration, true),
+            (ErrorKind::Authentication, true),
+            (ErrorKind::Unavailable, true),
+            (ErrorKind::RateLimited, true),
+            (ErrorKind::DailyQuota, true),
+            (ErrorKind::FailedQuota, true),
+            (ErrorKind::Transport, true),
+            (ErrorKind::Timeout, true),
+            (ErrorKind::Server, true),
+            (ErrorKind::Cancelled, true),
+            (ErrorKind::Local, false),
+            (ErrorKind::NotFound, false),
+            (ErrorKind::InvalidRequest, false),
+            (ErrorKind::MalformedResponse, false),
+        ] {
+            assert_eq!(
+                fatal_for_run(&Error::new(kind, "detail")),
+                fatal,
+                "{kind:?}"
+            );
         }
     }
 
@@ -3453,6 +3493,72 @@ mod tests {
     }
 
     #[test]
+    fn a_login_rejection_during_the_batch_still_stops_it() {
+        // A login ScreenScraper rejects mid-run answers every remaining
+        // game the same way: the run stops with the login error instead of
+        // failing each queued game one request at a time.
+        let root = temp("login-rejected-mid-batch");
+        std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
+        std::fs::write(root.join("Zebra.rom"), b"found").unwrap();
+        let Event::Failed { error, progress } = finish(
+            start_with_transport(
+                request(&root, settings(ImagePolicy::Off)),
+                Arc::new(RejectingMock {
+                    status: 403,
+                    content_type: "text/plain",
+                    body: "Erreur de login : Vérifier vos identifiants développeur !",
+                    at_title_search: false,
+                }),
+            )
+            .unwrap(),
+        ) else {
+            panic!("a rejected login was treated as one game's problem");
+        };
+        assert_eq!(error.kind, ErrorKind::Authentication);
+        assert_eq!(
+            progress.unresolved_games,
+            vec![UnresolvedGame {
+                label: "Nintendo: Rejected".into(),
+                reason: "ScreenScraper rejected the login".into(),
+            }]
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_page_instead_of_xml_still_stops_the_batch() {
+        // An HTML answer is not a match response for one game but a sign
+        // that the service is not answering; walking the queue would spend
+        // one request per remaining game for nothing.
+        let root = temp("html-page-mid-batch");
+        std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
+        std::fs::write(root.join("Zebra.rom"), b"found").unwrap();
+        let Event::Failed { error, progress } = finish(
+            start_with_transport(
+                request(&root, settings(ImagePolicy::Off)),
+                Arc::new(RejectingMock {
+                    status: 200,
+                    content_type: "text/html",
+                    body: "<html><body>Maintenance</body></html>",
+                    at_title_search: false,
+                }),
+            )
+            .unwrap(),
+        ) else {
+            panic!("a non-XML page was treated as one game's problem");
+        };
+        assert_eq!(error.kind, ErrorKind::Unavailable);
+        assert_eq!(
+            progress.unresolved_games,
+            vec![UnresolvedGame {
+                label: "Nintendo: Rejected".into(),
+                reason: "ScreenScraper is unavailable".into(),
+            }]
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn a_documented_closure_text_still_stops_the_batch() {
         let root = temp("closure-text");
         std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
@@ -4045,6 +4151,75 @@ mod tests {
         assert_eq!(progress.updated, 0);
         assert_eq!(mock.media_calls.load(Ordering::Relaxed), 2);
         assert!(!root.join("gamelist.xml").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// The lookup succeeds; the image address is then refused with HTTP 400.
+    struct RejectedMediaMock(Mock);
+
+    impl Transport for RejectedMediaMock {
+        fn get(
+            &self,
+            endpoint: &str,
+            params: &[(String, String)],
+            limit: u64,
+        ) -> Result<HttpResponse> {
+            self.0.get(endpoint, params, limit)
+        }
+
+        fn get_media(
+            &self,
+            _url: &str,
+            _limit: u64,
+            _max_kib_per_second: Option<u64>,
+        ) -> Result<HttpResponse> {
+            self.0.media_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(HttpResponse {
+                status: 400,
+                content_type: Some("text/plain".into()),
+                body: b"Erreur : Probleme dans l'adresse".to_vec(),
+            })
+        }
+    }
+
+    #[test]
+    fn a_rejected_image_address_still_writes_the_fetched_metadata() {
+        // Image and metadata completeness are independent: a refused image
+        // address is reported with the game, but the match already fetched
+        // is not thrown away, so the next run does not repeat the lookup
+        // for metadata it already had.
+        let root = temp("rejected-image-address");
+        std::fs::write(root.join("Game.rom"), b"game").unwrap();
+        let mock = Arc::new(RejectedMediaMock(Mock {
+            api_calls: AtomicUsize::new(0),
+            media_calls: AtomicUsize::new(0),
+            quota_empty: false,
+            bad_media: false,
+            no_media: false,
+        }));
+        let event = finish(
+            start_with_transport(
+                request(&root, settings(ImagePolicy::MissingOnly)),
+                mock.clone(),
+            )
+            .unwrap(),
+        );
+        let Event::Finished(progress) = event else {
+            panic!("a rejected image address stopped the run");
+        };
+        assert_eq!(progress.updated, 1);
+        assert_eq!(progress.failed, 1);
+        assert_eq!(
+            progress.unresolved_games,
+            vec![UnresolvedGame {
+                label: "Nintendo: Game".into(),
+                reason: "ScreenScraper rejected this request".into(),
+            }]
+        );
+        assert_eq!(mock.0.media_calls.load(Ordering::Relaxed), 1);
+        let text = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();
+        assert!(text.contains("<name>Remote Game</name>"));
+        assert!(!text.contains("<image>"));
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/src/scraper/worker.rs
+++ b/src/scraper/worker.rs
@@ -90,12 +90,13 @@ pub struct Progress {
     /// Batch runs keep counting unresolved entries without carrying every
     /// server response or interrupting an unattended scrape.
     pub manual_matches: Vec<Match>,
-    /// Every game the run could not resolve, with the reason: no match,
-    /// several matches, no image to fetch, or a failed lookup, download or
-    /// write. A game whose image failed but whose metadata was written is
-    /// listed with the image error. The report names them after an
-    /// unattended batch. Carried only by the terminal event; progress
-    /// snapshots leave it empty.
+    /// Every game the run attempted and could not resolve, with the
+    /// reason: no match, several matches, no image to fetch, or a failed
+    /// lookup, download or write. A game whose image failed but whose
+    /// metadata was written is listed with the image error; games not
+    /// reached before a failure or cancellation are not listed. The report
+    /// names them after an unattended batch. Carried only by the terminal
+    /// event; progress snapshots leave it empty.
     pub unresolved_games: Vec<UnresolvedGame>,
 }
 
@@ -1727,56 +1728,19 @@ fn prepare(
                     },
                 )?;
                 match result.lookup {
-                    Lookup::NotFound => {
-                        activity_text(events, &current, "Matching by name");
-                        retry(
-                            cancelled,
-                            |error, delay| retry_activity(events, &current, error, delay),
-                            || {
-                                limited_lookup(limits, || {
-                                    client.by_name_with_media_type(
-                                        target.screen_scraper_system_id,
-                                        &target.query,
-                                        media_type,
-                                    )
-                                })
-                            },
-                        )?
-                    }
+                    Lookup::NotFound => search_by_title(
+                        &target, &current, media_type, client, limits, cancelled, events,
+                    )?,
                     _ => result,
                 }
             }
-            None => {
-                activity_text(events, &current, "Matching by name");
-                retry(
-                    cancelled,
-                    |error, delay| retry_activity(events, &current, error, delay),
-                    || {
-                        limited_lookup(limits, || {
-                            client.by_name_with_media_type(
-                                target.screen_scraper_system_id,
-                                &target.query,
-                                media_type,
-                            )
-                        })
-                    },
-                )?
-            }
+            None => search_by_title(
+                &target, &current, media_type, client, limits, cancelled, events,
+            )?,
         }
     } else {
-        activity_text(events, &current, "Matching by name");
-        retry(
-            cancelled,
-            |error, delay| retry_activity(events, &current, error, delay),
-            || {
-                limited_lookup(limits, || {
-                    client.by_name_with_media_type(
-                        target.screen_scraper_system_id,
-                        &target.query,
-                        media_type,
-                    )
-                })
-            },
+        search_by_title(
+            &target, &current, media_type, client, limits, cancelled, events,
         )?
     };
 
@@ -1891,6 +1855,48 @@ fn retry_delay(kind: ErrorKind, attempt: usize) -> Duration {
 
 fn current_label(target: &Target) -> String {
     format!("{}: {}", target.system_name, target.title)
+}
+
+/// Search ScreenScraper by title. A file named only by its extension and
+/// dump tags leaves nothing to send once those are removed; that is one
+/// game without a match, recorded like a server miss without a request or
+/// a failed-search reservation being spent, not a setup fault that should
+/// stop the run.
+fn search_by_title(
+    target: &Target,
+    current: &str,
+    media_type: &str,
+    client: &Client,
+    limits: &LimitedTransport,
+    cancelled: &AtomicBool,
+    events: &SyncSender<WorkerMessage>,
+) -> Result<super::api::LookupResponse> {
+    if target.query.trim().is_empty() {
+        log_scraper_detail(
+            current,
+            "no title remains to search for once the extension and dump tags are removed",
+        );
+        return Ok(super::api::LookupResponse {
+            lookup: Lookup::NotFound,
+            alternatives: Vec::new(),
+            account: None,
+            server_miss: false,
+        });
+    }
+    activity_text(events, current, "Matching by name");
+    retry(
+        cancelled,
+        |error, delay| retry_activity(events, current, error, delay),
+        || {
+            limited_lookup(limits, || {
+                client.by_name_with_media_type(
+                    target.screen_scraper_system_id,
+                    &target.query,
+                    media_type,
+                )
+            })
+        },
+    )
 }
 
 fn retry_status(error: &Error, delay: Duration) -> String {
@@ -2496,16 +2502,6 @@ mod tests {
                 },
             })
         }
-    }
-
-    fn mock() -> Arc<Mock> {
-        Arc::new(Mock {
-            api_calls: AtomicUsize::new(0),
-            media_calls: AtomicUsize::new(0),
-            quota_empty: false,
-            bad_media: false,
-            no_media: false,
-        })
     }
 
     fn temp(name: &str) -> PathBuf {
@@ -3356,6 +3352,106 @@ mod tests {
         }
     }
 
+    struct TaglessMock;
+
+    impl Transport for TaglessMock {
+        fn get(
+            &self,
+            endpoint: &str,
+            params: &[(String, String)],
+            _limit: u64,
+        ) -> Result<HttpResponse> {
+            let parameter = |name: &str| {
+                params
+                    .iter()
+                    .find(|(key, _)| key == name)
+                    .map(|(_, value)| value.as_str())
+                    .unwrap_or_default()
+            };
+            let body = match endpoint {
+                "ssuserInfos.php" => "<Data><ssuser><niveau>1</niveau><maxthreads>1</maxthreads><maxdownloadspeed>256</maxdownloadspeed><requeststoday>0</requeststoday><requestskotoday>0</requestskotoday><maxrequestspermin>60</maxrequestspermin><maxrequestsperday>20</maxrequestsperday><maxrequestskoperday>20</maxrequestskoperday></ssuser></Data>".to_string(),
+                "jeuInfos.php" if parameter("romnom").starts_with('(') => {
+                    "<Data><jeux/></Data>".to_string()
+                }
+                "jeuInfos.php" => {
+                    let md5 = parameter("md5");
+                    format!("<Data><jeux><jeu id='42'><noms><nom region='wor'>Found</nom></noms><rom><rommd5>{md5}</rommd5></rom></jeu></jeux></Data>")
+                }
+                other => panic!("unexpected endpoint {other}"),
+            };
+            Ok(HttpResponse {
+                status: 200,
+                content_type: Some("application/xml".into()),
+                body: body.into_bytes(),
+            })
+        }
+
+        fn get_media(
+            &self,
+            _url: &str,
+            _limit: u64,
+            _max_kib_per_second: Option<u64>,
+        ) -> Result<HttpResponse> {
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn a_file_named_only_by_dump_tags_is_recorded_and_the_batch_continues() {
+        // A system with several extensions keeps the extension in the row
+        // name, so a file called only by its tags searches for an empty
+        // term once the extension and tags are removed. That is one game
+        // without a match, whether it reaches the title search after a hash
+        // miss or directly: the run counts it like a server miss, spends no
+        // failed-search allowance on it, and writes the next game instead
+        // of stopping on a setup error.
+        let root = temp("tagless-title");
+        std::fs::write(root.join("(Unl).bin"), b"unlicensed").unwrap();
+        std::fs::write(root.join("(Proto).cue"), b"FILE \"(Proto).bin\" BINARY").unwrap();
+        std::fs::write(root.join("Zebra.rom"), b"found").unwrap();
+        let mut request = request(&root, settings(ImagePolicy::Off));
+        request.systems = vec![FoundSystem {
+            def: toml::from_str(
+                "name = 'Nintendo'\nid = 'NES'\nfolders = ['NES']\nrbf = '_Console/NES'\nextensions = ['rom', 'bin', 'cue']\n",
+            )
+            .unwrap(),
+            ..system(&root)
+        }];
+        let Event::Finished(mut progress) =
+            finish(start_with_transport(request, Arc::new(TaglessMock)).unwrap())
+        else {
+            panic!("a file with no searchable title stopped the batch");
+        };
+        assert_eq!(progress.completed, 3);
+        assert_eq!(progress.not_found, 2);
+        assert_eq!(progress.failed, 0);
+        // Only the hash miss for "(Unl).bin" reached ScreenScraper; neither
+        // empty title search spent a failed-search slot.
+        assert_eq!(progress.failed_searches, 1);
+        assert_eq!(progress.updated, 1);
+        progress
+            .unresolved_games
+            .sort_by(|a, b| a.label.cmp(&b.label));
+        assert_eq!(
+            progress.unresolved_games,
+            vec![
+                UnresolvedGame {
+                    label: "Nintendo: (Proto).cue".into(),
+                    reason: "no match".into(),
+                },
+                UnresolvedGame {
+                    label: "Nintendo: (Unl).bin".into(),
+                    reason: "no match".into(),
+                },
+            ]
+        );
+        let gamelist = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();
+        assert!(gamelist.contains("<path>./Zebra.rom</path>"));
+        assert!(!gamelist.contains("(Unl)"));
+        assert!(!gamelist.contains("(Proto)"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     #[test]
     fn a_documented_closure_text_still_stops_the_batch() {
         let root = temp("closure-text");
@@ -4079,7 +4175,13 @@ mod tests {
         std::fs::write(root.join("art.png"), PNG).unwrap();
         let xml = "<gameList><game><path>./Game.rom</path><name>Name</name><image>./art.png</image></game></gameList>";
         std::fs::write(root.join("gamelist.xml"), xml).unwrap();
-        let mock = mock();
+        let mock = Arc::new(Mock {
+            api_calls: AtomicUsize::new(0),
+            media_calls: AtomicUsize::new(0),
+            quota_empty: false,
+            bad_media: false,
+            no_media: false,
+        });
         for scope_root in [
             {
                 let mut all = request(&root, settings(ImagePolicy::MissingOnly));
@@ -4130,7 +4232,13 @@ mod tests {
             "<gameList><game><path>./Game.rom</path><name>Local Name</name><image>./art.png</image></game></gameList>",
         )
         .unwrap();
-        let mock = mock();
+        let mock = Arc::new(Mock {
+            api_calls: AtomicUsize::new(0),
+            media_calls: AtomicUsize::new(0),
+            quota_empty: false,
+            bad_media: false,
+            no_media: false,
+        });
         let Event::Finished(progress) = finish(
             start_with_transport(
                 game_request(&root, settings(ImagePolicy::MissingOnly)),
@@ -4163,7 +4271,13 @@ mod tests {
             "<gameList><game><path>./Game.rom</path><name>Local Name</name></game></gameList>",
         )
         .unwrap();
-        let mock = mock();
+        let mock = Arc::new(Mock {
+            api_calls: AtomicUsize::new(0),
+            media_calls: AtomicUsize::new(0),
+            quota_empty: false,
+            bad_media: false,
+            no_media: false,
+        });
         let Event::Finished(progress) = finish(
             start_with_transport(
                 request(&root, settings(ImagePolicy::MissingOnly)),
@@ -4196,7 +4310,13 @@ mod tests {
             "<gameList><game><path>./Game.rom</path><image>./art.png</image></game></gameList>",
         )
         .unwrap();
-        let mock = mock();
+        let mock = Arc::new(Mock {
+            api_calls: AtomicUsize::new(0),
+            media_calls: AtomicUsize::new(0),
+            quota_empty: false,
+            bad_media: false,
+            no_media: false,
+        });
         let Event::Finished(progress) = finish(
             start_with_transport(
                 request(&root, settings(ImagePolicy::MissingOnly)),
@@ -4232,7 +4352,13 @@ mod tests {
         .unwrap();
         let mut replace = settings(ImagePolicy::ReplaceExisting);
         replace.metadata_policy = MetadataPolicy::ReplaceExisting;
-        let mock = mock();
+        let mock = Arc::new(Mock {
+            api_calls: AtomicUsize::new(0),
+            media_calls: AtomicUsize::new(0),
+            quota_empty: false,
+            bad_media: false,
+            no_media: false,
+        });
         let Event::Finished(progress) =
             finish(start_with_transport(request(&root, replace), mock.clone()).unwrap())
         else {

--- a/src/scraper/worker.rs
+++ b/src/scraper/worker.rs
@@ -93,9 +93,10 @@ pub struct Progress {
     /// Every game the run attempted and could not resolve, with the
     /// reason as the report shows it: "no match", "no searchable title",
     /// the number of matches ("3 matches"), "no image", or the message of
-    /// a failed lookup, download or write. A game whose image failed but
-    /// whose metadata was written is listed with the image error; games
-    /// not reached before a failure or cancellation are not listed. The
+    /// a failed lookup, download or write. A game whose image failed or
+    /// had none at ScreenScraper is listed even when its metadata was
+    /// written; games not reached before a failure or cancellation are
+    /// not listed. The
     /// report names them after an unattended batch. Carried only by the
     /// terminal event; progress snapshots leave it empty.
     pub unresolved_games: Vec<UnresolvedGame>,
@@ -1507,6 +1508,9 @@ fn limited_lookup(
     if let Ok(response) = &result {
         reservation.finish(response.server_miss);
     }
+    // ScreenScraper counts a KO only for a negative answer (rom or game
+    // not found), so a rejected or unreadable lookup releases its slot
+    // uncounted.
     result
 }
 
@@ -1624,9 +1628,9 @@ enum WorkerMessage {
     Done,
 }
 
-/// Report reasons for a game counted as not found: ScreenScraper answered
-/// the lookup with no exact match, or no title search was sent because
-/// nothing remained to search for.
+// Report reasons for a game counted as not found: ScreenScraper answered
+// the lookup with no exact match, or no title search was sent because
+// nothing remained to search for.
 const NO_MATCH: &str = "no match";
 const NO_SEARCHABLE_TITLE: &str = "no searchable title";
 
@@ -2012,6 +2016,9 @@ fn stage(
             "the match has no selected ScreenScraper image",
         );
         progress.no_media += 1;
+        // Listed whether or not its metadata is written, so the report's
+        // rows agree with the "no image" count.
+        progress.unresolved(target_label, "no image");
     }
     // Metadata the planning step found complete is left alone even though
     // the match carries some: an image-only entry writes only its image.
@@ -2019,9 +2026,6 @@ fn stage(
     if prepared.media.is_none() && !metadata_selected {
         if !media_failed {
             progress.unchanged += 1;
-        }
-        if prepared.no_media {
-            progress.unresolved(target_label, "no image");
         }
         return Ok(None);
     }
@@ -3399,7 +3403,7 @@ mod tests {
             (
                 200,
                 "text/plain",
-                "Erreur : Il manque des champs obligatoires dans l'url",
+                "Erreur dans le nom du fichier rom : celui-ci contient un chemin d'accés",
                 true,
             ),
         ] {
@@ -3664,6 +3668,43 @@ mod tests {
                     reason: "ScreenScraper is unavailable".into(),
                 }],
                 "{name}"
+            );
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn an_incomplete_request_address_stops_the_batch() {
+        // Degauss sends the same request fields for every game, so the
+        // documented text for a call missing its fields would recur for
+        // each remaining game; it stops the run like a refused client,
+        // whether it arrives in a 2xx body or with HTTP 400.
+        for status in [200, 400] {
+            let root = temp(&format!("incomplete-address-{status}"));
+            std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
+            std::fs::write(root.join("Zebra.rom"), b"found").unwrap();
+            let Event::Failed { error, progress } = finish(
+                start_with_transport(
+                    request(&root, settings(ImagePolicy::Off)),
+                    Arc::new(RejectingMock {
+                        status,
+                        content_type: "text/plain",
+                        body: "Erreur : Il manque des champs obligatoires dans l'url",
+                        at_title_search: false,
+                    }),
+                )
+                .unwrap(),
+            ) else {
+                panic!("an incomplete request address (HTTP {status}) was treated as one game's problem");
+            };
+            assert_eq!(error.kind, ErrorKind::Configuration, "HTTP {status}");
+            assert_eq!(
+                progress.unresolved_games,
+                vec![UnresolvedGame {
+                    label: "Nintendo: Rejected".into(),
+                    reason: "Scraper setup needs attention".into(),
+                }],
+                "HTTP {status}"
             );
             let _ = std::fs::remove_dir_all(root);
         }
@@ -4358,9 +4399,13 @@ mod tests {
         assert_eq!(progress.updated, 1);
         assert_eq!(progress.no_media, 1);
         assert_eq!(progress.failed, 0);
-        assert!(
-            progress.unresolved_games.is_empty(),
-            "a game whose metadata was written is not reported as unresolved"
+        assert_eq!(
+            progress.unresolved_games,
+            vec![UnresolvedGame {
+                label: "Nintendo: Game".into(),
+                reason: "no image".into(),
+            }],
+            "the requested image was not resolved, so the report names the game as its count does"
         );
         assert_eq!(mock.media_calls.load(Ordering::Relaxed), 1);
         let text = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();

--- a/src/scraper/worker.rs
+++ b/src/scraper/worker.rs
@@ -90,9 +90,12 @@ pub struct Progress {
     /// Batch runs keep counting unresolved entries without carrying every
     /// server response or interrupting an unattended scrape.
     pub manual_matches: Vec<Match>,
-    /// Every game the run did not write, with the reason, so the report can
-    /// name them after an unattended batch. Carried only by the terminal
-    /// event; progress snapshots leave it empty.
+    /// Every game the run could not resolve, with the reason: no match,
+    /// several matches, no image to fetch, or a failed lookup, download or
+    /// write. A game whose image failed but whose metadata was written is
+    /// listed with the image error. The report names them after an
+    /// unattended batch. Carried only by the terminal event; progress
+    /// snapshots leave it empty.
     pub unresolved_games: Vec<UnresolvedGame>,
 }
 
@@ -1976,6 +1979,9 @@ fn stage(prepared: Prepared, progress: &mut Progress) -> Result<Option<Pending>>
         if !media_failed {
             progress.unchanged += 1;
         }
+        if prepared.no_media {
+            progress.unresolved(&target_label, "no image");
+        }
         return Ok(None);
     }
     Ok(Some(Pending {
@@ -2490,6 +2496,16 @@ mod tests {
                 },
             })
         }
+    }
+
+    fn mock() -> Arc<Mock> {
+        Arc::new(Mock {
+            api_calls: AtomicUsize::new(0),
+            media_calls: AtomicUsize::new(0),
+            quota_empty: false,
+            bad_media: false,
+            no_media: false,
+        })
     }
 
     fn temp(name: &str) -> PathBuf {
@@ -3168,12 +3184,14 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
-    /// Answers the hash lookup for `Rejected.rom` with a configured
-    /// response and matches every other game.
+    /// Answers the lookup for `Rejected.rom` with a configured response
+    /// and matches every other game. With `at_title_search` the hash lookup
+    /// misses and the configured response answers the title search instead.
     struct RejectingMock {
         status: u16,
         content_type: &'static str,
         body: &'static str,
+        at_title_search: bool,
     }
 
     impl Transport for RejectingMock {
@@ -3192,7 +3210,17 @@ mod tests {
             };
             let body = match endpoint {
                 "ssuserInfos.php" => "<Data><ssuser><niveau>1</niveau><maxthreads>1</maxthreads><maxdownloadspeed>256</maxdownloadspeed><requeststoday>0</requeststoday><requestskotoday>0</requestskotoday><maxrequestspermin>60</maxrequestspermin><maxrequestsperday>20</maxrequestsperday><maxrequestskoperday>20</maxrequestskoperday></ssuser></Data>".to_string(),
+                "jeuInfos.php" if parameter("romnom") == "Rejected.rom" && self.at_title_search => {
+                    "<Data><jeux/></Data>".to_string()
+                }
                 "jeuInfos.php" if parameter("romnom") == "Rejected.rom" => {
+                    return Ok(HttpResponse {
+                        status: self.status,
+                        content_type: Some(self.content_type.into()),
+                        body: self.body.as_bytes().to_vec(),
+                    });
+                }
+                "jeuRecherche.php" if parameter("recherche") == "Rejected" && self.at_title_search => {
                     return Ok(HttpResponse {
                         status: self.status,
                         content_type: Some(self.content_type.into()),
@@ -3225,21 +3253,36 @@ mod tests {
     #[test]
     fn a_rejected_individual_search_is_recorded_and_the_batch_continues() {
         // One game ScreenScraper refuses, by HTTP 400 or by an error text it
-        // does not document as an outage, is that game's problem: the run
-        // still processes the next game and names the rejected one.
-        for (status, content_type, body) in [
+        // does not document as an outage, is that game's problem whether the
+        // refusal answers the hash lookup or the title search: the run still
+        // processes the next game and names the rejected one.
+        for (status, content_type, body, at_title_search) in [
             (
                 400,
                 "text/plain",
                 "Erreur : Problème dans le nom du fichier rom",
+                false,
             ),
             (
                 200,
                 "text/plain",
                 "Erreur : Problème dans le nom du fichier rom",
+                false,
+            ),
+            (
+                400,
+                "text/plain",
+                "Erreur : Problème dans la recherche",
+                true,
+            ),
+            (
+                200,
+                "text/plain",
+                "Erreur : Problème dans la recherche",
+                true,
             ),
         ] {
-            let root = temp(&format!("rejected-search-{status}"));
+            let root = temp(&format!("rejected-search-{status}-{at_title_search}"));
             std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
             std::fs::write(root.join("Zebra.rom"), b"found").unwrap();
             let Event::Finished(progress) = finish(
@@ -3249,11 +3292,14 @@ mod tests {
                         status,
                         content_type,
                         body,
+                        at_title_search,
                     }),
                 )
                 .unwrap(),
             ) else {
-                panic!("a rejected search stopped the batch (HTTP {status})");
+                panic!(
+                    "a rejected search stopped the batch (HTTP {status}, title search {at_title_search})"
+                );
             };
             assert_eq!(progress.completed, 2);
             assert_eq!(progress.failed, 1);
@@ -3262,7 +3308,7 @@ mod tests {
                 progress.unresolved_games,
                 vec![UnresolvedGame {
                     label: "Nintendo: Rejected".into(),
-                    reason: "ScreenScraper rejected this search".into(),
+                    reason: "ScreenScraper rejected this request".into(),
                 }]
             );
             let gamelist = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();
@@ -3274,35 +3320,40 @@ mod tests {
 
     #[test]
     fn an_unreadable_match_response_is_recorded_and_the_batch_continues() {
-        let root = temp("unreadable-match");
-        std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
-        std::fs::write(root.join("Zebra.rom"), b"found").unwrap();
-        let Event::Finished(progress) = finish(
-            start_with_transport(
-                request(&root, settings(ImagePolicy::Off)),
-                Arc::new(RejectingMock {
-                    status: 200,
-                    content_type: "application/xml",
-                    body: "<Data><message>no game list here</message></Data>",
-                }),
-            )
-            .unwrap(),
-        ) else {
-            panic!("an unusable match response stopped the batch");
-        };
-        assert_eq!(progress.failed, 1);
-        assert_eq!(progress.updated, 1);
-        assert_eq!(
-            progress.unresolved_games,
-            vec![UnresolvedGame {
-                label: "Nintendo: Rejected".into(),
-                reason: "ScreenScraper response was unreadable".into(),
-            }]
-        );
-        assert!(std::fs::read_to_string(root.join("gamelist.xml"))
-            .unwrap()
-            .contains("<path>./Zebra.rom</path>"));
-        let _ = std::fs::remove_dir_all(root);
+        for at_title_search in [false, true] {
+            let root = temp(&format!("unreadable-match-{at_title_search}"));
+            std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
+            std::fs::write(root.join("Zebra.rom"), b"found").unwrap();
+            let Event::Finished(progress) = finish(
+                start_with_transport(
+                    request(&root, settings(ImagePolicy::Off)),
+                    Arc::new(RejectingMock {
+                        status: 200,
+                        content_type: "application/xml",
+                        body: "<Data><message>no game list here</message></Data>",
+                        at_title_search,
+                    }),
+                )
+                .unwrap(),
+            ) else {
+                panic!(
+                    "an unusable match response stopped the batch (title search {at_title_search})"
+                );
+            };
+            assert_eq!(progress.failed, 1);
+            assert_eq!(progress.updated, 1);
+            assert_eq!(
+                progress.unresolved_games,
+                vec![UnresolvedGame {
+                    label: "Nintendo: Rejected".into(),
+                    reason: "ScreenScraper response was unreadable".into(),
+                }]
+            );
+            assert!(std::fs::read_to_string(root.join("gamelist.xml"))
+                .unwrap()
+                .contains("<path>./Zebra.rom</path>"));
+            let _ = std::fs::remove_dir_all(root);
+        }
     }
 
     #[test]
@@ -3317,6 +3368,7 @@ mod tests {
                     status: 200,
                     content_type: "text/plain",
                     body: "Erreur : API totalement fermé",
+                    at_title_search: false,
                 }),
             )
             .unwrap(),
@@ -3924,6 +3976,10 @@ mod tests {
         assert_eq!(progress.updated, 1);
         assert_eq!(progress.no_media, 1);
         assert_eq!(progress.failed, 0);
+        assert!(
+            progress.unresolved_games.is_empty(),
+            "a game whose metadata was written is not reported as unresolved"
+        );
         assert_eq!(mock.media_calls.load(Ordering::Relaxed), 1);
         let text = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();
         assert!(text.contains("<name>Remote Game</name>"));
@@ -3952,6 +4008,14 @@ mod tests {
         assert_eq!(progress.no_media, 1);
         assert_eq!(progress.unchanged, 1);
         assert_eq!(progress.updated, 0);
+        assert_eq!(
+            progress.unresolved_games,
+            vec![UnresolvedGame {
+                label: "Nintendo: Game".into(),
+                reason: "no image".into(),
+            }],
+            "nothing was written, so the report must name the game"
+        );
         assert!(!root.join("gamelist.xml").exists());
         assert_eq!(mock.media_calls.load(Ordering::Relaxed), 1);
         let _ = std::fs::remove_dir_all(root);
@@ -4008,16 +4072,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
-    fn mock() -> Arc<Mock> {
-        Arc::new(Mock {
-            api_calls: AtomicUsize::new(0),
-            media_calls: AtomicUsize::new(0),
-            quota_empty: false,
-            bad_media: false,
-            no_media: false,
-        })
-    }
-
     #[test]
     fn a_batch_entry_with_an_image_and_one_field_makes_no_request() {
         let root = temp("batch-one-field-complete");
@@ -4026,15 +4080,24 @@ mod tests {
         let xml = "<gameList><game><path>./Game.rom</path><name>Name</name><image>./art.png</image></game></gameList>";
         std::fs::write(root.join("gamelist.xml"), xml).unwrap();
         let mock = mock();
-        for scope_root in [request(&root, settings(ImagePolicy::MissingOnly)), {
-            let mut folder = request(&root, settings(ImagePolicy::MissingOnly));
-            folder.scope = Scope::Folder {
-                system_id: "NES".into(),
-                place: crate::browse::Place::Dir(root.clone()),
-                display_name: "Nintendo".into(),
-            };
-            folder
-        }] {
+        for scope_root in [
+            {
+                let mut all = request(&root, settings(ImagePolicy::MissingOnly));
+                all.scope = Scope::All;
+                all.scope_label = "All Systems".into();
+                all
+            },
+            request(&root, settings(ImagePolicy::MissingOnly)),
+            {
+                let mut folder = request(&root, settings(ImagePolicy::MissingOnly));
+                folder.scope = Scope::Folder {
+                    system_id: "NES".into(),
+                    place: crate::browse::Place::Dir(root.clone()),
+                    display_name: "Nintendo".into(),
+                };
+                folder
+            },
+        ] {
             let Event::Finished(progress) =
                 finish(start_with_transport(scope_root, mock.clone()).unwrap())
             else {

--- a/src/scraper/worker.rs
+++ b/src/scraper/worker.rs
@@ -1628,11 +1628,24 @@ enum WorkerMessage {
     Done,
 }
 
-// Report reasons for a game counted as not found: ScreenScraper answered
-// the lookup with no exact match, or no title search was sent because
-// nothing remained to search for.
-const NO_MATCH: &str = "no match";
-const NO_SEARCHABLE_TITLE: &str = "no searchable title";
+/// Why a game was counted as not found: ScreenScraper answered the lookup
+/// with no exact match, or no title search was sent because nothing
+/// remained to search for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NotFound {
+    NoMatch,
+    NoSearchableTitle,
+}
+
+impl NotFound {
+    /// The report row text.
+    fn reason(self) -> &'static str {
+        match self {
+            Self::NoMatch => "no match",
+            Self::NoSearchableTitle => "no searchable title",
+        }
+    }
+}
 
 struct Prepared {
     target: Target,
@@ -1642,8 +1655,7 @@ struct Prepared {
     media_error: Option<Error>,
     no_media: bool,
     ambiguous: Option<usize>,
-    /// The report reason when the game was counted as not found.
-    not_found: Option<&'static str>,
+    not_found: Option<NotFound>,
     alternatives: Vec<Match>,
 }
 
@@ -1765,7 +1777,7 @@ fn prepare(
             media_error: None,
             no_media: false,
             ambiguous: None,
-            not_found: Some(NO_SEARCHABLE_TITLE),
+            not_found: Some(NotFound::NoSearchableTitle),
             alternatives: Vec::new(),
         });
     };
@@ -1783,7 +1795,7 @@ fn prepare(
             media_error: None,
             no_media: false,
             ambiguous: None,
-            not_found: Some(NO_MATCH),
+            not_found: Some(NotFound::NoMatch),
             alternatives,
         }),
         Lookup::Ambiguous(count) => Ok(Prepared {
@@ -1969,20 +1981,23 @@ fn stage(
     target_label: &str,
     progress: &mut Progress,
 ) -> Result<Option<Pending>> {
-    if let Some(reason) = prepared.not_found {
+    if let Some(not_found) = prepared.not_found {
         // A file with no searchable title was never sent to ScreenScraper,
         // so the log names that reason rather than a miss that did not
         // happen.
-        if reason == NO_SEARCHABLE_TITLE {
-            log_scraper_detail(target_label, "no searchable title; skipped");
-        } else {
-            log_scraper_detail(target_label, "no exact ScreenScraper match; skipped");
+        match not_found {
+            NotFound::NoMatch => {
+                log_scraper_detail(target_label, "no exact ScreenScraper match; skipped");
+            }
+            NotFound::NoSearchableTitle => {
+                log_scraper_detail(target_label, "no searchable title; skipped");
+            }
         }
         if !prepared.alternatives.is_empty() {
             progress.manual_matches = prepared.alternatives;
         }
         progress.not_found += 1;
-        progress.unresolved(target_label, reason);
+        progress.unresolved(target_label, not_found.reason());
         return Ok(None);
     }
     if let Some(count) = prepared.ambiguous {

--- a/src/scraper/worker.rs
+++ b/src/scraper/worker.rs
@@ -1632,12 +1632,12 @@ enum WorkerMessage {
 /// with no exact match, or no title search was sent because nothing
 /// remained to search for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NotFound {
+enum Miss {
     NoMatch,
     NoSearchableTitle,
 }
 
-impl NotFound {
+impl Miss {
     /// The report row text.
     fn reason(self) -> &'static str {
         match self {
@@ -1655,7 +1655,7 @@ struct Prepared {
     media_error: Option<Error>,
     no_media: bool,
     ambiguous: Option<usize>,
-    not_found: Option<NotFound>,
+    not_found: Option<Miss>,
     alternatives: Vec<Match>,
 }
 
@@ -1777,7 +1777,7 @@ fn prepare(
             media_error: None,
             no_media: false,
             ambiguous: None,
-            not_found: Some(NotFound::NoSearchableTitle),
+            not_found: Some(Miss::NoSearchableTitle),
             alternatives: Vec::new(),
         });
     };
@@ -1795,7 +1795,7 @@ fn prepare(
             media_error: None,
             no_media: false,
             ambiguous: None,
-            not_found: Some(NotFound::NoMatch),
+            not_found: Some(Miss::NoMatch),
             alternatives,
         }),
         Lookup::Ambiguous(count) => Ok(Prepared {
@@ -1905,8 +1905,9 @@ fn current_label(target: &Target) -> String {
 /// Search ScreenScraper by title. A file named only by its extension and
 /// dump tags leaves nothing to send once those are removed: no search is
 /// made and `None` is returned, so the game is counted as not found with
-/// its own reason, without a request or a failed-search reservation being
-/// spent and without a setup fault stopping the run.
+/// its own reason (logged once by `stage`), without a request or a
+/// failed-search reservation being spent and without a setup fault
+/// stopping the run.
 fn search_by_title(
     target: &Target,
     current: &str,
@@ -1917,10 +1918,6 @@ fn search_by_title(
     events: &SyncSender<WorkerMessage>,
 ) -> Result<Option<super::api::LookupResponse>> {
     if target.query.trim().is_empty() {
-        log_scraper_detail(
-            current,
-            "no title remains to search for once the extension and dump tags are removed",
-        );
         return Ok(None);
     }
     activity_text(events, current, "Matching by name");
@@ -1986,11 +1983,14 @@ fn stage(
         // so the log names that reason rather than a miss that did not
         // happen.
         match not_found {
-            NotFound::NoMatch => {
+            Miss::NoMatch => {
                 log_scraper_detail(target_label, "no exact ScreenScraper match; skipped");
             }
-            NotFound::NoSearchableTitle => {
-                log_scraper_detail(target_label, "no searchable title; skipped");
+            Miss::NoSearchableTitle => {
+                log_scraper_detail(
+                    target_label,
+                    "no searchable title once the extension and dump tags are removed; skipped",
+                );
             }
         }
         if !prepared.alternatives.is_empty() {
@@ -2335,10 +2335,12 @@ fn safe_component(value: &str) -> String {
 }
 
 /// Whether one game's failure stops the batch. A request ScreenScraper
-/// rejected, or a match response it served unreadable, concerns that game
-/// alone; transport, login, rate limit, quota and service outages (which
-/// include an answer that is not XML at all, or a page whose root element
-/// is not ScreenScraper's `<Data>`, whatever its content type) concern
+/// rejected (by HTTP 400, by a documented bad-request text or by an error
+/// text it does not document answering that game's lookup), or a match
+/// response it served unreadable, concerns that game alone; transport,
+/// login, rate limit, quota and service outages (which include an answer
+/// that is not XML at all, or a page whose root element is not
+/// ScreenScraper's `<Data>`, whatever its content type or status) concern
 /// every game still queued.
 fn fatal_for_run(error: &Error) -> bool {
     !matches!(
@@ -3395,38 +3397,51 @@ mod tests {
 
     #[test]
     fn a_rejected_individual_search_is_recorded_and_the_batch_continues() {
-        // One game ScreenScraper refuses, by HTTP 400 or by one of the
-        // error texts it documents for a bad request, is that game's
-        // problem whether the refusal answers the hash lookup or the title
-        // search: the run still processes the next game and names the
-        // rejected one.
-        for (status, content_type, body, at_title_search) in [
+        // One game ScreenScraper refuses, by HTTP 400, by one of the error
+        // texts it documents for a bad request, or by an error text it
+        // does not document answering that game's lookup on a successful
+        // status (the invalid search that used to stop the whole batch as
+        // an outage), is that game's problem whether the refusal answers
+        // the hash lookup or the title search: the run still processes
+        // the next game and names the rejected one.
+        for (name, status, content_type, body, at_title_search) in [
             (
+                "documented-400",
                 400,
                 "text/plain",
                 "Erreur : Problème dans le nom du fichier rom",
                 false,
             ),
             (
+                "documented-2xx",
                 200,
                 "text/plain",
                 "Erreur : Champ crc, md5 ou sha1 erroné",
                 false,
             ),
             (
+                "undocumented-400",
                 400,
                 "text/plain",
                 "Erreur : Problème dans la recherche",
                 true,
             ),
             (
+                "undocumented-2xx",
+                200,
+                "text/plain",
+                "Erreur : Problème dans la recherche",
+                true,
+            ),
+            (
+                "documented-2xx-title",
                 200,
                 "text/plain",
                 "Erreur dans le nom du fichier rom : celui-ci contient un chemin d'accés",
                 true,
             ),
         ] {
-            let root = temp(&format!("rejected-search-{status}-{at_title_search}"));
+            let root = temp(&format!("rejected-search-{name}"));
             std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
             std::fs::write(root.join("Zebra.rom"), b"found").unwrap();
             let Event::Finished(progress) = finish(
@@ -3441,19 +3456,18 @@ mod tests {
                 )
                 .unwrap(),
             ) else {
-                panic!(
-                    "a rejected search stopped the batch (HTTP {status}, title search {at_title_search})"
-                );
+                panic!("a rejected search stopped the batch ({name})");
             };
-            assert_eq!(progress.completed, 2);
-            assert_eq!(progress.failed, 1);
-            assert_eq!(progress.updated, 1);
+            assert_eq!(progress.completed, 2, "{name}");
+            assert_eq!(progress.failed, 1, "{name}");
+            assert_eq!(progress.updated, 1, "{name}");
             assert_eq!(
                 progress.unresolved_games,
                 vec![UnresolvedGame {
                     label: "Nintendo: Rejected".into(),
                     reason: "ScreenScraper rejected this request".into(),
-                }]
+                }],
+                "{name}"
             );
             let gamelist = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();
             assert!(gamelist.contains("<path>./Zebra.rom</path>"));
@@ -3637,43 +3651,49 @@ mod tests {
 
     #[test]
     fn a_page_instead_of_xml_still_stops_the_batch() {
-        // An HTML page (whatever content type it is served with, or none),
-        // a plain notice, an empty body or an error text ScreenScraper has
-        // not documented is not a match response for one game but a sign
-        // that the service is not answering; walking the queue would spend
-        // one request per remaining game for nothing.
-        for (name, content_type, body, at_title_search) in [
+        // An HTML page (whatever content type or status it is served with,
+        // or no content type), a plain notice or an empty body is not a
+        // match response for one game but a sign that the service is not
+        // answering; walking the queue would spend one request per
+        // remaining game for nothing.
+        for (name, status, content_type, body, at_title_search) in [
             (
                 "html-page",
+                200,
                 "text/html",
                 "<html><body>Maintenance</body></html>",
                 false,
             ),
             (
                 "untyped-html-page",
+                200,
                 "",
                 "<html><body>Maintenance</body></html>",
                 false,
             ),
             (
                 "xml-labelled-html-page",
+                200,
                 "application/xml",
                 "<!DOCTYPE html><html><body><p>Maintenance</html>",
                 true,
             ),
             (
                 "notice",
+                200,
                 "text/plain",
                 "Service paused for maintenance",
                 true,
             ),
-            ("empty", "application/xml", "", false),
+            ("empty", 200, "application/xml", "", false),
             (
-                "undocumented",
-                "text/plain",
-                "Erreur : Problème dans la recherche",
+                "html-page-400",
+                400,
+                "text/html",
+                "<html><body>Bad request</body></html>",
                 true,
             ),
+            ("empty-400", 400, "text/plain", "", false),
         ] {
             let root = temp(&format!("{name}-mid-batch"));
             std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
@@ -3682,7 +3702,7 @@ mod tests {
                 start_with_transport(
                     request(&root, settings(ImagePolicy::Off)),
                     Arc::new(RejectingMock {
-                        status: 200,
+                        status,
                         content_type,
                         body,
                         at_title_search,
@@ -4533,10 +4553,22 @@ mod tests {
 
     #[test]
     fn a_batch_entry_with_an_image_and_one_field_makes_no_request() {
+        // One populated field beside the picture is complete for a batch,
+        // whether the other seven fields are absent or written as empty
+        // elements, so the game is not sent back to ScreenScraper on
+        // every system or full-library run.
+        for xml in [
+            "<gameList><game><path>./Game.rom</path><name>Name</name><image>./art.png</image></game></gameList>",
+            "<gameList><game><path>./Game.rom</path><name>Name</name><desc></desc><publisher></publisher><developer></developer><releasedate></releasedate><players></players><genre></genre><lang></lang><image>./art.png</image></game></gameList>",
+        ] {
+            a_batch_entry_makes_no_request(xml);
+        }
+    }
+
+    fn a_batch_entry_makes_no_request(xml: &str) {
         let root = temp("batch-one-field-complete");
         std::fs::write(root.join("Game.rom"), b"game").unwrap();
         std::fs::write(root.join("art.png"), PNG).unwrap();
-        let xml = "<gameList><game><path>./Game.rom</path><name>Name</name><image>./art.png</image></game></gameList>";
         std::fs::write(root.join("gamelist.xml"), xml).unwrap();
         let mock = Arc::new(Mock {
             api_calls: AtomicUsize::new(0),

--- a/src/scraper/worker.rs
+++ b/src/scraper/worker.rs
@@ -12,7 +12,7 @@ use crate::systems::FoundSystem;
 use sha1::{Digest, Sha1};
 
 use super::api::{Client, CurlTransport, HttpResponse, Lookup, Transport};
-use super::gamelist_edit::{self, Backups, Needs, Update};
+use super::gamelist_edit::{self, Backups, FillCompleteness, Needs, Update};
 use super::hashes;
 use super::{
     Account, DeveloperCredentials, Error, ErrorKind, Match, Result, Scope, ScraperSettings, Target,
@@ -90,9 +90,26 @@ pub struct Progress {
     /// Batch runs keep counting unresolved entries without carrying every
     /// server response or interrupting an unattended scrape.
     pub manual_matches: Vec<Match>,
+    /// Every game the run did not write, with the reason, so the report can
+    /// name them after an unattended batch. Carried only by the terminal
+    /// event; progress snapshots leave it empty.
+    pub unresolved_games: Vec<UnresolvedGame>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnresolvedGame {
+    pub label: String,
+    pub reason: String,
 }
 
 impl Progress {
+    fn unresolved(&mut self, label: &str, reason: &str) {
+        self.unresolved_games.push(UnresolvedGame {
+            label: label.to_string(),
+            reason: reason.to_string(),
+        });
+    }
+
     pub fn requests_left(&self) -> Option<u64> {
         Some(
             self.account
@@ -617,7 +634,7 @@ fn run(
         phase: Phase::Enumerating,
         ..Default::default()
     };
-    emit(events, &progress);
+    emit(events, &mut progress);
 
     let mut settings = request.settings.clone();
     let batch = match super::targets::collect(
@@ -630,7 +647,7 @@ fn run(
         &mut |system| {
             progress.current = system.to_string();
             progress.activity = "Enumerating game folders".to_string();
-            emit(events, &progress);
+            emit(events, &mut progress);
         },
     ) {
         Ok(batch) => batch,
@@ -719,10 +736,26 @@ fn run(
     }
     let keep_manual_matches =
         matches!(request.scope, Scope::Game { .. }) && selected_match.is_none();
+    // Choosing one game is permission to complete it field by field; a
+    // batch treats any stored metadata as complete so optional fields
+    // ScreenScraper never supplies do not send the same games back on
+    // every run.
+    let completeness = if matches!(request.scope, Scope::Game { .. }) {
+        FillCompleteness::EveryField
+    } else {
+        FillCompleteness::AnyField
+    };
     progress.phase = Phase::Planning;
     progress.activity = "Checking existing images and metadata".to_string();
-    emit(events, &progress);
-    let mut work = match plan_work(batch.targets, &settings, &mut progress, cancelled, events) {
+    emit(events, &mut progress);
+    let mut work = match plan_work(
+        batch.targets,
+        &settings,
+        completeness,
+        &mut progress,
+        cancelled,
+        events,
+    ) {
         Ok(work) => work,
         Err(error) if error.kind == ErrorKind::Cancelled => {
             let _ = events.send(Event::Cancelled(progress));
@@ -754,7 +787,7 @@ fn run(
             item.selected = Some(selected);
         }
     }
-    emit(events, &progress);
+    emit(events, &mut progress);
     if cancelled.load(Ordering::Relaxed) {
         let _ = events.send(Event::Cancelled(progress));
         return;
@@ -768,7 +801,7 @@ fn run(
 
     progress.activity.clear();
     progress.phase = Phase::Account;
-    emit(events, &progress);
+    emit(events, &mut progress);
     let Some(developer) = request.developer.clone() else {
         finish_error(
             events,
@@ -792,7 +825,7 @@ fn run(
         cancelled,
         |error, delay| {
             progress.activity = retry_status(error, delay);
-            emit(events, &progress);
+            emit(events, &mut progress);
         },
         || {
             account_requests.fetch_add(1, Ordering::Relaxed);
@@ -935,7 +968,7 @@ fn run(
     progress.workers = workers;
     progress.phase = Phase::Scraping;
     progress.activity.clear();
-    emit(events, &progress);
+    emit(events, &mut progress);
 
     let limits = Arc::new(LimitedTransport::new(
         transport,
@@ -1009,6 +1042,7 @@ fn run(
                     if results
                         .send(WorkerMessage::Target {
                             gamelist_path,
+                            target_label,
                             result: Box::new(result),
                         })
                         .is_err()
@@ -1031,20 +1065,20 @@ fn run(
                 WorkerMessage::Activity { current, status } => {
                     progress.current = current;
                     progress.activity = status;
-                    emit(events, &progress);
+                    emit(events, &mut progress);
                 }
                 WorkerMessage::Target {
                     gamelist_path,
+                    target_label,
                     result,
                 } => {
                     progress.completed += 1;
                     progress.activity = "Recording result".to_string();
                     match *result {
                         Ok(prepared) => {
-                            progress.current = current_label(&prepared.target);
+                            progress.current = target_label.clone();
                             progress.failed_searches = limits.failed();
-                            let target_label = current_label(&prepared.target);
-                            match stage(prepared, &settings, &mut progress) {
+                            match stage(prepared, &mut progress) {
                                 Ok(Some(item)) => {
                                     pending
                                         .entry(item.target.gamelist_path())
@@ -1055,6 +1089,7 @@ fn run(
                                 Err(error) => {
                                     progress.failed += 1;
                                     log_scraper_problem(&target_label, &error);
+                                    progress.unresolved(&target_label, error.user_message());
                                     progress.last_problem = Some(error.user_message().to_string());
                                     if fatal_for_run(&error) {
                                         let cancel = cancel_in_flight(&error);
@@ -1072,6 +1107,7 @@ fn run(
                         }
                         Err(error) => {
                             progress.failed += 1;
+                            progress.unresolved(&target_label, error.user_message());
                             progress.last_problem = Some(error.user_message().to_string());
                             if fatal_for_run(&error) {
                                 let cancel = cancel_in_flight(&error);
@@ -1104,7 +1140,7 @@ fn run(
                             );
                         }
                     }
-                    emit(events, &progress);
+                    emit(events, &mut progress);
                 }
             }
         }
@@ -1114,7 +1150,7 @@ fn run(
     progress.activity.clear();
     progress.requests_started = limits.used();
     progress.failed_searches = limits.failed();
-    emit(events, &progress);
+    emit(events, &mut progress);
     flush_pending(pending, &settings, &mut backups, &mut progress, events);
     if let Some(error) = fatal {
         finish_error(events, error, progress);
@@ -1164,6 +1200,7 @@ struct Work {
 fn plan_work(
     targets: Vec<Target>,
     settings: &ScraperSettings,
+    completeness: FillCompleteness,
     progress: &mut Progress,
     cancelled: &AtomicBool,
     events: &SyncSender<Event>,
@@ -1198,6 +1235,7 @@ fn plan_work(
                 .collect::<Vec<_>>(),
             settings.image_policy,
             settings.metadata_policy,
+            completeness,
             &mut |at| {
                 if cancelled.load(Ordering::Relaxed) {
                     return Err(Error::new(ErrorKind::Cancelled, "scrape cancelled"));
@@ -1247,6 +1285,7 @@ fn plan_work(
                             let target_label = current_label(&target);
                             progress.current = target.title;
                             log_scraper_problem(&target_label, &error);
+                            progress.unresolved(&target_label, error.user_message());
                             progress.last_problem = Some(error.user_message().to_string());
                         }
                     }
@@ -1261,6 +1300,9 @@ fn plan_work(
                     .map(|target| target.title.clone())
                     .unwrap_or_default();
                 log_scraper_problem(&gamelist_path.display().to_string(), &error);
+                for target in &targets {
+                    progress.unresolved(&current_label(target), error.user_message());
+                }
                 progress.last_problem = Some(error.user_message().to_string());
             }
         }
@@ -1268,8 +1310,13 @@ fn plan_work(
     Ok(work)
 }
 
-fn emit(events: &SyncSender<Event>, progress: &Progress) {
+fn emit(events: &SyncSender<Event>, progress: &mut Progress) {
+    // Snapshots carry counts only. The unresolved list grows with the run
+    // and travels once, on the terminal event, rather than being cloned
+    // into the event queue for every update of a full-library scrape.
+    let unresolved = std::mem::take(&mut progress.unresolved_games);
     let _ = events.try_send(Event::Progress(progress.clone()));
+    progress.unresolved_games = unresolved;
 }
 
 fn reconcile_alias_platforms(
@@ -1566,6 +1613,7 @@ enum WorkerMessage {
     },
     Target {
         gamelist_path: PathBuf,
+        target_label: String,
         result: Box<Result<Prepared>>,
     },
     Done,
@@ -1573,6 +1621,7 @@ enum WorkerMessage {
 
 struct Prepared {
     target: Target,
+    needs: Needs,
     matched: Option<Match>,
     media: Option<InstalledMedia>,
     media_error: Option<Error>,
@@ -1736,6 +1785,7 @@ fn prepare(
     match lookup.lookup {
         Lookup::NotFound => Ok(Prepared {
             target,
+            needs,
             matched: None,
             media: None,
             media_error: None,
@@ -1746,6 +1796,7 @@ fn prepare(
         }),
         Lookup::Ambiguous(count) => Ok(Prepared {
             target,
+            needs,
             matched: None,
             media: None,
             media_error: None,
@@ -1783,6 +1834,7 @@ fn prepare(
             };
             Ok(Prepared {
                 target,
+                needs,
                 matched: Some(*matched),
                 media,
                 media_error,
@@ -1869,15 +1921,12 @@ fn retry_activity(
 
 struct Pending {
     target: Target,
+    needs: Needs,
     metadata: super::Metadata,
     media: Option<InstalledMedia>,
 }
 
-fn stage(
-    prepared: Prepared,
-    settings: &ScraperSettings,
-    progress: &mut Progress,
-) -> Result<Option<Pending>> {
+fn stage(prepared: Prepared, progress: &mut Progress) -> Result<Option<Pending>> {
     let target_label = current_label(&prepared.target);
     if prepared.not_found {
         log_scraper_detail(&target_label, "no exact ScreenScraper match; skipped");
@@ -1885,6 +1934,7 @@ fn stage(
             progress.manual_matches = prepared.alternatives;
         }
         progress.not_found += 1;
+        progress.unresolved(&target_label, "no match");
         return Ok(None);
     }
     if let Some(count) = prepared.ambiguous {
@@ -1896,6 +1946,7 @@ fn stage(
             progress.manual_matches = prepared.alternatives;
         }
         progress.ambiguous += 1;
+        progress.unresolved(&target_label, &format!("{count} matches"));
         return Ok(None);
     }
     let matched = prepared
@@ -1905,8 +1956,9 @@ fn stage(
     if let Some(error) = prepared.media_error {
         progress.failed += 1;
         log_scraper_problem(&target_label, &error);
+        progress.unresolved(&target_label, error.user_message());
         progress.last_problem = Some(error.user_message().to_string());
-        if settings.metadata_policy == super::MetadataPolicy::Off {
+        if !prepared.needs.metadata {
             return Ok(None);
         }
     }
@@ -1917,8 +1969,9 @@ fn stage(
         );
         progress.no_media += 1;
     }
-    let metadata_selected =
-        settings.metadata_policy != super::MetadataPolicy::Off && matched.metadata.has_value();
+    // Metadata the planning step found complete is left alone even though
+    // the match carries some: an image-only entry writes only its image.
+    let metadata_selected = prepared.needs.metadata && matched.metadata.has_value();
     if prepared.media.is_none() && !metadata_selected {
         if !media_failed {
             progress.unchanged += 1;
@@ -1927,6 +1980,7 @@ fn stage(
     }
     Ok(Some(Pending {
         target: prepared.target,
+        needs: prepared.needs,
         metadata: matched.metadata,
         media: prepared.media,
     }))
@@ -1960,7 +2014,11 @@ fn flush_one_gamelist(
             image_path: item.media.as_ref().map(|media| media.relative_path.clone()),
             image_created: item.media.as_ref().is_some_and(|media| media.created),
             image_policy: settings.image_policy,
-            metadata_policy: settings.metadata_policy,
+            metadata_policy: if item.needs.metadata {
+                settings.metadata_policy
+            } else {
+                super::MetadataPolicy::Off
+            },
         })
         .collect();
     match gamelist_edit::apply_many_with_fallback(
@@ -1992,7 +2050,9 @@ fn flush_one_gamelist(
                     Ok(_) => progress.unchanged += 1,
                     Err(error) => {
                         progress.failed += 1;
-                        log_scraper_problem(&current_label(&item.target), &error);
+                        let target_label = current_label(&item.target);
+                        log_scraper_problem(&target_label, &error);
+                        progress.unresolved(&target_label, error.user_message());
                         progress.last_problem = Some(error.user_message().to_string());
                     }
                 }
@@ -2005,6 +2065,9 @@ fn flush_one_gamelist(
                 .map(|item| item.target.title.clone())
                 .unwrap_or_default();
             log_scraper_problem(&gamelist_path.display().to_string(), &error);
+            for item in &pending {
+                progress.unresolved(&current_label(&item.target), error.user_message());
+            }
             progress.last_problem = Some(error.user_message().to_string());
         }
     }
@@ -2205,8 +2268,18 @@ fn safe_component(value: &str) -> String {
     }
 }
 
+/// Whether one game's failure stops the batch. A request ScreenScraper
+/// rejected, or a match response it served unreadable, concerns that game
+/// alone; transport, login, quota and service outages concern every game
+/// still queued.
 fn fatal_for_run(error: &Error) -> bool {
-    !matches!(error.kind, ErrorKind::Local | ErrorKind::NotFound)
+    !matches!(
+        error.kind,
+        ErrorKind::Local
+            | ErrorKind::NotFound
+            | ErrorKind::InvalidRequest
+            | ErrorKind::MalformedResponse
+    )
 }
 
 fn cancel_in_flight(error: &Error) -> bool {
@@ -3054,23 +3127,210 @@ mod tests {
         let root = temp("batch-continues-after-miss");
         std::fs::write(root.join("Missing.rom"), b"missing").unwrap();
         std::fs::write(root.join("Found.rom"), b"found").unwrap();
-        let Event::Finished(progress) = finish(
-            start_with_transport(
-                request(&root, settings(ImagePolicy::Off)),
-                Arc::new(MixedBatchMock),
-            )
-            .unwrap(),
-        ) else {
-            panic!("batch stopped at an unresolved game");
+        let job = start_with_transport(
+            request(&root, settings(ImagePolicy::Off)),
+            Arc::new(MixedBatchMock),
+        )
+        .unwrap();
+        let mut snapshots = 0;
+        let progress = loop {
+            match job.events.recv_timeout(Duration::from_secs(5)).unwrap() {
+                Event::Progress(progress) => {
+                    snapshots += 1;
+                    assert!(
+                        progress.unresolved_games.is_empty(),
+                        "progress snapshots must not carry the growing unresolved list"
+                    );
+                }
+                Event::Finished(progress) => break progress,
+                Event::Cancelled(_) | Event::Failed { .. } => {
+                    panic!("batch stopped at an unresolved game")
+                }
+            }
         };
+        assert!(snapshots > 0);
         assert_eq!(progress.total, 2);
         assert_eq!(progress.completed, 2);
         assert_eq!(progress.not_found, 1);
         assert_eq!(progress.updated, 1);
         assert!(progress.manual_matches.is_empty());
+        assert_eq!(
+            progress.unresolved_games,
+            vec![UnresolvedGame {
+                label: "Nintendo: Missing".into(),
+                reason: "no match".into(),
+            }],
+            "the report must name the game the run could not write"
+        );
         let gamelist = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();
         assert!(gamelist.contains("<path>./Found.rom</path>"));
         assert!(!gamelist.contains("Missing.rom"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// Answers the hash lookup for `Rejected.rom` with a configured
+    /// response and matches every other game.
+    struct RejectingMock {
+        status: u16,
+        content_type: &'static str,
+        body: &'static str,
+    }
+
+    impl Transport for RejectingMock {
+        fn get(
+            &self,
+            endpoint: &str,
+            params: &[(String, String)],
+            _limit: u64,
+        ) -> Result<HttpResponse> {
+            let parameter = |name: &str| {
+                params
+                    .iter()
+                    .find(|(key, _)| key == name)
+                    .map(|(_, value)| value.as_str())
+                    .unwrap_or_default()
+            };
+            let body = match endpoint {
+                "ssuserInfos.php" => "<Data><ssuser><niveau>1</niveau><maxthreads>1</maxthreads><maxdownloadspeed>256</maxdownloadspeed><requeststoday>0</requeststoday><requestskotoday>0</requestskotoday><maxrequestspermin>60</maxrequestspermin><maxrequestsperday>20</maxrequestsperday><maxrequestskoperday>20</maxrequestskoperday></ssuser></Data>".to_string(),
+                "jeuInfos.php" if parameter("romnom") == "Rejected.rom" => {
+                    return Ok(HttpResponse {
+                        status: self.status,
+                        content_type: Some(self.content_type.into()),
+                        body: self.body.as_bytes().to_vec(),
+                    });
+                }
+                "jeuInfos.php" => {
+                    let md5 = parameter("md5");
+                    format!("<Data><jeux><jeu id='42'><noms><nom region='wor'>Found</nom></noms><rom><rommd5>{md5}</rommd5></rom></jeu></jeux></Data>")
+                }
+                other => panic!("unexpected endpoint {other}"),
+            };
+            Ok(HttpResponse {
+                status: 200,
+                content_type: Some("application/xml".into()),
+                body: body.into_bytes(),
+            })
+        }
+
+        fn get_media(
+            &self,
+            _url: &str,
+            _limit: u64,
+            _max_kib_per_second: Option<u64>,
+        ) -> Result<HttpResponse> {
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn a_rejected_individual_search_is_recorded_and_the_batch_continues() {
+        // One game ScreenScraper refuses, by HTTP 400 or by an error text it
+        // does not document as an outage, is that game's problem: the run
+        // still processes the next game and names the rejected one.
+        for (status, content_type, body) in [
+            (
+                400,
+                "text/plain",
+                "Erreur : Problème dans le nom du fichier rom",
+            ),
+            (
+                200,
+                "text/plain",
+                "Erreur : Problème dans le nom du fichier rom",
+            ),
+        ] {
+            let root = temp(&format!("rejected-search-{status}"));
+            std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
+            std::fs::write(root.join("Zebra.rom"), b"found").unwrap();
+            let Event::Finished(progress) = finish(
+                start_with_transport(
+                    request(&root, settings(ImagePolicy::Off)),
+                    Arc::new(RejectingMock {
+                        status,
+                        content_type,
+                        body,
+                    }),
+                )
+                .unwrap(),
+            ) else {
+                panic!("a rejected search stopped the batch (HTTP {status})");
+            };
+            assert_eq!(progress.completed, 2);
+            assert_eq!(progress.failed, 1);
+            assert_eq!(progress.updated, 1);
+            assert_eq!(
+                progress.unresolved_games,
+                vec![UnresolvedGame {
+                    label: "Nintendo: Rejected".into(),
+                    reason: "ScreenScraper rejected this search".into(),
+                }]
+            );
+            let gamelist = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();
+            assert!(gamelist.contains("<path>./Zebra.rom</path>"));
+            assert!(!gamelist.contains("Rejected.rom"));
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn an_unreadable_match_response_is_recorded_and_the_batch_continues() {
+        let root = temp("unreadable-match");
+        std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
+        std::fs::write(root.join("Zebra.rom"), b"found").unwrap();
+        let Event::Finished(progress) = finish(
+            start_with_transport(
+                request(&root, settings(ImagePolicy::Off)),
+                Arc::new(RejectingMock {
+                    status: 200,
+                    content_type: "application/xml",
+                    body: "<Data><message>no game list here</message></Data>",
+                }),
+            )
+            .unwrap(),
+        ) else {
+            panic!("an unusable match response stopped the batch");
+        };
+        assert_eq!(progress.failed, 1);
+        assert_eq!(progress.updated, 1);
+        assert_eq!(
+            progress.unresolved_games,
+            vec![UnresolvedGame {
+                label: "Nintendo: Rejected".into(),
+                reason: "ScreenScraper response was unreadable".into(),
+            }]
+        );
+        assert!(std::fs::read_to_string(root.join("gamelist.xml"))
+            .unwrap()
+            .contains("<path>./Zebra.rom</path>"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_documented_closure_text_still_stops_the_batch() {
+        let root = temp("closure-text");
+        std::fs::write(root.join("Rejected.rom"), b"rejected").unwrap();
+        std::fs::write(root.join("Zebra.rom"), b"found").unwrap();
+        let Event::Failed { error, progress } = finish(
+            start_with_transport(
+                request(&root, settings(ImagePolicy::Off)),
+                Arc::new(RejectingMock {
+                    status: 200,
+                    content_type: "text/plain",
+                    body: "Erreur : API totalement fermé",
+                }),
+            )
+            .unwrap(),
+        ) else {
+            panic!("a service closure was treated as one game's problem");
+        };
+        assert_eq!(error.kind, ErrorKind::Unavailable);
+        assert_eq!(
+            progress.unresolved_games,
+            vec![UnresolvedGame {
+                label: "Nintendo: Rejected".into(),
+                reason: "ScreenScraper is unavailable".into(),
+            }]
+        );
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -3748,6 +4008,185 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
+    fn mock() -> Arc<Mock> {
+        Arc::new(Mock {
+            api_calls: AtomicUsize::new(0),
+            media_calls: AtomicUsize::new(0),
+            quota_empty: false,
+            bad_media: false,
+            no_media: false,
+        })
+    }
+
+    #[test]
+    fn a_batch_entry_with_an_image_and_one_field_makes_no_request() {
+        let root = temp("batch-one-field-complete");
+        std::fs::write(root.join("Game.rom"), b"game").unwrap();
+        std::fs::write(root.join("art.png"), PNG).unwrap();
+        let xml = "<gameList><game><path>./Game.rom</path><name>Name</name><image>./art.png</image></game></gameList>";
+        std::fs::write(root.join("gamelist.xml"), xml).unwrap();
+        let mock = mock();
+        for scope_root in [request(&root, settings(ImagePolicy::MissingOnly)), {
+            let mut folder = request(&root, settings(ImagePolicy::MissingOnly));
+            folder.scope = Scope::Folder {
+                system_id: "NES".into(),
+                place: crate::browse::Place::Dir(root.clone()),
+                display_name: "Nintendo".into(),
+            };
+            folder
+        }] {
+            let Event::Finished(progress) =
+                finish(start_with_transport(scope_root, mock.clone()).unwrap())
+            else {
+                panic!("complete batch entry did not finish");
+            };
+            assert_eq!(progress.completed, 1);
+            assert_eq!(progress.unchanged, 1);
+            assert_eq!(progress.updated, 0);
+        }
+        assert_eq!(
+            mock.api_calls.load(Ordering::Relaxed),
+            0,
+            "an image plus one stored field is complete for a batch: no lookup"
+        );
+        assert_eq!(mock.media_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            std::fs::read_to_string(root.join("gamelist.xml")).unwrap(),
+            xml
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn scrape_this_game_fills_individual_empty_fields_without_redownloading() {
+        let root = temp("one-game-fills-fields");
+        std::fs::write(root.join("Game.rom"), b"game").unwrap();
+        std::fs::write(root.join("art.png"), PNG).unwrap();
+        std::fs::write(
+            root.join("gamelist.xml"),
+            "<gameList><game><path>./Game.rom</path><name>Local Name</name><image>./art.png</image></game></gameList>",
+        )
+        .unwrap();
+        let mock = mock();
+        let Event::Finished(progress) = finish(
+            start_with_transport(
+                game_request(&root, settings(ImagePolicy::MissingOnly)),
+                mock.clone(),
+            )
+            .unwrap(),
+        ) else {
+            panic!("single-game fill did not finish");
+        };
+        assert_eq!(progress.updated, 1);
+        assert_eq!(
+            mock.api_calls.load(Ordering::Relaxed),
+            2,
+            "account preflight plus the one lookup the chosen game is entitled to"
+        );
+        assert_eq!(mock.media_calls.load(Ordering::Relaxed), 0);
+        let text = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();
+        assert!(text.contains("<name>Local Name</name>"));
+        assert!(text.contains("<desc>Remote description</desc>"));
+        assert!(text.contains("<image>./art.png</image>"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_batch_entry_with_metadata_but_no_image_writes_only_the_image() {
+        let root = temp("batch-image-only");
+        std::fs::write(root.join("Game.rom"), b"game").unwrap();
+        std::fs::write(
+            root.join("gamelist.xml"),
+            "<gameList><game><path>./Game.rom</path><name>Local Name</name></game></gameList>",
+        )
+        .unwrap();
+        let mock = mock();
+        let Event::Finished(progress) = finish(
+            start_with_transport(
+                request(&root, settings(ImagePolicy::MissingOnly)),
+                mock.clone(),
+            )
+            .unwrap(),
+        ) else {
+            panic!("image-only batch entry did not finish");
+        };
+        assert_eq!(progress.updated, 1);
+        assert_eq!(mock.api_calls.load(Ordering::Relaxed), 2);
+        assert_eq!(mock.media_calls.load(Ordering::Relaxed), 1);
+        let text = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();
+        assert!(text.contains("<image>./media/screenscraper/3-42-"));
+        assert!(text.contains("<name>Local Name</name>"));
+        assert!(
+            !text.contains("<desc>"),
+            "metadata the batch found complete is not touched by an image-only match"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_batch_entry_with_an_image_but_no_metadata_writes_only_metadata() {
+        let root = temp("batch-metadata-only");
+        std::fs::write(root.join("Game.rom"), b"game").unwrap();
+        std::fs::write(root.join("art.png"), PNG).unwrap();
+        std::fs::write(
+            root.join("gamelist.xml"),
+            "<gameList><game><path>./Game.rom</path><image>./art.png</image></game></gameList>",
+        )
+        .unwrap();
+        let mock = mock();
+        let Event::Finished(progress) = finish(
+            start_with_transport(
+                request(&root, settings(ImagePolicy::MissingOnly)),
+                mock.clone(),
+            )
+            .unwrap(),
+        ) else {
+            panic!("metadata-only batch entry did not finish");
+        };
+        assert_eq!(progress.updated, 1);
+        assert_eq!(mock.api_calls.load(Ordering::Relaxed), 2);
+        assert_eq!(
+            mock.media_calls.load(Ordering::Relaxed),
+            0,
+            "an existing image is never downloaded again under Missing only"
+        );
+        let text = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();
+        assert!(text.contains("<name>Remote Game</name>"));
+        assert!(text.contains("<image>./art.png</image>"));
+        assert!(!root.join("media").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn replace_existing_still_requests_and_replaces_a_complete_batch_entry() {
+        let root = temp("batch-replace-complete");
+        std::fs::write(root.join("Game.rom"), b"game").unwrap();
+        std::fs::write(root.join("art.png"), PNG).unwrap();
+        std::fs::write(
+            root.join("gamelist.xml"),
+            "<gameList><game><path>./Game.rom</path><name>Name</name><desc>Description</desc><publisher>Publisher</publisher><developer>Developer</developer><releasedate>19910000T000000</releasedate><players>1</players><genre>Action</genre><lang>en</lang><image>./art.png</image></game></gameList>",
+        )
+        .unwrap();
+        let mut replace = settings(ImagePolicy::ReplaceExisting);
+        replace.metadata_policy = MetadataPolicy::ReplaceExisting;
+        let mock = mock();
+        let Event::Finished(progress) =
+            finish(start_with_transport(request(&root, replace), mock.clone()).unwrap())
+        else {
+            panic!("replace scrape did not finish");
+        };
+        assert_eq!(progress.updated, 1);
+        assert_eq!(mock.api_calls.load(Ordering::Relaxed), 2);
+        assert_eq!(mock.media_calls.load(Ordering::Relaxed), 1);
+        let text = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();
+        assert!(text.contains("<name>Remote Game</name>"));
+        assert!(text.contains("<desc>Remote description</desc>"));
+        assert!(text.contains("<image>./media/screenscraper/3-42-"));
+        assert!(!text.contains("<image>./art.png</image>"));
+        assert!(root.join("art.png").is_file(), "the previous file is kept");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     #[test]
     fn all_system_scrape_selects_each_systems_media_without_changing_global_default() {
         struct MediaChoices {
@@ -3844,11 +4283,26 @@ mod tests {
             bad_media: false,
             no_media: false,
         });
+        let Event::Finished(progress) = finish(
+            start_with_transport(
+                request(&root, settings(ImagePolicy::MissingOnly)),
+                mock.clone(),
+            )
+            .unwrap(),
+        ) else {
+            panic!("partial metadata batch scrape did not finish");
+        };
+        assert_eq!(progress.unchanged, 1);
+        assert_eq!(
+            mock.api_calls.load(Ordering::Relaxed),
+            0,
+            "a batch treats seven stored fields and an image as complete: one blank optional field must not send the game back every run"
+        );
         for _ in 0..2 {
             let before = mock.api_calls.load(Ordering::Relaxed);
             let event = finish(
                 start_with_transport(
-                    request(&root, settings(ImagePolicy::MissingOnly)),
+                    game_request(&root, settings(ImagePolicy::MissingOnly)),
                     mock.clone(),
                 )
                 .unwrap(),
@@ -3858,7 +4312,7 @@ mod tests {
             };
             assert_eq!(progress.updated, 0);
             assert_eq!(progress.unchanged, 1);
-            assert!(mock.api_calls.load(Ordering::Relaxed) > before, "FillMissing must retry a still absent field; no negative cache is part of this policy");
+            assert!(mock.api_calls.load(Ordering::Relaxed) > before, "Scrape This Game with Fill missing must retry a still absent field; no negative cache is part of this policy");
             assert_eq!(
                 mock.media_calls.load(Ordering::Relaxed),
                 0,
@@ -4018,6 +4472,10 @@ mod tests {
         let pending = |created| {
             vec![Pending {
                 target: target.clone(),
+                needs: Needs {
+                    image: true,
+                    metadata: false,
+                },
                 metadata: super::super::Metadata::default(),
                 media: Some(InstalledMedia {
                     relative_path: relative.clone(),

--- a/src/scraper/worker.rs
+++ b/src/scraper/worker.rs
@@ -91,12 +91,13 @@ pub struct Progress {
     /// server response or interrupting an unattended scrape.
     pub manual_matches: Vec<Match>,
     /// Every game the run attempted and could not resolve, with the
-    /// reason: no match, no searchable title, several matches, no image to
-    /// fetch, or a failed lookup, download or write. A game whose image
-    /// failed but whose metadata was written is listed with the image
-    /// error; games not reached before a failure or cancellation are not
-    /// listed. The report names them after an unattended batch. Carried
-    /// only by the terminal event; progress snapshots leave it empty.
+    /// reason as the report shows it: "no match", "no searchable title",
+    /// the number of matches ("3 matches"), "no image", or the message of
+    /// a failed lookup, download or write. A game whose image failed but
+    /// whose metadata was written is listed with the image error; games
+    /// not reached before a failure or cancellation are not listed. The
+    /// report names them after an unattended batch. Carried only by the
+    /// terminal event; progress snapshots leave it empty.
     pub unresolved_games: Vec<UnresolvedGame>,
 }
 
@@ -1082,7 +1083,7 @@ fn run(
                         Ok(prepared) => {
                             progress.current = target_label.clone();
                             progress.failed_searches = limits.failed();
-                            match stage(prepared, &mut progress) {
+                            match stage(prepared, &target_label, &mut progress) {
                                 Ok(Some(item)) => {
                                     pending
                                         .entry(item.target.gamelist_path())
@@ -1959,27 +1960,37 @@ struct Pending {
     media: Option<InstalledMedia>,
 }
 
-fn stage(prepared: Prepared, progress: &mut Progress) -> Result<Option<Pending>> {
-    let target_label = current_label(&prepared.target);
+fn stage(
+    prepared: Prepared,
+    target_label: &str,
+    progress: &mut Progress,
+) -> Result<Option<Pending>> {
     if let Some(reason) = prepared.not_found {
-        log_scraper_detail(&target_label, "no exact ScreenScraper match; skipped");
+        // A file with no searchable title was never sent to ScreenScraper,
+        // so the log names that reason rather than a miss that did not
+        // happen.
+        if reason == NO_SEARCHABLE_TITLE {
+            log_scraper_detail(target_label, "no searchable title; skipped");
+        } else {
+            log_scraper_detail(target_label, "no exact ScreenScraper match; skipped");
+        }
         if !prepared.alternatives.is_empty() {
             progress.manual_matches = prepared.alternatives;
         }
         progress.not_found += 1;
-        progress.unresolved(&target_label, reason);
+        progress.unresolved(target_label, reason);
         return Ok(None);
     }
     if let Some(count) = prepared.ambiguous {
         log_scraper_detail(
-            &target_label,
+            target_label,
             &format!("{count} automatic ScreenScraper matches; skipped"),
         );
         if !prepared.alternatives.is_empty() {
             progress.manual_matches = prepared.alternatives;
         }
         progress.ambiguous += 1;
-        progress.unresolved(&target_label, &format!("{count} matches"));
+        progress.unresolved(target_label, &format!("{count} matches"));
         return Ok(None);
     }
     let matched = prepared
@@ -1988,8 +1999,8 @@ fn stage(prepared: Prepared, progress: &mut Progress) -> Result<Option<Pending>>
     let media_failed = prepared.media_error.is_some();
     if let Some(error) = prepared.media_error {
         progress.failed += 1;
-        log_scraper_problem(&target_label, &error);
-        progress.unresolved(&target_label, error.user_message());
+        log_scraper_problem(target_label, &error);
+        progress.unresolved(target_label, error.user_message());
         progress.last_problem = Some(error.user_message().to_string());
         if !prepared.needs.metadata {
             return Ok(None);
@@ -1997,7 +2008,7 @@ fn stage(prepared: Prepared, progress: &mut Progress) -> Result<Option<Pending>>
     }
     if prepared.no_media {
         log_scraper_detail(
-            &target_label,
+            target_label,
             "the match has no selected ScreenScraper image",
         );
         progress.no_media += 1;
@@ -2010,7 +2021,7 @@ fn stage(prepared: Prepared, progress: &mut Progress) -> Result<Option<Pending>>
             progress.unchanged += 1;
         }
         if prepared.no_media {
-            progress.unresolved(&target_label, "no image");
+            progress.unresolved(target_label, "no image");
         }
         return Ok(None);
     }
@@ -3032,6 +3043,63 @@ mod tests {
         let gamelist = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();
         assert!(gamelist.contains("<name>Chosen Game</name>"));
         assert!(gamelist.contains("<desc>Description for Chosen Game</desc>"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_selected_match_fills_individual_empty_fields_and_keeps_the_existing_picture() {
+        // Search Manually forces a new search but still applies the chosen
+        // image and metadata policies: with a picture on disk and one
+        // stored field, the selected match fills the empty fields one by
+        // one without fetching the picture it offers or replacing the
+        // local name.
+        let root = temp("selected-match-partial");
+        std::fs::write(root.join("Game.rom"), b"game").unwrap();
+        std::fs::write(root.join("art.png"), PNG).unwrap();
+        std::fs::write(
+            root.join("gamelist.xml"),
+            "<gameList><game><path>./Game.rom</path><name>Local Name</name><image>./art.png</image></game></gameList>",
+        )
+        .unwrap();
+        let mock = Arc::new(Mock {
+            api_calls: AtomicUsize::new(0),
+            media_calls: AtomicUsize::new(0),
+            quota_empty: false,
+            bad_media: false,
+            no_media: false,
+        });
+        let event = finish(
+            start_with_transport_and_cancel_selected(
+                game_request(&root, settings(ImagePolicy::MissingOnly)),
+                mock.clone(),
+                Arc::new(AtomicBool::new(false)),
+                Some(matched("77", "Chosen Game", true)),
+            )
+            .unwrap(),
+        );
+        let Event::Finished(progress) = event else {
+            panic!("selected match on a partial entry did not finish");
+        };
+        assert_eq!(progress.updated, 1);
+        assert_eq!(progress.unchanged, 0);
+        assert_eq!(
+            mock.api_calls.load(Ordering::Relaxed),
+            1,
+            "only the account preflight is made; the selected match replaces the lookup"
+        );
+        assert_eq!(
+            mock.media_calls.load(Ordering::Relaxed),
+            0,
+            "the existing picture is kept under Missing only"
+        );
+        let text = std::fs::read_to_string(root.join("gamelist.xml")).unwrap();
+        assert!(text.contains("<name>Local Name</name>"), "{text}");
+        assert!(!text.contains("Chosen Game</name>"), "{text}");
+        assert!(
+            text.contains("<desc>Description for Chosen Game</desc>"),
+            "{text}"
+        );
+        assert!(text.contains("<image>./art.png</image>"), "{text}");
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/src/scraper/worker_live_tests.rs
+++ b/src/scraper/worker_live_tests.rs
@@ -240,14 +240,16 @@ fn real_service_policy_and_scope_matrix_is_non_destructive() {
         "<game id=\"legacy-id\"><path>./fixture.EXT</path><name>KEEP PARTIAL NAME</name><desc></desc><image>./existing.png</image><thumbnail>./legacy-thumb.png</thumbnail><video>./legacy-video.mp4</video><marquee>./legacy-marquee.png</marquee><rating>0.8</rating><favorite>true</favorite><comments>keep comments</comments><private-field>keep</private-field></game>",
         &config.extension,
     );
+    // One chosen game fills its empty fields one by one; a folder run
+    // would treat the stored name as complete and skip this entry.
     let partial_progress = run_case(
         &config,
         &partial,
-        ScopeKind::Folder,
+        ScopeKind::Game,
         ImagePolicy::Off,
         MetadataPolicy::FillMissing,
     );
-    assert_success(&partial_progress, "partial folder");
+    assert_success(&partial_progress, "partial game");
     let partial_xml = read_gamelist(&partial);
     assert!(partial_xml.contains("<name>KEEP PARTIAL NAME</name>"));
     assert!(partial_xml.contains("<private-field>keep</private-field>"));
@@ -265,6 +267,38 @@ fn real_service_policy_and_scope_matrix_is_non_destructive() {
         std::fs::read(&downloaded).unwrap()
     );
     assert_eq!(backup_count(&partial), 1);
+
+    // The same partially filled entry is complete for a folder run: an
+    // image plus one stored field makes no request and changes nothing.
+    let skipped = suite.case(&config, "partial-folder");
+    std::fs::copy(&downloaded, skipped.join("existing.png"))
+        .expect("copy a real downloaded image into the skipped fixture");
+    write_gamelist(
+        &skipped,
+        "<game><path>./fixture.EXT</path><name>KEEP PARTIAL NAME</name><image>./existing.png</image></game>",
+        &config.extension,
+    );
+    let skipped_xml = read_gamelist(&skipped);
+    let skipped_progress = run_case(
+        &config,
+        &skipped,
+        ScopeKind::Folder,
+        ImagePolicy::MissingOnly,
+        MetadataPolicy::FillMissing,
+    );
+    assert_eq!(
+        skipped_progress.failed, 0,
+        "partial folder recorded a failed target"
+    );
+    assert_eq!(skipped_progress.completed, 1);
+    assert_eq!(skipped_progress.unchanged, 1);
+    assert_eq!(skipped_progress.updated, 0);
+    assert_eq!(
+        skipped_progress.requests_started, 0,
+        "partial folder must not contact ScreenScraper"
+    );
+    assert_eq!(read_gamelist(&skipped), skipped_xml);
+    assert_eq!(backup_count(&skipped), 0);
 
     let complete = suite.case(&config, "complete-game");
     std::fs::copy(&downloaded, complete.join("existing.png"))

--- a/src/scraper/worker_live_tests.rs
+++ b/src/scraper/worker_live_tests.rs
@@ -232,7 +232,7 @@ fn real_service_policy_and_scope_matrix_is_non_destructive() {
     assert!(fresh_xml.contains("<name>"));
     let downloaded = only_downloaded_image(&fresh);
 
-    let partial = suite.case(&config, "partial-folder");
+    let partial = suite.case(&config, "partial-game");
     std::fs::copy(&downloaded, partial.join("existing.png"))
         .expect("copy a real downloaded image into the partial fixture");
     write_gamelist(

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -1129,6 +1129,10 @@ fn run_scraper_unresolved_report_flow(root: &Path, window: Rc<MinimalSoftwareWin
     assert!(!app.scraper_details);
     app.handle(Action::Quit);
     assert_eq!(app.screen, Screen::Browse);
+    assert!(
+        app.scraper_progress.unresolved_games.is_empty(),
+        "the closed report cannot be reopened, so its list is released rather than kept until the next scrape"
+    );
 
     let job = crate::scraper::start(crate::scraper::Request {
         scope: crate::scraper::Scope::All,

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -1052,6 +1052,97 @@ fn run_scraper_cache_refresh_flow(root: &Path, window: Rc<MinimalSoftwareWindow>
     app.ui.hide().unwrap();
 }
 
+fn run_scraper_unresolved_report_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
+    // A batch never stops for a game it cannot write, so the report after
+    // the run is the only place the user can learn which games those were.
+    let mut app = fixture_app(root, window, Settings::default());
+    app.screen = Screen::ScraperProgress;
+    app.scraper_return = Screen::Browse;
+    app.scraper_details = false;
+    app.scraper_terminal = None;
+    app.scraper_progress = crate::scraper::Progress {
+        phase: crate::scraper::Phase::Finishing,
+        scope: "Fixture System".into(),
+        total: 3,
+        completed: 3,
+        unchanged: 1,
+        not_found: 1,
+        failed: 1,
+        unresolved_games: vec![
+            crate::scraper::UnresolvedGame {
+                label: "Fixture System: Missing Game".into(),
+                reason: "no match".into(),
+            },
+            crate::scraper::UnresolvedGame {
+                label: "Fixture System: Rejected Game".into(),
+                reason: "ScreenScraper rejected this search".into(),
+            },
+        ],
+        ..Default::default()
+    };
+    app.begin_scraper_finish(ScraperTerminal::Finished);
+    assert!(
+        !app.scraper_cache_refresh_active,
+        "nothing was written, so no list refresh runs"
+    );
+    assert_eq!(app.scraper_terminal, Some(ScraperTerminal::Finished));
+    assert_eq!(app.scraper_progress_row_count(), SCRAPER_PROGRESS_ROWS + 3);
+    assert_eq!(
+        app.scraper_progress_list.count(),
+        SCRAPER_PROGRESS_ROWS + 3,
+        "the report can scroll to every unresolved game"
+    );
+    assert_eq!(app.scraper_progress_rows().len(), SCRAPER_PROGRESS_ROWS);
+    capture_live_if_requested(&mut app, "scraper-unresolved-overview");
+    app.handle(Action::Accept);
+    assert!(app.scraper_details);
+    app.handle(Action::End);
+    assert_eq!(
+        app.scraper_progress_list.selected(),
+        SCRAPER_PROGRESS_ROWS + 2
+    );
+    app.refresh();
+    let selected = app.rows.row_data(app.ui.get_selected() as usize).unwrap();
+    assert_eq!(selected.title, "Fixture System: Rejected Game");
+    assert_eq!(selected.value, "ScreenScraper rejected this search");
+    capture_live_if_requested(&mut app, "scraper-unresolved-details-end");
+    app.handle(Action::Up);
+    app.handle(Action::Up);
+    app.refresh();
+    let header = app.rows.row_data(app.ui.get_selected() as usize).unwrap();
+    assert_eq!(header.title, "Unresolved games");
+    assert_eq!(header.value, "2");
+    capture_live_if_requested(&mut app, "scraper-unresolved-details-header");
+    app.handle(Action::Quit);
+    assert!(!app.scraper_details);
+    app.handle(Action::Quit);
+    assert_eq!(app.screen, Screen::Browse);
+
+    let job = crate::scraper::start(crate::scraper::Request {
+        scope: crate::scraper::Scope::All,
+        scope_label: "All Systems".into(),
+        systems: Vec::new(),
+        names: browse::DisplayNames::default(),
+        settings: crate::scraper::ScraperSettings::default(),
+        developer: None,
+        artwork_pack_system_ids: std::collections::HashSet::new(),
+    })
+    .unwrap();
+    app.scraper_scope = crate::scraper::Scope::All;
+    app.begin_scraper_job(job, false);
+    assert!(
+        app.scraper_progress.unresolved_games.is_empty(),
+        "a new job starts with an empty report"
+    );
+    assert_eq!(
+        app.scraper_progress_list.count(),
+        SCRAPER_PROGRESS_ROWS,
+        "a new job resets the report to its fixed rows"
+    );
+    app.scraper_job = None;
+    app.ui.hide().unwrap();
+}
+
 fn run_scraper_image_choice_flow(app: &mut App) {
     use crate::scraper::{Scope, ScraperSettings};
     let original = app.scraper_settings.clone();
@@ -3575,6 +3666,7 @@ pub(super) fn run_ui_acceptance_flow(window: Rc<MinimalSoftwareWindow>) {
     run_favorite_information_flow(&root, window.clone());
     run_hold_y_flow(&root, window.clone());
     run_scraper_cache_refresh_flow(&root, window.clone());
+    run_scraper_unresolved_report_flow(&root, window.clone());
     run_indexing_ui_flow(&root, window.clone());
     capture_ui_if_requested(&root, window);
     std::fs::remove_dir_all(root).unwrap();

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -1058,8 +1058,13 @@ fn run_scraper_unresolved_report_flow(root: &Path, window: Rc<MinimalSoftwareWin
     let mut app = fixture_app(root, window, Settings::default());
     app.screen = Screen::ScraperProgress;
     app.scraper_return = Screen::Browse;
-    app.scraper_details = false;
+    app.scraper_details = true;
     app.scraper_terminal = None;
+    app.handle(Action::End);
+    assert_eq!(
+        app.scraper_progress_list.selected(),
+        SCRAPER_PROGRESS_ROWS - 1
+    );
     app.scraper_progress = crate::scraper::Progress {
         phase: crate::scraper::Phase::Finishing,
         scope: "Fixture System".into(),
@@ -1075,7 +1080,7 @@ fn run_scraper_unresolved_report_flow(root: &Path, window: Rc<MinimalSoftwareWin
             },
             crate::scraper::UnresolvedGame {
                 label: "Fixture System: Rejected Game".into(),
-                reason: "ScreenScraper rejected this search".into(),
+                reason: "ScreenScraper rejected this request".into(),
             },
         ],
         ..Default::default()
@@ -1092,7 +1097,14 @@ fn run_scraper_unresolved_report_flow(root: &Path, window: Rc<MinimalSoftwareWin
         SCRAPER_PROGRESS_ROWS + 3,
         "the report can scroll to every unresolved game"
     );
+    assert_eq!(
+        app.scraper_progress_list.selected(),
+        SCRAPER_PROGRESS_ROWS - 1,
+        "a Details view read during the run is not snapped back to the top when the run ends"
+    );
     assert_eq!(app.scraper_progress_rows().len(), SCRAPER_PROGRESS_ROWS);
+    app.handle(Action::Quit);
+    assert!(!app.scraper_details);
     capture_live_if_requested(&mut app, "scraper-unresolved-overview");
     app.handle(Action::Accept);
     assert!(app.scraper_details);
@@ -1104,7 +1116,7 @@ fn run_scraper_unresolved_report_flow(root: &Path, window: Rc<MinimalSoftwareWin
     app.refresh();
     let selected = app.rows.row_data(app.ui.get_selected() as usize).unwrap();
     assert_eq!(selected.title, "Fixture System: Rejected Game");
-    assert_eq!(selected.value, "ScreenScraper rejected this search");
+    assert_eq!(selected.value, "ScreenScraper rejected this request");
     capture_live_if_requested(&mut app, "scraper-unresolved-details-end");
     app.handle(Action::Up);
     app.handle(Action::Up);


### PR DESCRIPTION
## Summary

- Folder, system and all-systems scrapes check the picture and the metadata independently before any ScreenScraper request. Under `Images: Missing only` artwork is requested only when the effective image is absent or its file does not exist. Under `Metadata: Fill missing` a batch run requests metadata only when every one of the eight supported fields is empty, so a game with an existing picture and at least one stored field makes no API or media request.
- An entry with metadata but no picture receives only its picture (the game lookup still supplies the media address; its metadata is not written). An entry with a picture but no metadata receives only metadata and its picture is not downloaded again.
- `Scrape This Game` with `Metadata: Fill missing` keeps filling individual empty fields; `Search Manually` keeps forcing a new search with the selected policies. Neither changes the batch-completeness rule.
- A request ScreenScraper rejects for one game (HTTP 400, one of its documented bad-request texts delivered in a 2xx body, or an error text it does not document answering that game's hash lookup or title search on a successful status) and a `<Data>` match response served unreadable are recorded for that game as `ErrorKind::InvalidRequest` or `ErrorKind::MalformedResponse` and the run continues with the next game. Transport failures, timeouts, authentication failures, rate limits, exhausted allowances, server errors, the documented closure texts, an answer that is neither XML nor an error text, a non-XML content type, a non-UTF-8 body, and an error text ScreenScraper does not document at the account check or on a media transfer still stop the run. The account check runs before the first game, so an undocumented service-wide text present at the start still stops the run there.
- A 2xx error body naming the documented blacklist text, or one of the two documented texts about an incomplete request address ("problème avec l'url", "Il manque des champs obligatoires dans l'url"), is now a configuration failure (Scraper setup needs attention) rather than an outage; both kinds stop the run. The blacklist text matches the existing HTTP 426 mapping of the same text; the address texts concern every game because Degauss sends the same request fields for each.
- Under HTTP 400 every documented error text keeps its own classification: a service-wide text (closure, thread limit, exhausted allowance, refused client, incomplete address) stops the run, a per-request text is that game's rejection with the server's words in the log detail, and a not-found text is that game's miss. Any other text under HTTP 400 is that game's rejection on a lookup or a media transfer, with its words kept in the log detail; on the account check it stays a configuration failure (Scraper setup needs attention) as before. An HTML page, an empty body or a body that is not text under HTTP 400 on a lookup or the account check is reported as "ScreenScraper is unavailable" and stops the run, as the same page does on a successful status.
- A picture download that ScreenScraper answers with HTTP 400 is that game's image failure (listed with "ScreenScraper rejected this request") and the metadata already fetched is still written; previously HTTP 400 on a media transfer stopped the run as a configuration failure.
- A file whose name leaves nothing to search for once its extension and dump tags are removed no longer reaches the empty-title configuration error that stopped the batch: it is counted as missing with the reason "no searchable title", no title search is sent, and a hash lookup is still made when the file can be hashed.
- The completion report lists every game the run attempted and could not resolve, one row per game with its reason ("no match", "no searchable title", the number of matches, "no image", or the message of a failed lookup, download or gamelist write). The list is carried only by the terminal Finished, Cancelled or Failed event; per-event progress snapshots do not carry it. The Details view keeps its selection when the report grows.
- The interface text for a rejected request is "ScreenScraper rejected this request" and the manual-search status is "Request Rejected". Logging change: for a rejection, an unrecognised error text and a non-XML answer, a bounded one-line excerpt of the server text (at most 120 characters) is now written to the local log as part of the error detail, where previously no server body was logged; the values of the `devid`, `devpassword`, `ssid` and `sspassword` query parameters are replaced by "[redacted]" in case a page reflects the request address. Degauss's own request URLs and login data are still never logged.
- An HTML page under HTTP 400 stops the run whatever content type it is served with, or none (a body starting with `<` under that status is treated as a page, since the XML endpoints answer HTTP 400 with text).
- After the run is closed with Quit, the unresolved-games list is released rather than kept until the next scrape.
- An answer that is not a ScreenScraper XML answer (a non-XML content type, a plain notice, an empty body, a page whose root element is not `<Data>`, or text placed before that root, whatever the content type or the lack of one) is reported as "ScreenScraper is unavailable" on every path, including the account check and Search Manually, where it was previously "ScreenScraper response was unreadable". Only a `<Data>` answer whose content is unusable remains a malformed response for that one request.

Fixes #53

## Compatibility

- Existing scraper settings and stored gamelists work without migration or rebuilding; no configuration key, gamelist field or cache format changes.
- `Off`, `Replace existing`, `Images: Missing only` and `Metadata: Fill missing` keep their meanings; `Replace existing` still requests and replaces the selected data.
- No network request is added for entries the previous batch logic already skipped.
- HTTP 429 and 431 keep their status-based kinds and the rate-limit retries.

## Tests

- `a_batch_entry_with_an_image_and_one_field_makes_no_request` proves that an entry with an image and one populated field (the seven others absent, and the seven others written as empty elements) makes zero API and media requests under the All Systems, System and Folder scopes.
- `a_batch_entry_with_metadata_but_no_image_writes_only_the_image` and `a_batch_entry_with_an_image_but_no_metadata_writes_only_metadata` prove the two one-sided updates and that the existing picture is not downloaded again.
- `scrape_this_game_fills_individual_empty_fields_without_redownloading` and `a_selected_match_fills_individual_empty_fields_and_keeps_the_existing_picture` prove the single-game field-by-field fill.
- `replace_existing_still_requests_and_replaces_a_complete_batch_entry` proves the replacement policy is unchanged.
- `a_rejected_individual_search_is_recorded_and_the_batch_continues` and `an_unreadable_match_response_is_recorded_and_the_batch_continues` run HTTP 400, a documented 2xx rejection text, an undocumented 2xx error text and an unreadable body on both the hash lookup and the title search: the game is listed as unresolved and the next game is written.
- `a_file_named_only_by_dump_tags_is_recorded_and_the_batch_continues` proves that no title search or failed-search reservation is spent for a tagless name and the run continues.
- `a_login_rejection_during_the_batch_still_stops_it`, `a_page_instead_of_xml_still_stops_the_batch` (including an HTML page served without a Content-Type header, one served with an XML content type, and an HTML page or empty body under HTTP 400), `a_documented_closure_text_still_stops_the_batch` and the table test `only_one_games_failures_leave_the_rest_of_the_batch_running` prove which failure kinds stay fatal.
- `a_page_without_the_data_root_is_an_outage_whatever_its_content_type` proves the root-element rule on the hash lookup, the title search and the account check, including a non-UTF-8 body and a notice placed between the XML declaration and the root (while whitespace there still parses), and that a cut-short or game-less `<Data>` answer stays a per-request malformed response. `a_page_under_http_400_stops_the_run_and_a_text_names_the_rejection` proves the HTTP 400 page rule (an HTML page under text/html, under an XML content type and with no Content-Type header, an empty body and a non-UTF-8 body), the excerpted rejection text, the account check's configuration classification and the media transfer's per-game classification.
- `run_scraper_unresolved_report_flow` also proves the unresolved list is empty once the report is closed.
- `a_reflected_request_address_is_redacted_from_the_diagnosis` proves the credential query values never reach the log detail, including a value the excerpt cut leaves half in place.
- `only_documented_per_request_error_texts_leave_the_run_going` and `an_undocumented_error_text_is_kept_in_the_diagnosis_but_bounded` cover the error-text classification (an undocumented text is a per-game rejection on a lookup and an outage at the account check or on a media transfer) and the bounded log excerpt; `a_service_wide_text_under_http_400_still_stops_the_run` proves that the documented thread-limit, failed-search allowance, closure, quota, refused-client and incomplete-address texts stop the run under HTTP 400, that a per-request or unrecognised text under HTTP 400 keeps the server's words in the log detail, and that a not-found text under HTTP 400 is the game's miss.
- `a_rejected_image_address_still_writes_the_fetched_metadata` proves a refused media address keeps the fetched metadata.
- `run_scraper_unresolved_report_flow` (UI acceptance) proves the report rows appear after the run and the Details selection is preserved.

## Validation

- Host gates (fmt, test, rehearse, ra, clippy for the ARM target) passed on the pushed head.
- Device validation is pending for the maintainer. Headless checks of an earlier commit of this branch (`--check-install`, `--report` and `--render --screen scraper-progress`) produced the same frames as the baseline build, and no ScreenScraper request was made. A device build of the pushed head and a batch scrape against the live service (skipped complete entries, a rejected individual search continuing the run, the unresolved report in Details) remain to be performed by the maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scraper reports list each unresolved game with a specific reason.
  - Batch scraping skips entries with sufficient metadata, while individual searches complete missing fields separately.
  - Metadata is retained when image retrieval fails or no image is available.
  - Scraping continues past recoverable request, matching and media errors.

- **Bug Fixes**
  - Invalid requests and unavailable responses now show clearer messages.
  - Report selection remains preserved when results refresh and resets correctly for new jobs.
  - Failure handling better distinguishes service, authentication, quota, configuration and matching issues.
  - Error details truncate server messages and redact credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
