### PR TITLE
Remember dismissed degraded Artwork Pack warnings across restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,11 @@
 # Binaries staged for the card; built, not committed.
 /deploy/Scripts/.config/degauss/degauss
 
-# Written by Degauss itself: options, and where you were
+# Written by Degauss itself: options, where you were, and which incomplete
+# Artwork Pack warnings were already shown
 /settings.toml
 /state.toml
+/artwork-pack-warnings.toml
 
 # Staged for the card at build time from assets/logos; not committed twice.
 /deploy/Scripts/.config/degauss/logos/

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /deploy/Scripts/.config/degauss/degauss
 
 # Written by Degauss itself: options, where you were, and which incomplete
-# Artwork Pack warnings were already shown
+# Artwork Pack warnings were already dismissed
 /settings.toml
 /state.toml
 /artwork-pack-warnings.toml

--- a/README.md
+++ b/README.md
@@ -884,16 +884,17 @@ making a request.
 Degauss rechecks a selected database when the system is entered. After Update
 All replaces a style or updates the database, leave and reopen the system to
 load the current files. A damaged database is reported as incomplete once per
-database state: the warning is written down in `artwork-pack-warnings.toml`
-beside `settings.toml`, so it does not come back after a game launch or a
-restart until the selected location, the database content, its health or its
-diagnostic changes. A missing or invalid database is reported every time the
-system is opened; it remains selected and produces no stale or gamelist
-fallback data. Reconnect its storage, repair it through Update All, or choose
-**Gamelist**. The complete diagnostic is still written to `/tmp/degauss.log`
-and printed by `--system <id> --report`; delete `artwork-pack-warnings.toml`
-to see acknowledged warnings again. Games remain browseable and launchable
-from their normal filesystem entries.
+database state: dismissing the warning writes it down in
+`artwork-pack-warnings.toml` beside `settings.toml`, so it does not come back
+after a game launch or a restart until the selected location, the database
+content, its health or its diagnostic changes. A missing or invalid database
+is reported again at every start of Degauss; it remains selected and produces
+no stale or gamelist fallback data. Reconnect its storage, repair it through
+Update All, or choose **Gamelist**. The complete diagnostic is still written
+to `/tmp/degauss.log` and printed by `--system <id> --report`; delete
+`artwork-pack-warnings.toml` and restart Degauss to see acknowledged warnings
+again. Games remain browseable and launchable from their normal filesystem
+entries.
 
 Only systems with a reviewed database mapping show **Game Data Source**.
 Currently supported systems are 3DO, Amiga CD32, Arcade, Atari 2600, Atari

--- a/README.md
+++ b/README.md
@@ -883,11 +883,17 @@ making a request.
 
 Degauss rechecks a selected database when the system is entered. After Update
 All replaces a style or updates the database, leave and reopen the system to
-load the current files. A damaged database is reported as incomplete; a
-missing or invalid database remains selected and produces no stale or
-gamelist fallback data. Reconnect its storage, repair it through Update All,
-or choose **Gamelist**. Games remain browseable and launchable from their
-normal filesystem entries.
+load the current files. A damaged database is reported as incomplete once per
+database state: the warning is written down in `artwork-pack-warnings.toml`
+beside `settings.toml`, so it does not come back after a game launch or a
+restart until the selected location, the database content, its health or its
+diagnostic changes. A missing or invalid database is reported every time the
+system is opened; it remains selected and produces no stale or gamelist
+fallback data. Reconnect its storage, repair it through Update All, or choose
+**Gamelist**. The complete diagnostic is still written to `/tmp/degauss.log`
+and printed by `--system <id> --report`; delete `artwork-pack-warnings.toml`
+to see acknowledged warnings again. Games remain browseable and launchable
+from their normal filesystem entries.
 
 Only systems with a reviewed database mapping show **Game Data Source**.
 Currently supported systems are 3DO, Amiga CD32, Arcade, Atari 2600, Atari

--- a/src/app.rs
+++ b/src/app.rs
@@ -13698,8 +13698,12 @@ impl App {
             self.poll_provider_job();
             self.start_provider_job_if_ready();
             self.poll_information();
+            // A finished cache recovery reopens its system through another
+            // source resolution; that one has to finish as well before the
+            // only frame is drawn.
             if self.build.is_none()
                 && self.information.is_none()
+                && self.source_resolution.is_none()
                 && self.source_job.is_none()
                 && self.provider_job.is_none()
                 && self.provider_requests.is_empty()

--- a/src/app.rs
+++ b/src/app.rs
@@ -2910,6 +2910,9 @@ pub struct App {
     /// A changed provider invalidates its group's entries so a new problem is
     /// still reported, while ordinary re-entry does not repeat the same modal.
     pack_health_shown: HashSet<String>,
+    /// Incomplete-pack warnings already seen in earlier runs, read from the
+    /// card the first time a warning is about to be shown and not before.
+    pack_health_acknowledged: Option<crate::pack_health::Acknowledgements>,
     /// Set while the card is being read into the cache, a system at a time
     /// so the screen can say how far it has got.
     build: Option<Building>,
@@ -3231,6 +3234,7 @@ impl App {
             provider_recovery_needed: HashSet::new(),
             provider_validated: HashSet::new(),
             pack_health_shown: HashSet::new(),
+            pack_health_acknowledged: None,
             build: None,
             index_return_screen: Screen::Browse,
             index_details: false,
@@ -5383,29 +5387,47 @@ impl App {
             return;
         }
         let group = crate::artwork_pack::source_group(&provider.system_id)
-            .unwrap_or(provider.system_id.as_str());
-        let detail = provider
-            .diagnostics
-            .first()
-            .map(String::as_str)
-            .unwrap_or("the selected installation could not be read");
-        let shown_key = format!(
-            "{group}\0{}\0{}\0{detail}",
-            provider.docs_root.display(),
-            provider.health.label()
-        );
+            .unwrap_or(provider.system_id.as_str())
+            .to_string();
+        let digest = provider.health_digest();
+        // The group prefix is what invalidating the group prunes on.
+        let shown_key = format!("{group}\0{digest}");
         if !self.pack_health_shown.insert(shown_key) {
             return;
         }
         let system = provider.system_id.clone();
         let root = provider.docs_root.display().to_string();
         let health = provider.health;
-        let detail = detail.to_string();
+        let detail = if provider.diagnostics.is_empty() {
+            "the selected installation could not be read".to_string()
+        } else {
+            provider.diagnostics.join("; ")
+        };
         crate::note(&format!(
             "artwork pack {} at {}: {detail}",
             health.label(),
             root
         ));
+        // An incomplete pack is still usable, so its warning is worth one
+        // look per snapshot, not one per start: this program exits for every
+        // launch. Unavailable and invalid packs need acting on and are shown
+        // every time. Written when shown, not when dismissed: the message is
+        // modal, and a headless render never dismisses.
+        if health == crate::artwork_pack::ProviderHealth::Degraded {
+            let path = crate::pack_health::path_beside(&self.settings_path);
+            let seen = self
+                .pack_health_acknowledged
+                .get_or_insert_with(|| crate::pack_health::Acknowledgements::load(&path));
+            if seen.acknowledged(&group, &digest) {
+                return;
+            }
+            seen.acknowledge(&group, &digest);
+            if let Err(error) = seen.save(&path) {
+                crate::note(&format!(
+                    "artwork pack warning acknowledgement not saved: {error}"
+                ));
+            }
+        }
         self.message = artwork_pack_health_message(&system, health);
         self.dirty = true;
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -5429,7 +5429,16 @@ impl App {
             let path = crate::pack_health::path_beside(&self.settings_path);
             match crate::pack_health::Acknowledgements::load(&path) {
                 Ok(seen) if seen.acknowledged(&group, &digest) => return,
-                Ok(_) => {
+                // A file that could not be parsed read as empty; the press
+                // that dismisses this warning writes over it, so say why.
+                Ok(seen) => {
+                    if let Some(error) = seen.malformed() {
+                        message = message.map(|message| {
+                            format!(
+                                "{message}\n\nThe list of dismissed warnings could not be read and will be replaced: {error}"
+                            )
+                        });
+                    }
                     self.pack_health_pending = message.clone().map(|message| PendingPackHealth {
                         group,
                         digest,

--- a/src/app.rs
+++ b/src/app.rs
@@ -5430,9 +5430,15 @@ impl App {
             match crate::pack_health::Acknowledgements::load(&path) {
                 Ok(seen) if seen.acknowledged(&group, &digest) => return,
                 // A file that could not be parsed read as empty; the press
-                // that dismisses this warning writes over it, so say why.
+                // that dismisses this warning writes over it, so say why,
+                // here and in the log. The read before that save is the same
+                // file and is not logged again.
                 Ok(seen) => {
                     if let Some(error) = seen.malformed() {
+                        crate::note(&format!(
+                            "artwork pack warnings: {} is malformed: {error}",
+                            path.display()
+                        ));
                         message = message.map(|message| {
                             format!(
                                 "{message}\n\nThe list of dismissed warnings could not be read and will be replaced: {error}"

--- a/src/app.rs
+++ b/src/app.rs
@@ -5434,9 +5434,10 @@ impl App {
             match crate::pack_health::Acknowledgements::load(&path) {
                 Ok(seen) if seen.acknowledged(&group, &digest) => return,
                 // A file that could not be parsed read as empty; the press
-                // that dismisses this warning writes over it, so say why,
-                // here and in the log. The read before that save is the same
-                // file and is not logged again unless it broke meanwhile.
+                // that dismisses this warning writes over it, so say so
+                // here and why in the log. The read before that save is the
+                // same file and is not logged again unless it broke
+                // meanwhile.
                 Ok(seen) => {
                     let malformed_announced = seen.malformed().is_some();
                     if let Some(error) = seen.malformed() {
@@ -5446,7 +5447,7 @@ impl App {
                         ));
                         message = message.map(|message| {
                             format!(
-                                "{message}\n\nThe list of dismissed warnings could not be read and will be replaced: {error}"
+                                "{message}\n\nThe list of dismissed warnings could not be read and will be replaced; see degauss.log."
                             )
                         });
                     }
@@ -5462,7 +5463,7 @@ impl App {
                 Err(error) => {
                     crate::note(&format!("artwork pack warnings not read: {error}"));
                     message = message.map(|message| {
-                        format!("{message}\n\nThis warning cannot be remembered: {error}")
+                        format!("{message}\n\nThis warning cannot be remembered; see degauss.log.")
                     });
                 }
             }
@@ -5475,8 +5476,9 @@ impl App {
     /// it down, so the next start does not put it up again. What is on disk
     /// is read again first, so a deletion made while this program runs
     /// stays deleted. A failure is said on screen with its cause, as a
-    /// settings save failure is. So is a file that broke after the warning
-    /// went up: the save writes over it, and nothing else has said so.
+    /// settings save failure is. A file that broke after the warning went
+    /// up is said too, its cause in the log: the save writes over it, and
+    /// nothing else has said so.
     fn acknowledge_pack_health(&mut self, dismissed: Option<&str>) {
         let Some(pending) = self.pack_health_pending.take() else {
             return;
@@ -5500,9 +5502,8 @@ impl App {
                         "artwork pack warnings: {} is malformed: {error}",
                         path.display()
                     ));
-                    format!(
-                        "The list of dismissed warnings could not be read and was replaced: {error}"
-                    )
+                    "The list of dismissed warnings could not be read and was replaced; see degauss.log."
+                        .to_string()
                 });
                 self.message = match (outcome, replaced) {
                     (SaveOutcome::Durable, None) => None,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1919,6 +1919,17 @@ struct IndexOverview {
     report: String,
 }
 
+/// An incomplete-pack warning on screen, written down once a press
+/// dismisses it and not before: a headless render never dismisses, and
+/// only the press says somebody saw it.
+struct PendingPackHealth {
+    group: String,
+    digest: String,
+    /// The text that was put up. A press that dismisses something else,
+    /// put up over it meanwhile, does not count as having seen this.
+    message: String,
+}
+
 struct Building {
     /// Indices into `all_systems`, in reverse so the next one is popped.
     left: Vec<usize>,
@@ -2910,9 +2921,8 @@ pub struct App {
     /// A changed provider invalidates its group's entries so a new problem is
     /// still reported, while ordinary re-entry does not repeat the same modal.
     pack_health_shown: HashSet<String>,
-    /// Incomplete-pack warnings already seen in earlier runs, read from the
-    /// card the first time a warning is about to be shown and not before.
-    pack_health_acknowledged: Option<crate::pack_health::Acknowledgements>,
+    /// The incomplete-pack warning waiting to be dismissed, if one is up.
+    pack_health_pending: Option<PendingPackHealth>,
     /// Set while the card is being read into the cache, a system at a time
     /// so the screen can say how far it has got.
     build: Option<Building>,
@@ -3234,7 +3244,7 @@ impl App {
             provider_recovery_needed: HashSet::new(),
             provider_validated: HashSet::new(),
             pack_health_shown: HashSet::new(),
-            pack_health_acknowledged: None,
+            pack_health_pending: None,
             build: None,
             index_return_screen: Screen::Browse,
             index_details: false,
@@ -5408,28 +5418,71 @@ impl App {
             health.label(),
             root
         ));
+        let mut message = artwork_pack_health_message(&system, health);
         // An incomplete pack is still usable, so its warning is worth one
         // look per snapshot, not one per start: this program exits for every
         // launch. Unavailable and invalid packs need acting on and are shown
-        // every time. Written when shown, not when dismissed: the message is
-        // modal, and a headless render never dismisses.
+        // again on every start. The file is read each time and never kept
+        // in memory, so a deletion made while this program runs is not
+        // undone by the next save.
         if health == crate::artwork_pack::ProviderHealth::Degraded {
             let path = crate::pack_health::path_beside(&self.settings_path);
-            let seen = self
-                .pack_health_acknowledged
-                .get_or_insert_with(|| crate::pack_health::Acknowledgements::load(&path));
-            if seen.acknowledged(&group, &digest) {
-                return;
+            match crate::pack_health::Acknowledgements::load(&path) {
+                Ok(seen) if seen.acknowledged(&group, &digest) => return,
+                Ok(_) => {
+                    self.pack_health_pending = message.clone().map(|message| PendingPackHealth {
+                        group,
+                        digest,
+                        message,
+                    });
+                }
+                // Nothing is written down over a file that could not be
+                // read: it may hold other groups' acknowledgements.
+                Err(error) => {
+                    crate::note(&format!("artwork pack warnings not read: {error}"));
+                    message = message.map(|message| {
+                        format!("{message}\n\nThis warning cannot be remembered: {error}")
+                    });
+                }
             }
-            seen.acknowledge(&group, &digest);
-            if let Err(error) = seen.save(&path) {
+        }
+        self.message = message;
+        self.dirty = true;
+    }
+
+    /// The press that took an incomplete-pack warning off the screen: write
+    /// it down, so the next start does not put it up again. What is on disk
+    /// is read again first, so a deletion made while this program runs
+    /// stays deleted. A failure is said on screen with its cause, as a
+    /// settings save failure is.
+    fn acknowledge_pack_health(&mut self, dismissed: Option<&str>) {
+        let Some(pending) = self.pack_health_pending.take() else {
+            return;
+        };
+        if dismissed != Some(pending.message.as_str()) {
+            return;
+        }
+        let path = crate::pack_health::path_beside(&self.settings_path);
+        let outcome = crate::pack_health::Acknowledgements::load(&path).and_then(|mut seen| {
+            seen.acknowledge(&pending.group, &pending.digest);
+            seen.save(&path)
+        });
+        match outcome {
+            Ok(SaveOutcome::Durable) => {}
+            Ok(SaveOutcome::InstalledWithWarning(warning)) => {
+                self.message = Some(format!(
+                    "Artwork Pack warning remembered, but durability could not be confirmed: {warning}"
+                ));
+            }
+            Err(error) => {
                 crate::note(&format!(
                     "artwork pack warning acknowledgement not saved: {error}"
                 ));
+                self.message = Some(format!(
+                    "Artwork Pack warning not remembered, so it returns on the next start: {error}"
+                ));
             }
         }
-        self.message = artwork_pack_health_message(&system, health);
-        self.dirty = true;
     }
 
     fn has_custom_view(&self) -> bool {
@@ -7493,8 +7546,9 @@ impl App {
             if self.scroll_message(action) {
                 return;
             }
-            self.message = None;
+            let dismissed = self.message.take();
             self.dirty = true;
+            self.acknowledge_pack_health(dismissed.as_deref());
             return;
         }
         let Some(editor) = self.theme_editor.as_mut() else {
@@ -11829,8 +11883,9 @@ impl App {
             if self.scroll_message(action) {
                 return None;
             }
-            self.message = None;
+            let dismissed = self.message.take();
             self.dirty = true;
+            self.acknowledge_pack_health(dismissed.as_deref());
             return None;
         }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1928,6 +1928,10 @@ struct PendingPackHealth {
     /// The text that was put up. A press that dismisses something else,
     /// put up over it meanwhile, does not count as having seen this.
     message: String,
+    /// Whether that text already says the acknowledgement file could not
+    /// be parsed and will be written over. A file that breaks after the
+    /// warning went up is only found at the press, which then has to say so.
+    malformed_announced: bool,
 }
 
 struct Building {
@@ -5432,8 +5436,9 @@ impl App {
                 // A file that could not be parsed read as empty; the press
                 // that dismisses this warning writes over it, so say why,
                 // here and in the log. The read before that save is the same
-                // file and is not logged again.
+                // file and is not logged again unless it broke meanwhile.
                 Ok(seen) => {
+                    let malformed_announced = seen.malformed().is_some();
                     if let Some(error) = seen.malformed() {
                         crate::note(&format!(
                             "artwork pack warnings: {} is malformed: {error}",
@@ -5449,6 +5454,7 @@ impl App {
                         group,
                         digest,
                         message,
+                        malformed_announced,
                     });
                 }
                 // Nothing is written down over a file that could not be
@@ -5469,7 +5475,8 @@ impl App {
     /// it down, so the next start does not put it up again. What is on disk
     /// is read again first, so a deletion made while this program runs
     /// stays deleted. A failure is said on screen with its cause, as a
-    /// settings save failure is.
+    /// settings save failure is. So is a file that broke after the warning
+    /// went up: the save writes over it, and nothing else has said so.
     fn acknowledge_pack_health(&mut self, dismissed: Option<&str>) {
         let Some(pending) = self.pack_health_pending.take() else {
             return;
@@ -5479,15 +5486,34 @@ impl App {
         }
         let path = crate::pack_health::path_beside(&self.settings_path);
         let outcome = crate::pack_health::Acknowledgements::load(&path).and_then(|mut seen| {
+            let replaced = seen
+                .malformed()
+                .filter(|_| !pending.malformed_announced)
+                .map(str::to_string);
             seen.acknowledge(&pending.group, &pending.digest);
-            seen.save(&path)
+            seen.save(&path).map(|outcome| (outcome, replaced))
         });
         match outcome {
-            Ok(SaveOutcome::Durable) => {}
-            Ok(SaveOutcome::InstalledWithWarning(warning)) => {
-                self.message = Some(format!(
-                    "Artwork Pack warning remembered, but durability could not be confirmed: {warning}"
-                ));
+            Ok((outcome, replaced)) => {
+                let replaced = replaced.map(|error| {
+                    crate::note(&format!(
+                        "artwork pack warnings: {} is malformed: {error}",
+                        path.display()
+                    ));
+                    format!(
+                        "The list of dismissed warnings could not be read and was replaced: {error}"
+                    )
+                });
+                self.message = match (outcome, replaced) {
+                    (SaveOutcome::Durable, None) => None,
+                    (SaveOutcome::Durable, Some(replaced)) => {
+                        Some(format!("Artwork Pack warning remembered. {replaced}"))
+                    }
+                    (SaveOutcome::InstalledWithWarning(warning), replaced) => Some(format!(
+                        "Artwork Pack warning remembered, but durability could not be confirmed: {warning}{}",
+                        replaced.map(|replaced| format!("\n\n{replaced}")).unwrap_or_default()
+                    )),
+                };
             }
             Err(error) => {
                 crate::note(&format!(

--- a/src/artwork_pack.rs
+++ b/src/artwork_pack.rs
@@ -995,7 +995,13 @@ impl Provider {
                     };
                     field(fingerprint.directory_modified.to_string().as_bytes());
                     for (name, size, modified, content_crc32) in &fingerprint.tables {
-                        field(format!("{name}\0{size}\0{modified}\0{content_crc32:?}").as_bytes());
+                        field(name.as_bytes());
+                        field(size.to_string().as_bytes());
+                        field(modified.to_string().as_bytes());
+                        match content_crc32 {
+                            Some(crc32) => field(crc32.to_string().as_bytes()),
+                            None => field(b"no-crc32"),
+                        }
                     }
                 }
             }

--- a/src/artwork_pack.rs
+++ b/src/artwork_pack.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use quick_xml::events::Event;
 use quick_xml::Reader;
+use sha1::{Digest, Sha1};
 
 use crate::browse::{Details, Kind, Launch, Row};
 use crate::error::{DegaussError, Result};
@@ -971,8 +972,6 @@ impl Provider {
     /// source fingerprint. The system is left out so systems sharing one
     /// mapping share one acknowledgement, as they share one source.
     pub fn health_digest(&self) -> String {
-        use sha1::{Digest, Sha1};
-
         let mut hasher = Sha1::new();
         let mut field = |bytes: &[u8]| {
             hasher.update(bytes);

--- a/src/artwork_pack.rs
+++ b/src/artwork_pack.rs
@@ -965,6 +965,46 @@ impl Provider {
             None => self.health.label().to_string(),
         }
     }
+
+    /// Identity of this snapshot's health, for remembering that its warning
+    /// was seen: the selected root, the health, every diagnostic and the
+    /// source fingerprint. The system is left out so systems sharing one
+    /// mapping share one acknowledgement, as they share one source.
+    pub fn health_digest(&self) -> String {
+        use sha1::{Digest, Sha1};
+
+        let mut hasher = Sha1::new();
+        let mut field = |bytes: &[u8]| {
+            hasher.update(bytes);
+            hasher.update([0]);
+        };
+        field(self.docs_root.to_string_lossy().as_bytes());
+        field(self.health.label().as_bytes());
+        for diagnostic in &self.diagnostics {
+            field(diagnostic.as_bytes());
+        }
+        match self.snapshot.as_ref() {
+            None => field(b"no-snapshot"),
+            Some(SourceFingerprint(directories)) => {
+                for (folder, fingerprint) in directories {
+                    field(folder.as_bytes());
+                    let Some(fingerprint) = fingerprint else {
+                        field(b"absent");
+                        continue;
+                    };
+                    field(fingerprint.directory_modified.to_string().as_bytes());
+                    for (name, size, modified, content_crc32) in &fingerprint.tables {
+                        field(format!("{name}\0{size}\0{modified}\0{content_crc32:?}").as_bytes());
+                    }
+                }
+            }
+        }
+        hasher
+            .finalize()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
 }
 
 fn apply_presentation(row: &mut Row, presentation: PackPresentation) {
@@ -2898,6 +2938,110 @@ mod tests {
         let provider = Provider::load("SuperGrafx", &root, None);
         assert_eq!(provider.health, ProviderHealth::Invalid);
         assert!(!provider.health.usable());
+    }
+
+    #[test]
+    fn health_digest_is_stable_for_an_unchanged_degraded_pack() {
+        let (root, _art) = pack("digest-stable");
+        let first = Provider::load("SuperGrafx", &root, None);
+        assert_eq!(first.health, ProviderHealth::Degraded);
+        let again = Provider::load("SuperGrafx", &root, None);
+        assert_eq!(
+            first.health_digest(),
+            again.health_digest(),
+            "the same pack read by a later process must carry the same acknowledged identity"
+        );
+        assert_eq!(first.health_digest().len(), 40);
+        std::fs::remove_dir_all(root.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn health_digest_is_shared_by_systems_of_one_source_group() {
+        let root = temp("digest-group").join("docs");
+        let art = root.join("NEOGEO/Artwork");
+        std::fs::create_dir_all(&art).unwrap();
+        std::fs::write(
+            art.join("manifest.tsv"),
+            "#key\tstyle\tss_system_id\nOne\tbox-2D\t142\nTwo\tbox-2D\t142\n",
+        )
+        .unwrap();
+        std::fs::write(art.join("One.jpg"), b"jpeg").unwrap();
+        let mvs = Provider::load("NeoGeoMVS", &root, None);
+        let aes = Provider::load("NeoGeo", &root, None);
+        assert_eq!(mvs.health, ProviderHealth::Degraded);
+        assert_eq!(
+            mvs.health_digest(),
+            aes.health_digest(),
+            "one shared source is one warning, whichever member of the group is opened"
+        );
+        let elsewhere = temp("digest-group-elsewhere").join("docs");
+        std::fs::create_dir_all(elsewhere.join("NEOGEO")).unwrap();
+        std::fs::rename(&art, elsewhere.join("NEOGEO/Artwork")).unwrap();
+        assert_ne!(
+            Provider::load("NeoGeo", &elsewhere, None).health_digest(),
+            aes.health_digest(),
+            "the same content at another root is another selection"
+        );
+        std::fs::remove_dir_all(root.parent().unwrap()).ok();
+        std::fs::remove_dir_all(elsewhere.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn health_digest_changes_with_content_diagnostics_and_health() {
+        let (root, art) = pack("digest-changes");
+        ready_tables(&art, "Chosen Game (USA)\t\t\tChosen Game (USA)\n", "");
+        std::fs::write(
+            art.join("manifest.tsv"),
+            "#key\tstyle\tss_system_id\nChosen Game (USA)\tbox-2D\t105\nMissing\tbox-2D\t105\n",
+        )
+        .unwrap();
+        let missing_one = Provider::load("SuperGrafx", &root, None);
+        assert_eq!(missing_one.health, ProviderHealth::Degraded);
+        assert!(missing_one
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.contains("1 manifest images are missing")));
+
+        std::fs::write(
+            art.join("manifest.tsv"),
+            "#key\tstyle\tss_system_id\nChosen Game (USA)\tbox-2D\t105\nMissing\tbox-2D\t105\nAlso Missing\tbox-2D\t105\n",
+        )
+        .unwrap();
+        let missing_two = Provider::load("SuperGrafx", &root, None);
+        assert_eq!(missing_two.health, ProviderHealth::Degraded);
+        assert_ne!(
+            missing_one.health_digest(),
+            missing_two.health_digest(),
+            "an updated manifest is a new pack state whose warning has not been seen"
+        );
+
+        std::fs::remove_file(art.join("index.tsv")).unwrap();
+        let no_index = Provider::load("SuperGrafx", &root, None);
+        assert_eq!(no_index.health, ProviderHealth::Degraded);
+        assert_ne!(
+            missing_two.health_digest(),
+            no_index.health_digest(),
+            "a new diagnostic must be reported even when the health label is unchanged"
+        );
+
+        std::fs::write(
+            art.join("manifest.tsv"),
+            "#key\tstyle\tss_system_id\n../escape\tbox-2D\t105\n",
+        )
+        .unwrap();
+        let invalid = Provider::load("SuperGrafx", &root, None);
+        assert_eq!(invalid.health, ProviderHealth::Invalid);
+        assert_ne!(no_index.health_digest(), invalid.health_digest());
+
+        std::fs::remove_dir_all(&art).unwrap();
+        let unavailable = Provider::load("SuperGrafx", &root, None);
+        assert_eq!(unavailable.health, ProviderHealth::Unavailable);
+        assert_ne!(invalid.health_digest(), unavailable.health_digest());
+        assert_eq!(
+            unavailable.health_digest(),
+            Provider::load("SuperGrafx", &root, None).health_digest()
+        );
+        std::fs::remove_dir_all(root.parent().unwrap()).ok();
     }
 
     #[test]

--- a/src/artwork_pack.rs
+++ b/src/artwork_pack.rs
@@ -993,13 +993,13 @@ impl Provider {
                         field(b"absent");
                         continue;
                     };
-                    field(fingerprint.directory_modified.to_string().as_bytes());
+                    field(&fingerprint.directory_modified.to_le_bytes());
                     for (name, size, modified, content_crc32) in &fingerprint.tables {
                         field(name.as_bytes());
-                        field(size.to_string().as_bytes());
-                        field(modified.to_string().as_bytes());
+                        field(&size.to_le_bytes());
+                        field(&modified.to_le_bytes());
                         match content_crc32 {
-                            Some(crc32) => field(crc32.to_string().as_bytes()),
+                            Some(crc32) => field(&crc32.to_le_bytes()),
                             None => field(b"no-crc32"),
                         }
                     }

--- a/src/artwork_pack.rs
+++ b/src/artwork_pack.rs
@@ -972,6 +972,8 @@ impl Provider {
     /// source fingerprint. The system is left out so systems sharing one
     /// mapping share one acknowledgement, as they share one source.
     pub fn health_digest(&self) -> String {
+        use std::fmt::Write as _;
+
         let mut hasher = Sha1::new();
         let mut field = |bytes: &[u8]| {
             hasher.update(bytes);
@@ -998,11 +1000,11 @@ impl Provider {
                 }
             }
         }
-        hasher
-            .finalize()
-            .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect()
+        let mut digest = String::with_capacity(40);
+        for byte in hasher.finalize() {
+            let _ = write!(digest, "{byte:02x}");
+        }
+        digest
     }
 }
 
@@ -3001,6 +3003,23 @@ mod tests {
             .iter()
             .any(|diagnostic| diagnostic.contains("1 manifest images are missing")));
 
+        // A well-formed row added to gameinfo.tsv changes the table's size
+        // and nothing that the diagnostics or the health report: only the
+        // source fingerprint tells this state from the one already seen.
+        ready_tables(
+            &art,
+            "Chosen Game (USA)\t\t\tChosen Game (USA)\n",
+            "Chosen Game (USA)\tChosen Game\t1990\t\t\t\n",
+        );
+        let more_gameinfo = Provider::load("SuperGrafx", &root, None);
+        assert_eq!(more_gameinfo.health, missing_one.health);
+        assert_eq!(more_gameinfo.diagnostics, missing_one.diagnostics);
+        assert_ne!(
+            missing_one.health_digest(),
+            more_gameinfo.health_digest(),
+            "updated pack content with the same diagnostic is a new pack state whose warning has not been seen"
+        );
+
         std::fs::write(
             art.join("manifest.tsv"),
             "#key\tstyle\tss_system_id\nChosen Game (USA)\tbox-2D\t105\nMissing\tbox-2D\t105\nAlso Missing\tbox-2D\t105\n",
@@ -3009,7 +3028,7 @@ mod tests {
         let missing_two = Provider::load("SuperGrafx", &root, None);
         assert_eq!(missing_two.health, ProviderHealth::Degraded);
         assert_ne!(
-            missing_one.health_digest(),
+            more_gameinfo.health_digest(),
             missing_two.health_digest(),
             "an updated manifest is a new pack state whose warning has not been seen"
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -1558,15 +1558,30 @@ fn effective_library_with_sources(
     })
 }
 
+/// What the report says about an Artwork Pack: its health, its root and
+/// every diagnostic. A dismissed warning never shortens this; the complete
+/// diagnostic is what the report is for.
+fn pack_report_lines(provider: &artwork_pack::Provider) -> Vec<String> {
+    let mut lines = vec![
+        format!("source       Artwork Pack ({})", provider.health.label()),
+        format!("pack root    {}", provider.docs_root.display()),
+    ];
+    lines.extend(
+        provider
+            .diagnostics
+            .iter()
+            .map(|diagnostic| format!("pack note    {diagnostic}")),
+    );
+    lines
+}
+
 fn print_report(system: &FoundSystem, effective: &EffectiveLibrary, audit: &browse::Audit) {
     let library = &effective.library;
     println!("system       {} ({})", system.name(), system.category());
     match effective.provider.as_ref() {
         Some(provider) => {
-            println!("source       Artwork Pack ({})", provider.health.label());
-            println!("pack root    {}", provider.docs_root.display());
-            for diagnostic in &provider.diagnostics {
-                println!("pack note    {diagnostic}");
+            for line in pack_report_lines(provider) {
+                println!("{line}");
             }
         }
         None => println!("source       Gamelist"),
@@ -2002,11 +2017,22 @@ category = "Favorites"
         seen.save(&pack_health::path_beside(&loaded.settings_path))
             .unwrap();
 
+        let report = pack_report_lines(provider);
+        assert_eq!(
+            report
+                .iter()
+                .filter(|line| line.starts_with("pack note    "))
+                .count(),
+            provider.diagnostics.len(),
+            "every diagnostic is a line of the report: {report:?}"
+        );
+
         let after = effective_library(&loaded, &loaded.systems[0]).unwrap();
         let acknowledged = after.provider.as_ref().unwrap();
         assert_eq!(acknowledged.health, artwork_pack::ProviderHealth::Degraded);
         assert_eq!(
-            acknowledged.diagnostics, provider.diagnostics,
+            pack_report_lines(acknowledged),
+            report,
             "a dismissed warning must not shorten what --report says about the pack"
         );
         std::fs::remove_dir_all(root).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -876,7 +876,6 @@ pub fn note(line: &str) {
     }
 }
 
-/// Beside the settings, which is beside the configuration.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 /// Write a favourite for every line of a list.
 ///
@@ -1036,6 +1035,7 @@ fn import_favorites(loaded: &Loaded, list: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Beside the settings, which is beside the configuration.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn state_path_for(settings: &Path) -> PathBuf {
     settings

--- a/src/main.rs
+++ b/src/main.rs
@@ -1954,6 +1954,65 @@ category = "Favorites"
     }
 
     #[test]
+    fn a_report_of_an_incomplete_pack_keeps_every_diagnostic_once_its_warning_was_dismissed() {
+        // The acknowledgement silences the screen, never the report: the
+        // complete diagnostic is what a person runs `--report` for, and it
+        // must read the same before and after the warning was dismissed.
+        let (root, mut loaded) = diagnostic_fixture("acknowledged-report");
+        let docs = root.join("docs");
+        let artwork = docs.join("NES/Artwork");
+        std::fs::create_dir_all(&artwork).unwrap();
+        std::fs::write(root.join("games/NES/Known.nes"), b"first rom").unwrap();
+        std::fs::write(root.join("games/NES/Second.nes"), b"second rom").unwrap();
+        std::fs::write(
+            artwork.join("manifest.tsv"),
+            "#key\tstyle\tss_system_id\nKnown\tbox-2D\t3\nSecond\tbox-2D\t3\n",
+        )
+        .unwrap();
+        std::fs::write(
+            artwork.join("index.tsv"),
+            "#name\tcrc\tsize\tkey\nKnown\t\t\tKnown\nSecond\t\t\tSecond\n",
+        )
+        .unwrap();
+        std::fs::write(
+            artwork.join("gameinfo.tsv"),
+            "#key\tname\tyear\tgenre\tdeveloper\tplayers\nKnown\tPack First\t1990\tAction\tStudio\t1\nSecond\tPack Second\t1991\tPuzzle\tStudio\t2\n",
+        )
+        .unwrap();
+        std::fs::write(artwork.join("Known.jpg"), covers::JPEG_16).unwrap();
+        loaded
+            .settings
+            .artwork_pack_roots
+            .insert("NES".into(), docs.to_string_lossy().into_owned());
+
+        let before = effective_library(&loaded, &loaded.systems[0]).unwrap();
+        let provider = before.provider.as_ref().unwrap();
+        assert_eq!(
+            provider.health,
+            artwork_pack::ProviderHealth::Degraded,
+            "{:?}",
+            provider.diagnostics
+        );
+        assert!(
+            !provider.diagnostics.is_empty(),
+            "an incomplete pack has something to report"
+        );
+        let mut seen = pack_health::Acknowledgements::default();
+        seen.acknowledge("NES", &provider.health_digest());
+        seen.save(&pack_health::path_beside(&loaded.settings_path))
+            .unwrap();
+
+        let after = effective_library(&loaded, &loaded.systems[0]).unwrap();
+        let acknowledged = after.provider.as_ref().unwrap();
+        assert_eq!(acknowledged.health, artwork_pack::ProviderHealth::Degraded);
+        assert_eq!(
+            acknowledged.diagnostics, provider.diagnostics,
+            "a dismissed warning must not shorten what --report says about the pack"
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn diagnostic_favorite_uses_the_owning_system_core_choice() {
         let (root, mut loaded) = diagnostic_fixture("favorite-owner");
         std::fs::write(root.join("games/NES/Game.fds"), b"path fixture").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ mod launch;
 mod list_state;
 mod metrics;
 mod options;
+mod pack_health;
 mod provider_job;
 mod render;
 mod scraper;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1969,11 +1969,12 @@ category = "Favorites"
     }
 
     #[test]
-    fn a_report_of_an_incomplete_pack_keeps_every_diagnostic_once_its_warning_was_dismissed() {
-        // The acknowledgement silences the screen, never the report: the
-        // complete diagnostic is what a person runs `--report` for, and it
-        // must read the same before and after the warning was dismissed.
-        let (root, mut loaded) = diagnostic_fixture("acknowledged-report");
+    fn a_report_of_an_incomplete_pack_lists_every_diagnostic() {
+        // The complete diagnostic is what a person runs `--report` for: a
+        // report that printed only the first of several, or none, would
+        // send them to the log for what the report is meant to say. A
+        // missing image and a missing table are two diagnostics.
+        let (root, mut loaded) = diagnostic_fixture("incomplete-report");
         let docs = root.join("docs");
         let artwork = docs.join("NES/Artwork");
         std::fs::create_dir_all(&artwork).unwrap();
@@ -1982,11 +1983,6 @@ category = "Favorites"
         std::fs::write(
             artwork.join("manifest.tsv"),
             "#key\tstyle\tss_system_id\nKnown\tbox-2D\t3\nSecond\tbox-2D\t3\n",
-        )
-        .unwrap();
-        std::fs::write(
-            artwork.join("index.tsv"),
-            "#name\tcrc\tsize\tkey\nKnown\t\t\tKnown\nSecond\t\t\tSecond\n",
         )
         .unwrap();
         std::fs::write(
@@ -2000,40 +1996,30 @@ category = "Favorites"
             .artwork_pack_roots
             .insert("NES".into(), docs.to_string_lossy().into_owned());
 
-        let before = effective_library(&loaded, &loaded.systems[0]).unwrap();
-        let provider = before.provider.as_ref().unwrap();
+        let effective = effective_library(&loaded, &loaded.systems[0]).unwrap();
+        let provider = effective.provider.as_ref().unwrap();
         assert_eq!(
             provider.health,
             artwork_pack::ProviderHealth::Degraded,
             "{:?}",
             provider.diagnostics
         );
-        assert!(
-            !provider.diagnostics.is_empty(),
-            "an incomplete pack has something to report"
+        assert_eq!(
+            provider.diagnostics.len(),
+            2,
+            "one line per diagnostic is only proven with more than one: {:?}",
+            provider.diagnostics
         );
-        let mut seen = pack_health::Acknowledgements::default();
-        seen.acknowledge("NES", &provider.health_digest());
-        seen.save(&pack_health::path_beside(&loaded.settings_path))
-            .unwrap();
 
         let report = pack_report_lines(provider);
+        assert_eq!(report[0], "source       Artwork Pack (Degraded)");
         assert_eq!(
             report
                 .iter()
-                .filter(|line| line.starts_with("pack note    "))
-                .count(),
-            provider.diagnostics.len(),
-            "every diagnostic is a line of the report: {report:?}"
-        );
-
-        let after = effective_library(&loaded, &loaded.systems[0]).unwrap();
-        let acknowledged = after.provider.as_ref().unwrap();
-        assert_eq!(acknowledged.health, artwork_pack::ProviderHealth::Degraded);
-        assert_eq!(
-            pack_report_lines(acknowledged),
-            report,
-            "a dismissed warning must not shorten what --report says about the pack"
+                .filter_map(|line| line.strip_prefix("pack note    "))
+                .collect::<Vec<_>>(),
+            provider.diagnostics,
+            "every diagnostic is a line of the report, in order: {report:?}"
         );
         std::fs::remove_dir_all(root).unwrap();
     }

--- a/src/pack_health.rs
+++ b/src/pack_health.rs
@@ -15,19 +15,21 @@
 //! undone by the next save.
 
 use std::collections::BTreeMap;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::{DegaussError, Result};
-use crate::settings::{cleanup_temporary, SaveOutcome};
+use crate::settings::{install_beside_settings, SaveLabels, SaveOutcome};
 
 pub const FILE: &str = "artwork-pack-warnings.toml";
 
 /// Beside the settings, which is beside the configuration.
 pub fn path_beside(settings_path: &Path) -> PathBuf {
-    settings_path.parent().unwrap_or(Path::new(".")).join(FILE)
+    settings_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(FILE)
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -85,13 +87,10 @@ impl Acknowledgements {
         self.degraded.insert(group.to_string(), digest.to_string());
     }
 
-    /// Written beside and moved into place: a file cut short must not be
-    /// read back as a shorter list of warnings already seen. The directory
-    /// is flushed afterwards like the settings are, so the move itself
-    /// survives a power cut; when that flush fails the file is in place and
-    /// the outcome says what could not be confirmed. A temporary file left
-    /// by a failed write or move is removed by the settings writer's
-    /// cleanup, which folds a removal failure into the error.
+    /// Written beside and moved into place by the settings writer's
+    /// install, so a file cut short is never read back as a shorter list of
+    /// warnings already seen, and the outcome says when the move could not
+    /// be confirmed durable.
     pub fn save(&self, path: &Path) -> Result<SaveOutcome> {
         let text = toml::to_string_pretty(self).map_err(|error| {
             DegaussError::malformed("artwork pack warnings", path, error.to_string())
@@ -100,57 +99,18 @@ impl Acknowledgements {
             "# Written by Degauss when an incomplete Artwork Pack warning is dismissed.\n\
              # Delete this file and restart Degauss to see those warnings again.\n\n{text}"
         );
-        let parent = path
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-            .unwrap_or_else(|| Path::new("."));
-        let temporary = parent.join(format!(".{FILE}.degauss-{}.tmp", std::process::id()));
-        let mut file = std::fs::File::create(&temporary).map_err(|error| {
-            DegaussError::io(
-                "creating temporary artwork pack warnings",
-                &temporary,
-                error,
-            )
-        })?;
-        let written: Result<()> = (|| {
-            file.write_all(body.as_bytes()).map_err(|error| {
-                DegaussError::io("writing temporary artwork pack warnings", &temporary, error)
-            })?;
-            file.sync_all().map_err(|error| {
-                DegaussError::io(
-                    "flushing temporary artwork pack warnings",
-                    &temporary,
-                    error,
-                )
-            })?;
-            Ok(())
-        })();
-        drop(file);
-        if let Err(error) = written {
-            return Err(cleanup_temporary(
-                "writing artwork pack warnings",
-                &temporary,
-                error,
-            ));
-        }
-        if let Err(error) = std::fs::rename(&temporary, path) {
-            let error = DegaussError::io("installing artwork pack warnings", path, error);
-            return Err(cleanup_temporary(
-                "writing artwork pack warnings",
-                &temporary,
-                error,
-            ));
-        }
-        match std::fs::File::open(parent).and_then(|directory| directory.sync_all()) {
-            Ok(()) => Ok(SaveOutcome::Durable),
-            Err(error) => Ok(SaveOutcome::InstalledWithWarning(DegaussError::io(
-                "flushing artwork pack warnings directory",
-                parent,
-                error,
-            ))),
-        }
+        install_beside_settings(&LABELS, path, &body)
     }
 }
+
+const LABELS: SaveLabels = SaveLabels {
+    creating_temporary: "creating temporary artwork pack warnings",
+    writing_temporary: "writing temporary artwork pack warnings",
+    flushing_temporary: "flushing temporary artwork pack warnings",
+    writing: "writing artwork pack warnings",
+    installing: "installing artwork pack warnings",
+    flushing_directory: "flushing artwork pack warnings directory",
+};
 
 #[cfg(test)]
 mod tests {
@@ -274,6 +234,29 @@ mod tests {
         assert!(
             text.contains("restart Degauss"),
             "the reset instruction must say that a running program keeps its own list"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_leftover_temporary_file_is_stepped_around_not_written_over() {
+        let dir = temp("leftover");
+        let path = dir.join(FILE);
+        let leftover = dir.join(format!(".{FILE}.degauss-{}-0.tmp", std::process::id()));
+        std::fs::write(&leftover, b"left by an interrupted run").unwrap();
+        let mut seen = Acknowledgements::default();
+        seen.acknowledge("NES", "abc");
+        seen.save(&path).unwrap();
+        assert!(
+            Acknowledgements::load(&path)
+                .unwrap()
+                .acknowledged("NES", "abc"),
+            "a name already taken must not stop the save"
+        );
+        assert_eq!(
+            std::fs::read(&leftover).unwrap(),
+            b"left by an interrupted run",
+            "a file already at the temporary name is not this save's to truncate"
         );
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/src/pack_health.rs
+++ b/src/pack_health.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{DegaussError, Result};
-use crate::settings::SaveOutcome;
+use crate::settings::{cleanup_temporary, SaveOutcome};
 
 pub const FILE: &str = "artwork-pack-warnings.toml";
 
@@ -90,8 +90,8 @@ impl Acknowledgements {
     /// is flushed afterwards like the settings are, so the move itself
     /// survives a power cut; when that flush fails the file is in place and
     /// the outcome says what could not be confirmed. A temporary file left
-    /// by a failed write or move is removed, and when that fails too the
-    /// error says so, as the settings writer does.
+    /// by a failed write or move is removed by the settings writer's
+    /// cleanup, which folds a removal failure into the error.
     pub fn save(&self, path: &Path) -> Result<SaveOutcome> {
         let text = toml::to_string_pretty(self).map_err(|error| {
             DegaussError::malformed("artwork pack warnings", path, error.to_string())
@@ -127,11 +127,19 @@ impl Acknowledgements {
         })();
         drop(file);
         if let Err(error) = written {
-            return Err(cleanup_temporary(&temporary, error));
+            return Err(cleanup_temporary(
+                "writing artwork pack warnings",
+                &temporary,
+                error,
+            ));
         }
         if let Err(error) = std::fs::rename(&temporary, path) {
             let error = DegaussError::io("installing artwork pack warnings", path, error);
-            return Err(cleanup_temporary(&temporary, error));
+            return Err(cleanup_temporary(
+                "writing artwork pack warnings",
+                &temporary,
+                error,
+            ));
         }
         match std::fs::File::open(parent).and_then(|directory| directory.sync_all()) {
             Ok(()) => Ok(SaveOutcome::Durable),
@@ -141,23 +149,6 @@ impl Acknowledgements {
                 error,
             ))),
         }
-    }
-}
-
-/// The failure that stopped the save, with the leftover temporary file
-/// removed; when even that fails the error says so, because a stray file
-/// beside the settings is worth knowing about.
-fn cleanup_temporary(path: &Path, error: DegaussError) -> DegaussError {
-    match std::fs::remove_file(path) {
-        Ok(()) => error,
-        Err(cleanup) if cleanup.kind() == std::io::ErrorKind::NotFound => error,
-        Err(cleanup) => DegaussError::unsupported(
-            "writing artwork pack warnings",
-            format!(
-                "{error}; removing the temporary file {} also failed: {cleanup}",
-                path.display()
-            ),
-        ),
     }
 }
 
@@ -335,33 +326,6 @@ mod tests {
             names,
             vec![FILE.to_string()],
             "the written temporary file must not be left beside the settings"
-        );
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
-
-    #[test]
-    fn a_temporary_file_that_cannot_be_removed_is_part_of_the_reported_failure() {
-        let dir = temp("stuck");
-        let stuck = dir.join("stuck.tmp");
-        std::fs::create_dir(&stuck).unwrap();
-        let error = cleanup_temporary(
-            &stuck,
-            DegaussError::unsupported("writing artwork pack warnings", "the save failed"),
-        );
-        let text = error.to_string();
-        assert!(
-            text.contains("the save failed") && text.contains("also failed"),
-            "both failures must reach the screen, or a stray file goes unexplained: {text}"
-        );
-        assert!(text.contains(&stuck.display().to_string()));
-        let gone = cleanup_temporary(
-            &dir.join("never-written.tmp"),
-            DegaussError::unsupported("writing artwork pack warnings", "the save failed"),
-        );
-        assert_eq!(
-            gone.to_string(),
-            "writing artwork pack warnings unsupported: the save failed",
-            "a temporary file that was never written is nothing to report"
         );
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/src/pack_health.rs
+++ b/src/pack_health.rs
@@ -3,14 +3,16 @@
 //! An incomplete Pack stays usable, and its warning is worth one look, not
 //! one per start: launching a game ends this program, so a warning kept only
 //! in memory came back on every return. This file holds, per source group,
-//! the identity of the snapshot whose warning was shown. A pack that is
+//! the identity of the snapshot whose warning was dismissed. A pack that is
 //! unavailable or invalid is never written here; those need acting on and
-//! are shown every time.
+//! are shown again on every start.
 //!
 //! Kept apart from `state.toml`, which a cold start deletes, and from
 //! `settings.toml`, which refuses to start on a broken value. This file may
 //! be missing, stale or broken and the only cost is one more warning, which
-//! the next acknowledgement then replaces.
+//! the next acknowledgement then replaces. Read fresh each time it is
+//! needed, never cached: deleting it while this program runs must not be
+//! undone by the next save.
 
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -19,6 +21,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{DegaussError, Result};
+use crate::settings::SaveOutcome;
 
 pub const FILE: &str = "artwork-pack-warnings.toml";
 
@@ -35,29 +38,29 @@ pub struct Acknowledgements {
 }
 
 impl Acknowledgements {
-    /// Read it back. A missing file is the normal case; one that cannot be
-    /// read or parsed is written to the log and read as empty, so the
-    /// warning is shown once more and the next acknowledgement replaces it.
-    pub fn load(path: &Path) -> Self {
+    /// Read it back. A missing file is the normal case, and one that cannot
+    /// be parsed is written to the log and read as empty, so the warning is
+    /// shown once more and the next acknowledgement replaces it. A file that
+    /// is there but cannot be read is an error: saving over it would throw
+    /// away every acknowledgement it holds.
+    pub fn load(path: &Path) -> Result<Self> {
         match std::fs::read_to_string(path) {
             Ok(text) => match toml::from_str(&text) {
-                Ok(parsed) => parsed,
+                Ok(parsed) => Ok(parsed),
                 Err(error) => {
                     crate::note(&format!(
                         "artwork pack warnings: {} is malformed: {error}",
                         path.display()
                     ));
-                    Self::default()
+                    Ok(Self::default())
                 }
             },
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Self::default(),
-            Err(error) => {
-                crate::note(&format!(
-                    "artwork pack warnings: reading {} failed: {error}",
-                    path.display()
-                ));
-                Self::default()
-            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(error) => Err(DegaussError::io(
+                "reading artwork pack warnings",
+                path,
+                error,
+            )),
         }
     }
 
@@ -65,7 +68,7 @@ impl Acknowledgements {
         self.degraded.get(group).is_some_and(|seen| seen == digest)
     }
 
-    /// Record the snapshot whose warning is being shown. One entry per
+    /// Record the snapshot whose warning was dismissed. One entry per
     /// group: an updated pack's warning is for another state, and the old
     /// one is of no further use.
     pub fn acknowledge(&mut self, group: &str, digest: &str) {
@@ -73,14 +76,17 @@ impl Acknowledgements {
     }
 
     /// Written beside and moved into place: a file cut short must not be
-    /// read back as a shorter list of warnings already seen.
-    pub fn save(&self, path: &Path) -> Result<()> {
+    /// read back as a shorter list of warnings already seen. The directory
+    /// is flushed afterwards like the settings are, so the move itself
+    /// survives a power cut; when that flush fails the file is in place and
+    /// the outcome says what could not be confirmed.
+    pub fn save(&self, path: &Path) -> Result<SaveOutcome> {
         let text = toml::to_string_pretty(self).map_err(|error| {
             DegaussError::malformed("artwork pack warnings", path, error.to_string())
         })?;
         let body = format!(
-            "# Written by Degauss when an incomplete Artwork Pack warning is shown.\n\
-             # Delete this file to see those warnings again.\n\n{text}"
+            "# Written by Degauss when an incomplete Artwork Pack warning is dismissed.\n\
+             # Delete this file and restart Degauss to see those warnings again.\n\n{text}"
         );
         let parent = path
             .parent()
@@ -108,7 +114,15 @@ impl Acknowledgements {
         if outcome.is_err() {
             let _ = std::fs::remove_file(&temporary);
         }
-        outcome
+        outcome?;
+        match std::fs::File::open(parent).and_then(|directory| directory.sync_all()) {
+            Ok(()) => Ok(SaveOutcome::Durable),
+            Err(error) => Ok(SaveOutcome::InstalledWithWarning(DegaussError::io(
+                "flushing artwork pack warnings directory",
+                parent,
+                error,
+            ))),
+        }
     }
 }
 
@@ -131,12 +145,15 @@ mod tests {
         assert_eq!(path, dir.join(FILE));
         let mut seen = Acknowledgements::default();
         seen.acknowledge("NES", "abc");
-        seen.save(&path).unwrap();
+        assert!(
+            matches!(seen.save(&path).unwrap(), SaveOutcome::Durable),
+            "a save into a writable directory is complete, file and directory alike"
+        );
 
-        let read = Acknowledgements::load(&path);
+        let read = Acknowledgements::load(&path).unwrap();
         assert!(
             read.acknowledged("NES", "abc"),
-            "a warning shown before a game must stay acknowledged in the next process"
+            "a warning dismissed before a game must stay acknowledged in the next process"
         );
         assert!(
             !read.acknowledged("NES", "abd"),
@@ -152,7 +169,7 @@ mod tests {
     #[test]
     fn a_missing_file_acknowledges_nothing() {
         let dir = temp("missing");
-        let read = Acknowledgements::load(&dir.join(FILE));
+        let read = Acknowledgements::load(&dir.join(FILE)).unwrap();
         assert!(!read.acknowledged("NES", "abc"));
         std::fs::remove_dir_all(&dir).unwrap();
     }
@@ -162,14 +179,31 @@ mod tests {
         let dir = temp("malformed");
         let path = dir.join(FILE);
         std::fs::write(&path, "degraded = 3\n[[[").unwrap();
-        let mut read = Acknowledgements::load(&path);
+        let mut read = Acknowledgements::load(&path).unwrap();
         assert!(
             !read.acknowledged("NES", "abc"),
             "a broken file must cost one more warning, never a refusal to start"
         );
         read.acknowledge("NES", "abc");
         read.save(&path).unwrap();
-        assert!(Acknowledgements::load(&path).acknowledged("NES", "abc"));
+        assert!(Acknowledgements::load(&path)
+            .unwrap()
+            .acknowledged("NES", "abc"));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_file_that_cannot_be_read_is_an_error_not_an_empty_list() {
+        let dir = temp("unreadable");
+        let path = dir.join(FILE);
+        std::fs::create_dir_all(&path).unwrap();
+        let error = Acknowledgements::load(&path).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .starts_with("reading artwork pack warnings failed for"),
+            "a read failure must be reported, not read as nothing acknowledged: {error}"
+        );
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
@@ -204,11 +238,15 @@ mod tests {
             text.starts_with("# Written by Degauss"),
             "the file says what it is for and how to reset it"
         );
+        assert!(
+            text.contains("restart Degauss"),
+            "the reset instruction must say that a running program keeps its own list"
+        );
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
     #[test]
-    fn a_save_that_cannot_install_reports_its_error() {
+    fn a_save_whose_temporary_file_cannot_be_created_reports_its_error() {
         let dir = temp("blocked");
         let blocked = dir.join("not-a-directory");
         std::fs::write(&blocked, b"file").unwrap();
@@ -216,8 +254,15 @@ mod tests {
         seen.acknowledge("NES", "abc");
         let error = seen.save(&blocked.join(FILE)).unwrap_err();
         assert!(
-            error.to_string().contains("artwork pack warnings"),
-            "a failed save must say what failed: {error}"
+            error
+                .to_string()
+                .starts_with("writing temporary artwork pack warnings failed for"),
+            "a failed save must say which step failed: {error}"
+        );
+        assert_eq!(
+            std::fs::read(&blocked).unwrap(),
+            b"file",
+            "a failed save must leave what was in the way alone"
         );
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/src/pack_health.rs
+++ b/src/pack_health.rs
@@ -1,0 +1,224 @@
+//! Artwork Pack warnings already seen, remembered across a game.
+//!
+//! An incomplete Pack stays usable, and its warning is worth one look, not
+//! one per start: launching a game ends this program, so a warning kept only
+//! in memory came back on every return. This file holds, per source group,
+//! the identity of the snapshot whose warning was shown. A pack that is
+//! unavailable or invalid is never written here; those need acting on and
+//! are shown every time.
+//!
+//! Kept apart from `state.toml`, which a cold start deletes, and from
+//! `settings.toml`, which refuses to start on a broken value. This file may
+//! be missing, stale or broken and the only cost is one more warning, which
+//! the next acknowledgement then replaces.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{DegaussError, Result};
+
+pub const FILE: &str = "artwork-pack-warnings.toml";
+
+/// Beside the settings, which is beside the configuration.
+pub fn path_beside(settings_path: &Path) -> PathBuf {
+    settings_path.parent().unwrap_or(Path::new(".")).join(FILE)
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Acknowledgements {
+    /// Source group to the health digest whose incomplete warning was shown.
+    #[serde(default)]
+    degraded: BTreeMap<String, String>,
+}
+
+impl Acknowledgements {
+    /// Read it back. A missing file is the normal case; one that cannot be
+    /// read or parsed is written to the log and read as empty, so the
+    /// warning is shown once more and the next acknowledgement replaces it.
+    pub fn load(path: &Path) -> Self {
+        match std::fs::read_to_string(path) {
+            Ok(text) => match toml::from_str(&text) {
+                Ok(parsed) => parsed,
+                Err(error) => {
+                    crate::note(&format!(
+                        "artwork pack warnings: {} is malformed: {error}",
+                        path.display()
+                    ));
+                    Self::default()
+                }
+            },
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Self::default(),
+            Err(error) => {
+                crate::note(&format!(
+                    "artwork pack warnings: reading {} failed: {error}",
+                    path.display()
+                ));
+                Self::default()
+            }
+        }
+    }
+
+    pub fn acknowledged(&self, group: &str, digest: &str) -> bool {
+        self.degraded.get(group).is_some_and(|seen| seen == digest)
+    }
+
+    /// Record the snapshot whose warning is being shown. One entry per
+    /// group: an updated pack's warning is for another state, and the old
+    /// one is of no further use.
+    pub fn acknowledge(&mut self, group: &str, digest: &str) {
+        self.degraded.insert(group.to_string(), digest.to_string());
+    }
+
+    /// Written beside and moved into place: a file cut short must not be
+    /// read back as a shorter list of warnings already seen.
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let text = toml::to_string_pretty(self).map_err(|error| {
+            DegaussError::malformed("artwork pack warnings", path, error.to_string())
+        })?;
+        let body = format!(
+            "# Written by Degauss when an incomplete Artwork Pack warning is shown.\n\
+             # Delete this file to see those warnings again.\n\n{text}"
+        );
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let temporary = parent.join(format!(".{FILE}.{}.part", std::process::id()));
+        let outcome = (|| {
+            let mut file = std::fs::File::create(&temporary).map_err(|error| {
+                DegaussError::io("writing temporary artwork pack warnings", &temporary, error)
+            })?;
+            file.write_all(body.as_bytes()).map_err(|error| {
+                DegaussError::io("writing temporary artwork pack warnings", &temporary, error)
+            })?;
+            file.sync_all().map_err(|error| {
+                DegaussError::io(
+                    "flushing temporary artwork pack warnings",
+                    &temporary,
+                    error,
+                )
+            })?;
+            drop(file);
+            std::fs::rename(&temporary, path)
+                .map_err(|error| DegaussError::io("installing artwork pack warnings", path, error))
+        })();
+        if outcome.is_err() {
+            let _ = std::fs::remove_file(&temporary);
+        }
+        outcome
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp(name: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("degauss-pack-health-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn a_saved_acknowledgement_reads_back_for_its_group_only() {
+        let dir = temp("round-trip");
+        let path = path_beside(&dir.join("settings.toml"));
+        assert_eq!(path, dir.join(FILE));
+        let mut seen = Acknowledgements::default();
+        seen.acknowledge("NES", "abc");
+        seen.save(&path).unwrap();
+
+        let read = Acknowledgements::load(&path);
+        assert!(
+            read.acknowledged("NES", "abc"),
+            "a warning shown before a game must stay acknowledged in the next process"
+        );
+        assert!(
+            !read.acknowledged("NES", "abd"),
+            "a changed snapshot is a different warning"
+        );
+        assert!(
+            !read.acknowledged("SNES", "abc"),
+            "one group's acknowledgement must not silence another group's pack"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_missing_file_acknowledges_nothing() {
+        let dir = temp("missing");
+        let read = Acknowledgements::load(&dir.join(FILE));
+        assert!(!read.acknowledged("NES", "abc"));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_malformed_file_acknowledges_nothing_and_is_replaced_by_the_next_save() {
+        let dir = temp("malformed");
+        let path = dir.join(FILE);
+        std::fs::write(&path, "degraded = 3\n[[[").unwrap();
+        let mut read = Acknowledgements::load(&path);
+        assert!(
+            !read.acknowledged("NES", "abc"),
+            "a broken file must cost one more warning, never a refusal to start"
+        );
+        read.acknowledge("NES", "abc");
+        read.save(&path).unwrap();
+        assert!(Acknowledgements::load(&path).acknowledged("NES", "abc"));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_new_snapshot_replaces_the_old_one_and_leaves_other_groups_alone() {
+        let mut seen = Acknowledgements::default();
+        seen.acknowledge("NES", "first");
+        seen.acknowledge("SNES", "other");
+        seen.acknowledge("NES", "second");
+        assert!(
+            !seen.acknowledged("NES", "first"),
+            "the pack was updated; the old snapshot's warning was for another state"
+        );
+        assert!(seen.acknowledged("NES", "second"));
+        assert!(seen.acknowledged("SNES", "other"));
+    }
+
+    #[test]
+    fn saving_leaves_no_temporary_file_beside_the_warnings() {
+        let dir = temp("no-part");
+        let path = dir.join(FILE);
+        let mut seen = Acknowledgements::default();
+        seen.acknowledge("NES", "abc");
+        seen.save(&path).unwrap();
+        let names: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec![FILE.to_string()]);
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            text.starts_with("# Written by Degauss"),
+            "the file says what it is for and how to reset it"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_save_that_cannot_install_reports_its_error() {
+        let dir = temp("blocked");
+        let blocked = dir.join("not-a-directory");
+        std::fs::write(&blocked, b"file").unwrap();
+        let mut seen = Acknowledgements::default();
+        seen.acknowledge("NES", "abc");
+        let error = seen.save(&blocked.join(FILE)).unwrap_err();
+        assert!(
+            error.to_string().contains("artwork pack warnings"),
+            "a failed save must say what failed: {error}"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/src/pack_health.rs
+++ b/src/pack_health.rs
@@ -111,6 +111,8 @@ const LABELS: SaveLabels = SaveLabels {
     writing_temporary: "writing temporary artwork pack warnings",
     flushing_temporary: "flushing temporary artwork pack warnings",
     writing: "writing artwork pack warnings",
+    no_file_name: "artwork pack warnings path has no file name",
+    could_not_reserve: "could not reserve a temporary artwork pack warnings file",
     installing: "installing artwork pack warnings",
     flushing_directory: "flushing artwork pack warnings directory",
 };

--- a/src/pack_health.rs
+++ b/src/pack_health.rs
@@ -44,25 +44,21 @@ pub struct Acknowledgements {
 
 impl Acknowledgements {
     /// Read it back. A missing file is the normal case, and one that cannot
-    /// be parsed is written to the log and read as empty with the reason
-    /// kept in `malformed`, so the warning is shown once more, saying why,
-    /// and the next acknowledgement replaces it. A file that is there but
-    /// cannot be read is an error: saving over it would throw away every
-    /// acknowledgement it holds.
+    /// be parsed is read as empty with the reason kept in `malformed`, so
+    /// the warning is shown once more, saying why, and the next
+    /// acknowledgement replaces it. Nothing is logged here: the file is read
+    /// again before that save, and the caller that puts the warning up
+    /// writes the reason down once. A file that is there but cannot be read
+    /// is an error: saving over it would throw away every acknowledgement
+    /// it holds.
     pub fn load(path: &Path) -> Result<Self> {
         match std::fs::read_to_string(path) {
             Ok(text) => match toml::from_str(&text) {
                 Ok(parsed) => Ok(parsed),
-                Err(error) => {
-                    crate::note(&format!(
-                        "artwork pack warnings: {} is malformed: {error}",
-                        path.display()
-                    ));
-                    Ok(Self {
-                        malformed: Some(error.to_string()),
-                        ..Self::default()
-                    })
-                }
+                Err(error) => Ok(Self {
+                    malformed: Some(error.to_string()),
+                    ..Self::default()
+                }),
             },
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
             Err(error) => Err(DegaussError::io(

--- a/src/pack_health.rs
+++ b/src/pack_health.rs
@@ -35,14 +35,20 @@ pub struct Acknowledgements {
     /// Source group to the health digest whose incomplete warning was shown.
     #[serde(default)]
     degraded: BTreeMap<String, String>,
+    /// Why the file read as empty, when it was there but could not be
+    /// parsed: the warning it would have silenced says so, and that the
+    /// next dismissal writes over it.
+    #[serde(skip)]
+    malformed: Option<String>,
 }
 
 impl Acknowledgements {
     /// Read it back. A missing file is the normal case, and one that cannot
-    /// be parsed is written to the log and read as empty, so the warning is
-    /// shown once more and the next acknowledgement replaces it. A file that
-    /// is there but cannot be read is an error: saving over it would throw
-    /// away every acknowledgement it holds.
+    /// be parsed is written to the log and read as empty with the reason
+    /// kept in `malformed`, so the warning is shown once more, saying why,
+    /// and the next acknowledgement replaces it. A file that is there but
+    /// cannot be read is an error: saving over it would throw away every
+    /// acknowledgement it holds.
     pub fn load(path: &Path) -> Result<Self> {
         match std::fs::read_to_string(path) {
             Ok(text) => match toml::from_str(&text) {
@@ -52,7 +58,10 @@ impl Acknowledgements {
                         "artwork pack warnings: {} is malformed: {error}",
                         path.display()
                     ));
-                    Ok(Self::default())
+                    Ok(Self {
+                        malformed: Some(error.to_string()),
+                        ..Self::default()
+                    })
                 }
             },
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
@@ -66,6 +75,11 @@ impl Acknowledgements {
 
     pub fn acknowledged(&self, group: &str, digest: &str) -> bool {
         self.degraded.get(group).is_some_and(|seen| seen == digest)
+    }
+
+    /// Why the file was read as empty, when that is what happened.
+    pub fn malformed(&self) -> Option<&str> {
+        self.malformed.as_deref()
     }
 
     /// Record the snapshot whose warning was dismissed. One entry per
@@ -184,11 +198,18 @@ mod tests {
             !read.acknowledged("NES", "abc"),
             "a broken file must cost one more warning, never a refusal to start"
         );
+        assert!(
+            read.malformed().is_some(),
+            "the warning shown in its place must be able to say why the file was set aside"
+        );
         read.acknowledge("NES", "abc");
         read.save(&path).unwrap();
-        assert!(Acknowledgements::load(&path)
-            .unwrap()
-            .acknowledged("NES", "abc"));
+        let replaced = Acknowledgements::load(&path).unwrap();
+        assert!(replaced.acknowledged("NES", "abc"));
+        assert!(
+            replaced.malformed().is_none(),
+            "the replacement reads back clean; the reason must not be written into it"
+        );
         std::fs::remove_dir_all(&dir).unwrap();
     }
 

--- a/src/pack_health.rs
+++ b/src/pack_health.rs
@@ -93,7 +93,9 @@ impl Acknowledgements {
     /// read back as a shorter list of warnings already seen. The directory
     /// is flushed afterwards like the settings are, so the move itself
     /// survives a power cut; when that flush fails the file is in place and
-    /// the outcome says what could not be confirmed.
+    /// the outcome says what could not be confirmed. A temporary file left
+    /// by a failed write or move is removed, and when that fails too the
+    /// error says so, as the settings writer does.
     pub fn save(&self, path: &Path) -> Result<SaveOutcome> {
         let text = toml::to_string_pretty(self).map_err(|error| {
             DegaussError::malformed("artwork pack warnings", path, error.to_string())
@@ -106,11 +108,15 @@ impl Acknowledgements {
             .parent()
             .filter(|parent| !parent.as_os_str().is_empty())
             .unwrap_or_else(|| Path::new("."));
-        let temporary = parent.join(format!(".{FILE}.{}.part", std::process::id()));
-        let outcome = (|| {
-            let mut file = std::fs::File::create(&temporary).map_err(|error| {
-                DegaussError::io("writing temporary artwork pack warnings", &temporary, error)
-            })?;
+        let temporary = parent.join(format!(".{FILE}.degauss-{}.tmp", std::process::id()));
+        let mut file = std::fs::File::create(&temporary).map_err(|error| {
+            DegaussError::io(
+                "creating temporary artwork pack warnings",
+                &temporary,
+                error,
+            )
+        })?;
+        let written: Result<()> = (|| {
             file.write_all(body.as_bytes()).map_err(|error| {
                 DegaussError::io("writing temporary artwork pack warnings", &temporary, error)
             })?;
@@ -121,14 +127,16 @@ impl Acknowledgements {
                     error,
                 )
             })?;
-            drop(file);
-            std::fs::rename(&temporary, path)
-                .map_err(|error| DegaussError::io("installing artwork pack warnings", path, error))
+            Ok(())
         })();
-        if outcome.is_err() {
-            let _ = std::fs::remove_file(&temporary);
+        drop(file);
+        if let Err(error) = written {
+            return Err(cleanup_temporary(&temporary, error));
         }
-        outcome?;
+        if let Err(error) = std::fs::rename(&temporary, path) {
+            let error = DegaussError::io("installing artwork pack warnings", path, error);
+            return Err(cleanup_temporary(&temporary, error));
+        }
         match std::fs::File::open(parent).and_then(|directory| directory.sync_all()) {
             Ok(()) => Ok(SaveOutcome::Durable),
             Err(error) => Ok(SaveOutcome::InstalledWithWarning(DegaussError::io(
@@ -137,6 +145,23 @@ impl Acknowledgements {
                 error,
             ))),
         }
+    }
+}
+
+/// The failure that stopped the save, with the leftover temporary file
+/// removed; when even that fails the error says so, because a stray file
+/// beside the settings is worth knowing about.
+fn cleanup_temporary(path: &Path, error: DegaussError) -> DegaussError {
+    match std::fs::remove_file(path) {
+        Ok(()) => error,
+        Err(cleanup) if cleanup.kind() == std::io::ErrorKind::NotFound => error,
+        Err(cleanup) => DegaussError::unsupported(
+            "writing artwork pack warnings",
+            format!(
+                "{error}; removing the temporary file {} also failed: {cleanup}",
+                path.display()
+            ),
+        ),
     }
 }
 
@@ -277,13 +302,70 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .starts_with("writing temporary artwork pack warnings failed for"),
+                .starts_with("creating temporary artwork pack warnings failed for"),
             "a failed save must say which step failed: {error}"
         );
         assert_eq!(
             std::fs::read(&blocked).unwrap(),
             b"file",
             "a failed save must leave what was in the way alone"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_save_that_cannot_move_into_place_reports_it_and_leaves_no_temporary_file() {
+        let dir = temp("in-the-way");
+        let path = dir.join(FILE);
+        std::fs::create_dir(&path).unwrap();
+        let mut seen = Acknowledgements::default();
+        seen.acknowledge("NES", "abc");
+        let error = seen.save(&path).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .starts_with("installing artwork pack warnings failed for"),
+            "the move is the step that failed, and the error must say so: {error}"
+        );
+        assert!(
+            !error.to_string().contains("also failed"),
+            "a temporary file that was removed is not part of the failure: {error}"
+        );
+        let names: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec![FILE.to_string()],
+            "the written temporary file must not be left beside the settings"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_temporary_file_that_cannot_be_removed_is_part_of_the_reported_failure() {
+        let dir = temp("stuck");
+        let stuck = dir.join("stuck.tmp");
+        std::fs::create_dir(&stuck).unwrap();
+        let error = cleanup_temporary(
+            &stuck,
+            DegaussError::unsupported("writing artwork pack warnings", "the save failed"),
+        );
+        let text = error.to_string();
+        assert!(
+            text.contains("the save failed") && text.contains("also failed"),
+            "both failures must reach the screen, or a stray file goes unexplained: {text}"
+        );
+        assert!(text.contains(&stuck.display().to_string()));
+        let gone = cleanup_temporary(
+            &dir.join("never-written.tmp"),
+            DegaussError::unsupported("writing artwork pack warnings", "the save failed"),
+        );
+        assert_eq!(
+            gone.to_string(),
+            "writing artwork pack warnings unsupported: the save failed",
+            "a temporary file that was never written is nothing to report"
         );
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/src/pack_health.rs
+++ b/src/pack_health.rs
@@ -46,22 +46,25 @@ pub struct Acknowledgements {
 
 impl Acknowledgements {
     /// Read it back. A missing file is the normal case, and one that cannot
-    /// be parsed is read as empty with the reason kept in `malformed`, so
-    /// the warning is shown once more, saying why, and the next
-    /// acknowledgement replaces it. Nothing is logged here: the file is read
-    /// again before that save, and the caller that puts the warning up
-    /// writes the reason down once. A file that is there but cannot be read
-    /// is an error: saving over it would throw away every acknowledgement
-    /// it holds.
+    /// be parsed, as text or as TOML, is read as empty with the reason kept
+    /// in `malformed`, so the warning is shown once more, saying why, and
+    /// the next acknowledgement replaces it. Nothing is logged here: the
+    /// file is read again before that save, and the caller that puts the
+    /// warning up writes the reason down once. A file that is there but
+    /// cannot be read is an error: saving over it would throw away every
+    /// acknowledgement it holds.
     pub fn load(path: &Path) -> Result<Self> {
-        match std::fs::read_to_string(path) {
-            Ok(text) => match toml::from_str(&text) {
-                Ok(parsed) => Ok(parsed),
-                Err(error) => Ok(Self {
-                    malformed: Some(error.to_string()),
+        match std::fs::read(path) {
+            Ok(bytes) => {
+                let parsed = match String::from_utf8(bytes) {
+                    Ok(text) => toml::from_str::<Self>(&text).map_err(|error| error.to_string()),
+                    Err(error) => Err(error.to_string()),
+                };
+                Ok(parsed.unwrap_or_else(|malformed| Self {
+                    malformed: Some(malformed),
                     ..Self::default()
-                }),
-            },
+                }))
+            }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
             Err(error) => Err(DegaussError::io(
                 "reading artwork pack warnings",
@@ -182,6 +185,32 @@ mod tests {
             replaced.malformed().is_none(),
             "the replacement reads back clean; the reason must not be written into it"
         );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_file_that_is_not_text_is_malformed_not_unreadable() {
+        // Bytes that are not UTF-8 are a broken file like broken TOML is:
+        // read as an error, nothing would ever write over it and the
+        // warning would return at every start with no way to dismiss it.
+        let dir = temp("not-text");
+        let path = dir.join(FILE);
+        std::fs::write(&path, [0xff, 0xfe, b'd', b'e', b'g']).unwrap();
+        let mut read = Acknowledgements::load(&path)
+            .expect("a file that is not text costs one more warning, never an error");
+        assert!(!read.acknowledged("NES", "abc"));
+        assert!(
+            read.malformed().is_some(),
+            "the warning shown in its place must be able to say why the file was set aside"
+        );
+        read.acknowledge("NES", "abc");
+        read.save(&path).unwrap();
+        let replaced = Acknowledgements::load(&path).unwrap();
+        assert!(
+            replaced.acknowledged("NES", "abc"),
+            "the next dismissal must replace the broken file"
+        );
+        assert!(replaced.malformed().is_none());
         std::fs::remove_dir_all(&dir).unwrap();
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -313,11 +313,7 @@ fn install_with_directory_sync(
 /// The failure that stopped a save, with the leftover temporary file
 /// removed; when even that fails the error says so under `what`, because
 /// a stray file beside the settings is worth knowing about.
-pub(crate) fn cleanup_temporary(
-    what: &'static str,
-    path: &Path,
-    error: DegaussError,
-) -> DegaussError {
+fn cleanup_temporary(what: &'static str, path: &Path, error: DegaussError) -> DegaussError {
     match std::fs::remove_file(path) {
         Ok(()) => error,
         Err(cleanup) if cleanup.kind() == std::io::ErrorKind::NotFound => error,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -233,9 +233,14 @@ pub(crate) struct SaveLabels {
     pub creating_temporary: &'static str,
     pub writing_temporary: &'static str,
     pub flushing_temporary: &'static str,
-    /// The save as a whole: a temporary file that could not be reserved,
-    /// or one that could not be removed after a failure.
+    /// The save as a whole: a path without a file name, a temporary file
+    /// that could not be reserved, or one that could not be removed after
+    /// a failure.
     pub writing: &'static str,
+    /// The details under `writing` for the first two of those, so each
+    /// writer's message names its own file.
+    pub no_file_name: &'static str,
+    pub could_not_reserve: &'static str,
     pub installing: &'static str,
     pub flushing_directory: &'static str,
 }
@@ -245,6 +250,8 @@ const SETTINGS_LABELS: SaveLabels = SaveLabels {
     writing_temporary: "writing temporary settings",
     flushing_temporary: "flushing temporary settings",
     writing: "writing settings",
+    no_file_name: "settings path has no file name",
+    could_not_reserve: "could not reserve a temporary settings file",
     installing: "installing settings",
     flushing_directory: "flushing settings directory",
 };
@@ -275,9 +282,9 @@ fn install_with_directory_sync(
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
-    let file_name = path.file_name().ok_or_else(|| {
-        DegaussError::unsupported(labels.writing, "the path to write has no file name")
-    })?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| DegaussError::unsupported(labels.writing, labels.no_file_name))?;
     let (temporary, mut handle) = temporary_file(labels, parent, file_name)?;
 
     let write_result: Result<()> = (|| {
@@ -357,7 +364,7 @@ fn temporary_file(
     }
     Err(DegaussError::unsupported(
         labels.writing,
-        "could not reserve a temporary file",
+        labels.could_not_reserve,
     ))
 }
 
@@ -684,5 +691,25 @@ mod tests {
             "a temporary file that was never written is nothing to report, whichever writer asks"
         );
         std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn a_path_without_a_file_name_is_refused_in_each_writers_own_words() {
+        // The install is shared, the words are not: a failure must name the
+        // file it was for, and the settings writer must say exactly what it
+        // said before the install was shared, so nothing reads as a new
+        // failure after an update.
+        let error = Settings::default().save(Path::new("/")).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "writing settings unsupported: settings path has no file name"
+        );
+        let error = crate::pack_health::Acknowledgements::default()
+            .save(Path::new("/"))
+            .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "writing artwork pack warnings unsupported: artwork pack warnings path has no file name"
+        );
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -244,13 +244,13 @@ impl Settings {
         })();
         if let Err(error) = write_result {
             drop(handle);
-            return Err(cleanup_temporary(&temporary, error));
+            return Err(cleanup_temporary("writing settings", &temporary, error));
         }
         drop(handle);
 
         if let Err(error) = std::fs::rename(&temporary, path) {
             let error = DegaussError::io("installing settings", path, error);
-            return Err(cleanup_temporary(&temporary, error));
+            return Err(cleanup_temporary("writing settings", &temporary, error));
         }
 
         match sync_directory(parent) {
@@ -264,12 +264,20 @@ impl Settings {
     }
 }
 
-fn cleanup_temporary(path: &Path, error: DegaussError) -> DegaussError {
+/// The failure that stopped a save, with the leftover temporary file
+/// removed; when even that fails the error says so under `what`, because
+/// a stray file beside the settings is worth knowing about. Shared with
+/// the other writer that installs a file beside the settings.
+pub(crate) fn cleanup_temporary(
+    what: &'static str,
+    path: &Path,
+    error: DegaussError,
+) -> DegaussError {
     match std::fs::remove_file(path) {
         Ok(()) => error,
         Err(cleanup) if cleanup.kind() == std::io::ErrorKind::NotFound => error,
         Err(cleanup) => DegaussError::unsupported(
-            "writing settings",
+            what,
             format!(
                 "{error}; removing the temporary file {} also failed: {cleanup}",
                 path.display()
@@ -598,5 +606,36 @@ mod tests {
         let decoded: Settings = toml::from_str(&encoded).unwrap();
         assert_eq!(decoded.core_choices, settings.core_choices);
         assert_eq!(decoded.core_preference, None);
+    }
+
+    #[test]
+    fn a_temporary_file_that_cannot_be_removed_is_part_of_the_reported_failure() {
+        let dir =
+            std::env::temp_dir().join(format!("degauss-settings-stuck-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let stuck = dir.join("stuck.tmp");
+        std::fs::create_dir_all(&stuck).unwrap();
+        let error = cleanup_temporary(
+            "writing settings",
+            &stuck,
+            DegaussError::unsupported("writing settings", "the save failed"),
+        );
+        let text = error.to_string();
+        assert!(
+            text.contains("the save failed") && text.contains("also failed"),
+            "both failures must reach the screen, or a stray file goes unexplained: {text}"
+        );
+        assert!(text.contains(&stuck.display().to_string()));
+        let gone = cleanup_temporary(
+            "writing artwork pack warnings",
+            &dir.join("never-written.tmp"),
+            DegaussError::unsupported("writing artwork pack warnings", "the save failed"),
+        );
+        assert_eq!(
+            gone.to_string(),
+            "writing artwork pack warnings unsupported: the save failed",
+            "a temporary file that was never written is nothing to report, whichever writer asks"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -223,51 +223,96 @@ impl Settings {
              # The documented defaults live in degauss.toml; delete this file\n\
              # to go back to them.\n\n{text}"
         );
+        install_with_directory_sync(&SETTINGS_LABELS, path, &body, sync_directory)
+    }
+}
 
-        let parent = path
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-            .unwrap_or_else(|| Path::new("."));
-        let file_name = path.file_name().ok_or_else(|| {
-            DegaussError::unsupported("writing settings", "settings path has no file name")
-        })?;
-        let (temporary, mut handle) = temporary_file(parent, file_name)?;
+/// The words each step of a save is reported under. One set per file
+/// written beside the settings, so a failure names the file it was for.
+pub(crate) struct SaveLabels {
+    pub creating_temporary: &'static str,
+    pub writing_temporary: &'static str,
+    pub flushing_temporary: &'static str,
+    /// The save as a whole: a temporary file that could not be reserved,
+    /// or one that could not be removed after a failure.
+    pub writing: &'static str,
+    pub installing: &'static str,
+    pub flushing_directory: &'static str,
+}
 
-        let write_result: Result<()> = (|| {
-            handle.write_all(body.as_bytes()).map_err(|error| {
-                DegaussError::io("writing temporary settings", &temporary, error)
-            })?;
-            handle.sync_all().map_err(|error| {
-                DegaussError::io("flushing temporary settings", &temporary, error)
-            })?;
-            Ok(())
-        })();
-        if let Err(error) = write_result {
-            drop(handle);
-            return Err(cleanup_temporary("writing settings", &temporary, error));
-        }
+const SETTINGS_LABELS: SaveLabels = SaveLabels {
+    creating_temporary: "creating temporary settings",
+    writing_temporary: "writing temporary settings",
+    flushing_temporary: "flushing temporary settings",
+    writing: "writing settings",
+    installing: "installing settings",
+    flushing_directory: "flushing settings directory",
+};
+
+/// Write `body` to a temporary file beside `path`, flush it and move it
+/// into place, then flush the directory so the move itself survives a
+/// power cut. A file cut short is never read back as a shorter one. When
+/// the directory flush fails the file is in place and the outcome says
+/// what could not be confirmed. Shared with the other writer that installs
+/// a file beside the settings.
+pub(crate) fn install_beside_settings(
+    labels: &SaveLabels,
+    path: &Path,
+    body: &str,
+) -> Result<SaveOutcome> {
+    install_with_directory_sync(labels, path, body, |parent| {
+        std::fs::File::open(parent).and_then(|directory| directory.sync_all())
+    })
+}
+
+fn install_with_directory_sync(
+    labels: &SaveLabels,
+    path: &Path,
+    body: &str,
+    sync_directory: impl FnOnce(&Path) -> std::io::Result<()>,
+) -> Result<SaveOutcome> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().ok_or_else(|| {
+        DegaussError::unsupported(labels.writing, "the path to write has no file name")
+    })?;
+    let (temporary, mut handle) = temporary_file(labels, parent, file_name)?;
+
+    let write_result: Result<()> = (|| {
+        handle
+            .write_all(body.as_bytes())
+            .map_err(|error| DegaussError::io(labels.writing_temporary, &temporary, error))?;
+        handle
+            .sync_all()
+            .map_err(|error| DegaussError::io(labels.flushing_temporary, &temporary, error))?;
+        Ok(())
+    })();
+    if let Err(error) = write_result {
         drop(handle);
+        return Err(cleanup_temporary(labels.writing, &temporary, error));
+    }
+    drop(handle);
 
-        if let Err(error) = std::fs::rename(&temporary, path) {
-            let error = DegaussError::io("installing settings", path, error);
-            return Err(cleanup_temporary("writing settings", &temporary, error));
-        }
+    if let Err(error) = std::fs::rename(&temporary, path) {
+        let error = DegaussError::io(labels.installing, path, error);
+        return Err(cleanup_temporary(labels.writing, &temporary, error));
+    }
 
-        match sync_directory(parent) {
-            Ok(()) => Ok(SaveOutcome::Durable),
-            Err(error) => Ok(SaveOutcome::InstalledWithWarning(DegaussError::io(
-                "flushing settings directory",
-                parent,
-                error,
-            ))),
-        }
+    match sync_directory(parent) {
+        Ok(()) => Ok(SaveOutcome::Durable),
+        Err(error) => Ok(SaveOutcome::InstalledWithWarning(DegaussError::io(
+            labels.flushing_directory,
+            parent,
+            error,
+        ))),
     }
 }
 
 /// The failure that stopped a save, with the leftover temporary file
 /// removed; when even that fails the error says so under `what`, because
-/// a stray file beside the settings is worth knowing about. Shared with
-/// the other writer that installs a file beside the settings.
+/// a stray file beside the settings is worth knowing about.
 pub(crate) fn cleanup_temporary(
     what: &'static str,
     path: &Path,
@@ -286,7 +331,13 @@ pub(crate) fn cleanup_temporary(
     }
 }
 
-fn temporary_file(parent: &Path, file_name: &std::ffi::OsStr) -> Result<(PathBuf, std::fs::File)> {
+/// A fresh temporary file beside the target: never an existing one, so a
+/// leftover of another run is not written over and read back as this one.
+fn temporary_file(
+    labels: &SaveLabels,
+    parent: &Path,
+    file_name: &std::ffi::OsStr,
+) -> Result<(PathBuf, std::fs::File)> {
     for attempt in 0..1000 {
         let mut temporary_name = OsString::from(".");
         temporary_name.push(file_name);
@@ -301,7 +352,7 @@ fn temporary_file(parent: &Path, file_name: &std::ffi::OsStr) -> Result<(PathBuf
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(error) => {
                 return Err(DegaussError::io(
-                    "creating temporary settings",
+                    labels.creating_temporary,
                     &temporary,
                     error,
                 ));
@@ -309,8 +360,8 @@ fn temporary_file(parent: &Path, file_name: &std::ffi::OsStr) -> Result<(PathBuf
         }
     }
     Err(DegaussError::unsupported(
-        "writing settings",
-        "could not reserve a temporary settings file",
+        labels.writing,
+        "could not reserve a temporary file",
     ))
 }
 

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3249,12 +3249,32 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     // The log is one file for every process on the host, appended to by
     // whatever else runs; counted lines carry this fixture's path, so only
     // this flow adds to them. Read as bytes: a stray byte from elsewhere is
-    // no reason to fail, and a log that cannot be read at all is named.
+    // no reason to fail, and a log that cannot be read at all is named. A
+    // log nobody has started yet holds no lines.
     let logged = |line: &str| {
-        let bytes = std::fs::read(crate::LOG_PATH)
-            .unwrap_or_else(|error| panic!("{} could not be read: {error}", crate::LOG_PATH));
+        let bytes = match std::fs::read(crate::LOG_PATH) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+            Err(error) => panic!("{} could not be read: {error}", crate::LOG_PATH),
+        };
         String::from_utf8_lossy(&bytes).matches(line).count()
     };
+    // Writing the log is best effort and never stops the program, so a
+    // host where the file cannot be written would fail the counts below
+    // as if nothing had been logged. One probe line first: a missing probe
+    // is the environment, not the acknowledgement.
+    let probe = format!(
+        "degraded pack acknowledgement flow probe at {}",
+        docs.display()
+    );
+    let probed_before = logged(&probe);
+    crate::note(&probe);
+    assert_eq!(
+        logged(&probe),
+        probed_before + 1,
+        "{} must take what note() appends on this host; the log counts below depend on it",
+        crate::LOG_PATH
+    );
 
     // 6. A complete pack: no warning, and nothing written down.
     let app = start(window.clone());

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3268,6 +3268,20 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     app.ui.hide().unwrap();
     drop(app);
 
+    // A press that takes another message off the screen, put up over the
+    // warning meanwhile, has not seen the warning: nothing is written down.
+    let mut app = start(window.clone());
+    assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
+    app.message = Some("Put up over the warning before any press".into());
+    app.handle(Action::Accept);
+    assert!(app.message.is_none(), "{:?}", app.message);
+    assert!(
+        !warnings.exists(),
+        "dismissing another message is not seeing the warning under it"
+    );
+    app.ui.hide().unwrap();
+    drop(app);
+
     // The same pack in the next process: still not seen, so warned again;
     // dismissing it is what writes it down.
     let mut app = start(window.clone());
@@ -3315,12 +3329,28 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         "one acknowledgement per source group: the old state is gone"
     );
     let no_index_file = std::fs::read_to_string(&warnings).unwrap();
+    let no_index_diagnostics = app.artwork_provider.as_ref().unwrap().diagnostics.clone();
+    assert_eq!(
+        no_index_diagnostics.len(),
+        2,
+        "a missing image and a missing table are two diagnostics: {no_index_diagnostics:?}"
+    );
     app.ui.hide().unwrap();
     drop(app);
 
     // 3. Back from a game: a new process, the same pack, no warning. The
     // log still gets the whole diagnostic, every part of it, acknowledged
-    // or not: the screen is quiet, the record is not.
+    // or not: the screen is quiet, the record is not. The warning just
+    // dismissed wrote the same line, so only one more line proves it.
+    let logged_line = format!(
+        "artwork pack Degraded at {}: {}",
+        docs.display(),
+        no_index_diagnostics.join("; ")
+    );
+    let logged_before = std::fs::read_to_string(crate::LOG_PATH)
+        .unwrap()
+        .matches(&logged_line)
+        .count();
     let app = start(window.clone());
     assert!(
         app.message.is_none(),
@@ -3329,21 +3359,14 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     );
     let provider = app.artwork_provider.as_ref().unwrap();
     assert_eq!(provider.health, ProviderHealth::Degraded);
+    assert_eq!(provider.diagnostics, no_index_diagnostics);
     assert_eq!(
-        provider.diagnostics.len(),
-        2,
-        "a missing image and a missing table are two diagnostics: {:?}",
-        provider.diagnostics
-    );
-    let logged = std::fs::read_to_string(crate::LOG_PATH).unwrap();
-    let expected = format!(
-        "artwork pack Degraded at {}: {}",
-        docs.display(),
-        provider.diagnostics.join("; ")
-    );
-    assert!(
-        logged.contains(&expected),
-        "an acknowledged warning must still be written to the log in full: {expected:?}"
+        std::fs::read_to_string(crate::LOG_PATH)
+            .unwrap()
+            .matches(&logged_line)
+            .count(),
+        logged_before + 1,
+        "an acknowledged warning must still be written to the log in full: {logged_line:?}"
     );
     assert_eq!(std::fs::read_to_string(&warnings).unwrap(), no_index_file);
     app.ui.hide().unwrap();
@@ -3414,16 +3437,19 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     app.ui.hide().unwrap();
     drop(app);
 
-    // A save that fails when the warning is dismissed is said on screen with
-    // its cause, and the warning comes back on the next start.
+    // A dismissal whose acknowledgement cannot be written down is said on
+    // screen with its cause, and the warning comes back on the next start.
+    // The file is read again before the save, so a file turned into a
+    // directory after the warning went up fails at that read.
     std::fs::remove_dir(&warnings).unwrap();
     let mut app = start(window.clone());
     assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
     std::fs::create_dir(&warnings).unwrap();
     app.handle(Action::Accept);
     assert!(
-        message_contains(&app, "not remembered"),
-        "a failed save must not be silent: {:?}",
+        message_contains(&app, "not remembered")
+            && message_contains(&app, "reading artwork pack warnings failed for"),
+        "a failed acknowledgement must say which step failed: {:?}",
         app.message
     );
     app.handle(Action::Accept);

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3400,6 +3400,14 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     // else; that warning says the file was set aside, and why, because the
     // press that dismisses it writes over what was there.
     std::fs::write(&warnings, "degraded = \"not a table").unwrap();
+    let malformed_line = format!(
+        "artwork pack warnings: {} is malformed:",
+        warnings.display()
+    );
+    let malformed_before = std::fs::read_to_string(crate::LOG_PATH)
+        .unwrap()
+        .matches(&malformed_line)
+        .count();
     let mut app = start(window.clone());
     assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
     assert!(
@@ -3411,6 +3419,14 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     assert!(
         acknowledged("NES", &updated_digest),
         "the broken file is replaced by a readable one"
+    );
+    assert_eq!(
+        std::fs::read_to_string(crate::LOG_PATH)
+            .unwrap()
+            .matches(&malformed_line)
+            .count(),
+        malformed_before + 1,
+        "one broken file is one log line, not one per read of it"
     );
     let acknowledged_file = std::fs::read_to_string(&warnings).unwrap();
     app.ui.hide().unwrap();

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3203,6 +3203,11 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         app.open_system_by_index(0);
         assert_eq!(app.open_system.as_deref(), Some("NES"), "{:?}", app.message);
     };
+    let acknowledged = |group: &str, digest: &str| {
+        Acknowledgements::load(&warnings)
+            .unwrap()
+            .acknowledged(group, digest)
+    };
 
     // 6. A complete pack: no warning, and nothing written down.
     let app = start(window.clone());
@@ -3220,9 +3225,11 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     app.ui.hide().unwrap();
     drop(app);
 
-    // 1. The first look at an incomplete pack warns, and remembers it.
+    // 1. The first look at an incomplete pack warns. Putting the warning up
+    // is not seeing it: a headless render opens a system the same way and
+    // nobody dismisses what it draws, so nothing is written down yet.
     std::fs::remove_file(artwork.join("Second.jpg")).unwrap();
-    let mut app = start(window.clone());
+    let app = start(window.clone());
     assert_eq!(
         app.artwork_provider.as_ref().unwrap().health,
         ProviderHealth::Degraded
@@ -3230,14 +3237,29 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
     let first_digest = app.artwork_provider.as_ref().unwrap().health_digest();
     assert!(
-        Acknowledgements::load(&warnings).acknowledged("NES", &first_digest),
-        "the shown warning is written down beside settings.toml before it is dismissed"
+        !warnings.exists(),
+        "a warning nobody dismissed must not be written down"
+    );
+    app.ui.hide().unwrap();
+    drop(app);
+
+    // The same pack in the next process: still not seen, so warned again;
+    // dismissing it is what writes it down.
+    let mut app = start(window.clone());
+    assert!(
+        message_contains(&app, "is incomplete"),
+        "an undismissed warning must come back: {:?}",
+        app.message
+    );
+    app.handle(Action::Accept);
+    assert!(app.message.is_none(), "{:?}", app.message);
+    assert!(
+        acknowledged("NES", &first_digest),
+        "the dismissed warning is written down beside settings.toml"
     );
     let first_file = std::fs::read_to_string(&warnings).unwrap();
 
     // 2. Dismissed, left and re-entered in the same process: not again.
-    app.handle(Action::Accept);
-    assert!(app.message.is_none());
     reopen(&mut app);
     assert!(app.message.is_none(), "{:?}", app.message);
     assert_eq!(std::fs::read_to_string(&warnings).unwrap(), first_file);
@@ -3256,13 +3278,17 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         .diagnostics
         .iter()
         .any(|diagnostic| diagnostic.contains("index.tsv is missing")));
-    let seen = Acknowledgements::load(&warnings);
-    assert!(seen.acknowledged("NES", &no_index_digest));
-    assert!(
-        !seen.acknowledged("NES", &first_digest),
-        "one acknowledgement per source group: the old state is gone"
+    assert_eq!(
+        std::fs::read_to_string(&warnings).unwrap(),
+        first_file,
+        "nothing is written until the new warning is dismissed"
     );
     app.handle(Action::Accept);
+    assert!(acknowledged("NES", &no_index_digest));
+    assert!(
+        !acknowledged("NES", &first_digest),
+        "one acknowledgement per source group: the old state is gone"
+    );
     let no_index_file = std::fs::read_to_string(&warnings).unwrap();
     app.ui.hide().unwrap();
     drop(app);
@@ -3283,13 +3309,26 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     drop(app);
 
     // 4. An updated manifest is another pack state: warned about once more.
+    // Meanwhile the file on the card was replaced by hand while this
+    // process runs (another group's acknowledgement, this one's gone): the
+    // save must start from what is on the card, not from what was read
+    // earlier, or the deletion is undone and the other group's entry lost.
     write_manifest(&["Known", "Second", "Third"]);
     let mut app = start(window.clone());
     assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
     let updated_digest = app.artwork_provider.as_ref().unwrap().health_digest();
     assert_ne!(updated_digest, no_index_digest);
-    assert!(Acknowledgements::load(&warnings).acknowledged("NES", &updated_digest));
+    let mut by_hand = Acknowledgements::default();
+    by_hand.acknowledge("SNES", "kept");
+    by_hand.save(&warnings).unwrap();
     app.handle(Action::Accept);
+    assert!(app.message.is_none(), "{:?}", app.message);
+    assert!(acknowledged("NES", &updated_digest));
+    assert!(
+        acknowledged("SNES", "kept"),
+        "an entry written by hand while the program runs must survive the next save"
+    );
+    assert!(!acknowledged("NES", &no_index_digest));
     app.ui.hide().unwrap();
     drop(app);
 
@@ -3297,16 +3336,65 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     std::fs::write(&warnings, "degraded = \"not a table").unwrap();
     let mut app = start(window.clone());
     assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
+    app.handle(Action::Accept);
     assert!(
-        Acknowledgements::load(&warnings).acknowledged("NES", &updated_digest),
+        acknowledged("NES", &updated_digest),
         "the broken file is replaced by a readable one"
     );
-    app.handle(Action::Accept);
     let acknowledged_file = std::fs::read_to_string(&warnings).unwrap();
     app.ui.hide().unwrap();
     drop(app);
 
-    // 5. Invalid and unavailable packs need acting on: shown every time,
+    // A file that is there but cannot be read is another matter: it may
+    // hold acknowledgements, so the warning is shown with the reason and
+    // nothing is written over it.
+    std::fs::remove_file(&warnings).unwrap();
+    std::fs::create_dir(&warnings).unwrap();
+    let mut app = start(window.clone());
+    assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
+    assert!(
+        message_contains(&app, "cannot be remembered"),
+        "an unreadable file must be said on screen with its cause: {:?}",
+        app.message
+    );
+    app.handle(Action::Accept);
+    assert!(app.message.is_none(), "{:?}", app.message);
+    assert!(
+        warnings.is_dir(),
+        "an unreadable file must not be replaced by a fresh list"
+    );
+    app.ui.hide().unwrap();
+    drop(app);
+
+    // A save that fails when the warning is dismissed is said on screen with
+    // its cause, and the warning comes back on the next start.
+    std::fs::remove_dir(&warnings).unwrap();
+    let mut app = start(window.clone());
+    assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
+    std::fs::create_dir(&warnings).unwrap();
+    app.handle(Action::Accept);
+    assert!(
+        message_contains(&app, "not remembered"),
+        "a failed save must not be silent: {:?}",
+        app.message
+    );
+    app.handle(Action::Accept);
+    assert!(app.message.is_none(), "{:?}", app.message);
+    assert!(warnings.is_dir());
+    app.ui.hide().unwrap();
+    drop(app);
+    std::fs::remove_dir(&warnings).unwrap();
+    std::fs::write(&warnings, &acknowledged_file).unwrap();
+    let app = start(window.clone());
+    assert!(
+        app.message.is_none(),
+        "the acknowledgement put back reads as before: {:?}",
+        app.message
+    );
+    app.ui.hide().unwrap();
+    drop(app);
+
+    // 5. Invalid and unavailable packs need acting on: shown at every start,
     // and never written down.
     write_manifest(&["../escape"]);
     for _ in 0..2 {

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3332,10 +3332,17 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     app.ui.hide().unwrap();
     drop(app);
 
-    // 7. A broken acknowledgement file costs one more warning, nothing else.
+    // 7. A broken acknowledgement file costs one more warning, nothing
+    // else; that warning says the file was set aside, and why, because the
+    // press that dismisses it writes over what was there.
     std::fs::write(&warnings, "degraded = \"not a table").unwrap();
     let mut app = start(window.clone());
     assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
+    assert!(
+        message_contains(&app, "could not be read and will be replaced"),
+        "a file set aside as malformed must be said on screen with its cause: {:?}",
+        app.message
+    );
     app.handle(Action::Accept);
     assert!(
         acknowledged("NES", &updated_digest),

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3220,10 +3220,17 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
             .is_some_and(|message| message.contains(text))
     };
     // The overlay is small and names no file: the cause of a file that
-    // could not be read or written stays in the log.
-    let names_the_file = |app: &App| {
-        message_contains(app, &warnings.display().to_string())
-            || message_contains(app, "not a table")
+    // could not be read or written stays in the log. The cause is the one
+    // the read itself gives, whatever words it uses.
+    let names_the_file = |app: &App, cause: &str| {
+        message_contains(app, &warnings.display().to_string()) || message_contains(app, cause)
+    };
+    let malformed_cause = || {
+        Acknowledgements::load(&warnings)
+            .unwrap()
+            .malformed()
+            .expect("the file written as broken must read as malformed")
+            .to_string()
     };
     let reopen = |app: &mut App| {
         app.handle(Action::Quit);
@@ -3393,11 +3400,12 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         "#key\tname\tyear\tgenre\tdeveloper\tplayers\nKnown\tPack First\t1990\tAction\tStudio\t1\nSecond\tPack Second\t1991\tPuzzle\tStudio\t2\nExtra\tPack Extra\t1992\tAction\tStudio\t1\n",
     )
     .unwrap();
-    let malformed_line = format!(
-        "artwork pack warnings: {} is malformed:",
-        warnings.display()
-    );
-    let malformed_before = logged(&malformed_line);
+    let malformed_line = |cause: &str| {
+        format!(
+            "artwork pack warnings: {} is malformed: {cause}",
+            warnings.display()
+        )
+    };
     let mut app = start(window.clone());
     assert!(
         message_contains(&app, "is incomplete"),
@@ -3417,6 +3425,8 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     let extra_digest = provider.health_digest();
     assert_ne!(extra_digest, no_index_digest);
     std::fs::write(&warnings, "degraded = \"not a table").unwrap();
+    let cause = malformed_cause();
+    let malformed_before = logged(&malformed_line(&cause));
     app.handle(Action::Accept);
     assert!(
         message_contains(&app, "remembered")
@@ -3425,14 +3435,14 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         app.message
     );
     assert!(
-        !names_the_file(&app),
+        !names_the_file(&app, &cause),
         "the press says the file was replaced, not the parse error or the path: {:?}",
         app.message
     );
     assert_eq!(
-        logged(&malformed_line),
+        logged(&malformed_line(&cause)),
         malformed_before + 1,
-        "the replacement of a file that broke meanwhile must reach {}",
+        "the replacement of a file that broke meanwhile must reach {} with its cause",
         crate::LOG_PATH
     );
     assert!(
@@ -3472,7 +3482,8 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     // else; that warning says the file was set aside, and why, because the
     // press that dismisses it writes over what was there.
     std::fs::write(&warnings, "degraded = \"not a table").unwrap();
-    let malformed_before = logged(&malformed_line);
+    let cause = malformed_cause();
+    let malformed_before = logged(&malformed_line(&cause));
     let mut app = start(window.clone());
     assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
     assert!(
@@ -3481,7 +3492,7 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         app.message
     );
     assert!(
-        !names_the_file(&app),
+        !names_the_file(&app, &cause),
         "the parse error and the path belong in the log, not on the overlay: {:?}",
         app.message
     );
@@ -3491,9 +3502,9 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         "the broken file is replaced by a readable one"
     );
     assert_eq!(
-        logged(&malformed_line),
+        logged(&malformed_line(&cause)),
         malformed_before + 1,
-        "one broken file is one line in {}, not one per read of it",
+        "one broken file is one line in {}, with its cause, not one per read of it",
         crate::LOG_PATH
     );
     let acknowledged_file = std::fs::read_to_string(&warnings).unwrap();
@@ -3505,6 +3516,9 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     // nothing is written over it.
     std::fs::remove_file(&warnings).unwrap();
     std::fs::create_dir(&warnings).unwrap();
+    let cause = Acknowledgements::load(&warnings)
+        .expect_err("a directory in the file's place cannot be read")
+        .to_string();
     let mut app = start(window.clone());
     assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
     assert!(
@@ -3513,7 +3527,7 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         app.message
     );
     assert!(
-        !names_the_file(&app),
+        !names_the_file(&app, &cause),
         "the read error and the path belong in the log, not on the overlay: {:?}",
         app.message
     );

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3130,6 +3130,217 @@ fn run_auto_source_choice_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
     app.ui.hide().unwrap();
 }
 
+fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwareWindow>) {
+    use crate::artwork_pack::ProviderHealth;
+    use crate::pack_health::Acknowledgements;
+
+    let root = root.join("degraded-pack-acknowledgement");
+    let games = root.join("games/NES");
+    let docs = root.join("docs");
+    let artwork = docs.join("NES/Artwork");
+    for directory in [&games, &artwork] {
+        std::fs::create_dir_all(directory).unwrap();
+    }
+    std::fs::write(games.join("Known.nes"), b"first rom").unwrap();
+    std::fs::write(games.join("Second.nes"), b"second rom").unwrap();
+    let write_manifest = |keys: &[&str]| {
+        let rows: String = keys
+            .iter()
+            .map(|key| format!("{key}\tbox-2D\t3\n"))
+            .collect();
+        std::fs::write(
+            artwork.join("manifest.tsv"),
+            format!("#key\tstyle\tss_system_id\n{rows}"),
+        )
+        .unwrap();
+    };
+    write_manifest(&["Known", "Second"]);
+    std::fs::write(
+        artwork.join("index.tsv"),
+        "#name\tcrc\tsize\tkey\nKnown\t\t\tKnown\nSecond\t\t\tSecond\n",
+    )
+    .unwrap();
+    std::fs::write(
+        artwork.join("gameinfo.tsv"),
+        "#key\tname\tyear\tgenre\tdeveloper\tplayers\nKnown\tPack First\t1990\tAction\tStudio\t1\nSecond\tPack Second\t1991\tPuzzle\tStudio\t2\n",
+    )
+    .unwrap();
+    for key in ["Known", "Second"] {
+        std::fs::write(artwork.join(format!("{key}.jpg")), crate::covers::JPEG_16).unwrap();
+    }
+    let settings_path = root.join("settings.toml");
+    let warnings = crate::pack_health::path_beside(&settings_path);
+    assert_eq!(warnings.parent(), settings_path.parent());
+    let mut settings = Settings::default();
+    settings
+        .artwork_pack_roots
+        .insert("NES".into(), docs.to_string_lossy().into_owned());
+    settings.save(&settings_path).unwrap();
+    // Every start reads the card afresh, as a return from a game does.
+    let start = |window: Rc<MinimalSoftwareWindow>| {
+        let mut app = unopened_fixture_app(&root, window, Settings::load(&settings_path).unwrap());
+        app.open_system_by_index(0);
+        assert!(
+            app.source_resolution.is_none() && app.source_job.is_none(),
+            "a headless open must also finish the resolution that a cache recovery restarts"
+        );
+        assert!(app.build.is_none());
+        assert_eq!(app.open_system.as_deref(), Some("NES"), "{:?}", app.message);
+        app.leave_splash();
+        app
+    };
+    let message_contains = |app: &App, text: &str| {
+        app.message
+            .as_deref()
+            .is_some_and(|message| message.contains(text))
+    };
+    let reopen = |app: &mut App| {
+        app.handle(Action::Quit);
+        assert!(
+            app.open_system.is_none(),
+            "B on the top folder leaves the system"
+        );
+        app.open_system_by_index(0);
+        assert_eq!(app.open_system.as_deref(), Some("NES"), "{:?}", app.message);
+    };
+
+    // 6. A complete pack: no warning, and nothing written down.
+    let app = start(window.clone());
+    assert_eq!(
+        app.artwork_provider.as_ref().unwrap().health,
+        ProviderHealth::Ready,
+        "{:?}",
+        app.artwork_provider.as_ref().unwrap().diagnostics
+    );
+    assert!(app.message.is_none(), "{:?}", app.message);
+    assert!(
+        !warnings.exists(),
+        "a Ready pack must not create the acknowledgement file"
+    );
+    app.ui.hide().unwrap();
+    drop(app);
+
+    // 1. The first look at an incomplete pack warns, and remembers it.
+    std::fs::remove_file(artwork.join("Second.jpg")).unwrap();
+    let mut app = start(window.clone());
+    assert_eq!(
+        app.artwork_provider.as_ref().unwrap().health,
+        ProviderHealth::Degraded
+    );
+    assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
+    let first_digest = app.artwork_provider.as_ref().unwrap().health_digest();
+    assert!(
+        Acknowledgements::load(&warnings).acknowledged("NES", &first_digest),
+        "the shown warning is written down beside settings.toml before it is dismissed"
+    );
+    let first_file = std::fs::read_to_string(&warnings).unwrap();
+
+    // 2. Dismissed, left and re-entered in the same process: not again.
+    app.handle(Action::Accept);
+    assert!(app.message.is_none());
+    reopen(&mut app);
+    assert!(app.message.is_none(), "{:?}", app.message);
+    assert_eq!(std::fs::read_to_string(&warnings).unwrap(), first_file);
+
+    // 4. A new diagnostic on the same pack, noticed on re-entry, is a new
+    // warning even while the process that saw the old one is still running.
+    std::fs::remove_file(artwork.join("index.tsv")).unwrap();
+    reopen(&mut app);
+    assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
+    let no_index_digest = app.artwork_provider.as_ref().unwrap().health_digest();
+    assert_ne!(no_index_digest, first_digest);
+    assert!(app
+        .artwork_provider
+        .as_ref()
+        .unwrap()
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.contains("index.tsv is missing")));
+    let seen = Acknowledgements::load(&warnings);
+    assert!(seen.acknowledged("NES", &no_index_digest));
+    assert!(
+        !seen.acknowledged("NES", &first_digest),
+        "one acknowledgement per source group: the old state is gone"
+    );
+    app.handle(Action::Accept);
+    let no_index_file = std::fs::read_to_string(&warnings).unwrap();
+    app.ui.hide().unwrap();
+    drop(app);
+
+    // 3. Back from a game: a new process, the same pack, no warning.
+    let app = start(window.clone());
+    assert!(
+        app.message.is_none(),
+        "an unchanged degraded pack must not warn again after a restart: {:?}",
+        app.message
+    );
+    assert_eq!(
+        app.artwork_provider.as_ref().unwrap().health,
+        ProviderHealth::Degraded
+    );
+    assert_eq!(std::fs::read_to_string(&warnings).unwrap(), no_index_file);
+    app.ui.hide().unwrap();
+    drop(app);
+
+    // 4. An updated manifest is another pack state: warned about once more.
+    write_manifest(&["Known", "Second", "Third"]);
+    let mut app = start(window.clone());
+    assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
+    let updated_digest = app.artwork_provider.as_ref().unwrap().health_digest();
+    assert_ne!(updated_digest, no_index_digest);
+    assert!(Acknowledgements::load(&warnings).acknowledged("NES", &updated_digest));
+    app.handle(Action::Accept);
+    app.ui.hide().unwrap();
+    drop(app);
+
+    // 7. A broken acknowledgement file costs one more warning, nothing else.
+    std::fs::write(&warnings, "degraded = \"not a table").unwrap();
+    let mut app = start(window.clone());
+    assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
+    assert!(
+        Acknowledgements::load(&warnings).acknowledged("NES", &updated_digest),
+        "the broken file is replaced by a readable one"
+    );
+    app.handle(Action::Accept);
+    let acknowledged_file = std::fs::read_to_string(&warnings).unwrap();
+    app.ui.hide().unwrap();
+    drop(app);
+
+    // 5. Invalid and unavailable packs need acting on: shown every time,
+    // and never written down.
+    write_manifest(&["../escape"]);
+    for _ in 0..2 {
+        let mut app = start(window.clone());
+        assert_eq!(
+            app.artwork_provider.as_ref().unwrap().health,
+            ProviderHealth::Invalid
+        );
+        assert!(message_contains(&app, "is invalid"), "{:?}", app.message);
+        app.handle(Action::Accept);
+        app.ui.hide().unwrap();
+    }
+    std::fs::remove_dir_all(&artwork).unwrap();
+    for _ in 0..2 {
+        let mut app = start(window.clone());
+        assert_eq!(
+            app.artwork_provider.as_ref().unwrap().health,
+            ProviderHealth::Unavailable
+        );
+        assert!(
+            message_contains(&app, "is unavailable"),
+            "{:?}",
+            app.message
+        );
+        app.handle(Action::Accept);
+        app.ui.hide().unwrap();
+    }
+    assert_eq!(
+        std::fs::read_to_string(&warnings).unwrap(),
+        acknowledged_file,
+        "actionable failures leave the incomplete-pack acknowledgement alone"
+    );
+}
+
 pub(super) fn run_ui_acceptance_flow(window: Rc<MinimalSoftwareWindow>) {
     let root = fixture_directory();
     std::fs::create_dir_all(root.join("games/NES")).unwrap();
@@ -3145,6 +3356,7 @@ pub(super) fn run_ui_acceptance_flow(window: Rc<MinimalSoftwareWindow>) {
     run_artwork_matte_flow(&root, window.clone());
     run_fresh_auto_pack_index_flow(&root, window.clone());
     run_auto_source_choice_flow(&root, window.clone());
+    run_degraded_pack_acknowledgement_flow(&root, window.clone());
     let mut app = fixture_app(&root, window.clone(), Settings::default());
     run_selected_controls_flow(&mut app);
     run_artwork_visibility_flow(&mut app);

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -317,6 +317,19 @@ fn fixture_directory() -> PathBuf {
 }
 
 fn unopened_fixture_app(root: &Path, window: Rc<MinimalSoftwareWindow>, settings: Settings) -> App {
+    unopened_fixture_app_with_systems(root, window, settings, &["NES"], "games/NES")
+}
+
+/// The given systems, in that order, all over one games directory under
+/// the root: the members of a shared source group share their folder on
+/// the card.
+fn unopened_fixture_app_with_systems(
+    root: &Path,
+    window: Rc<MinimalSoftwareWindow>,
+    settings: Settings,
+    ids: &[&str],
+    games: &str,
+) -> App {
     let mut config = Config::parse("[app]", &root.join("degauss.toml")).unwrap();
     config.menu_root = root.to_string_lossy().into_owned();
     config.game_roots = vec![root.join("games").to_string_lossy().into_owned()];
@@ -325,18 +338,30 @@ fn unopened_fixture_app(root: &Path, window: Rc<MinimalSoftwareWindow>, settings
         Path::new("systems.toml"),
     )
     .unwrap();
-    let def = table.into_iter().find(|system| system.id == "NES").unwrap();
+    let defs: Vec<_> = ids
+        .iter()
+        .map(|id| {
+            table
+                .iter()
+                .find(|system| system.id == *id)
+                .unwrap()
+                .clone()
+        })
+        .collect();
     let loaded = Loaded {
         config,
         settings,
         settings_path: root.join("settings.toml"),
-        systems: vec![FoundSystem {
-            def: def.clone(),
-            paths: vec![root.join("games/NES")],
-            logo_dir: None,
-            menu_folder: None,
-        }],
-        table: vec![def],
+        systems: defs
+            .iter()
+            .map(|def| FoundSystem {
+                def: def.clone(),
+                paths: vec![root.join(games)],
+                logo_dir: None,
+                menu_folder: None,
+            })
+            .collect(),
+        table: defs,
         names: Default::default(),
         logo_dir: None,
         themes_dir: root.join("themes"),
@@ -3293,16 +3318,32 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     app.ui.hide().unwrap();
     drop(app);
 
-    // 3. Back from a game: a new process, the same pack, no warning.
+    // 3. Back from a game: a new process, the same pack, no warning. The
+    // log still gets the whole diagnostic, every part of it, acknowledged
+    // or not: the screen is quiet, the record is not.
     let app = start(window.clone());
     assert!(
         app.message.is_none(),
         "an unchanged degraded pack must not warn again after a restart: {:?}",
         app.message
     );
+    let provider = app.artwork_provider.as_ref().unwrap();
+    assert_eq!(provider.health, ProviderHealth::Degraded);
     assert_eq!(
-        app.artwork_provider.as_ref().unwrap().health,
-        ProviderHealth::Degraded
+        provider.diagnostics.len(),
+        2,
+        "a missing image and a missing table are two diagnostics: {:?}",
+        provider.diagnostics
+    );
+    let logged = std::fs::read_to_string(crate::LOG_PATH).unwrap();
+    let expected = format!(
+        "artwork pack Degraded at {}: {}",
+        docs.display(),
+        provider.diagnostics.join("; ")
+    );
+    assert!(
+        logged.contains(&expected),
+        "an acknowledged warning must still be written to the log in full: {expected:?}"
     );
     assert_eq!(std::fs::read_to_string(&warnings).unwrap(), no_index_file);
     app.ui.hide().unwrap();
@@ -3434,6 +3475,89 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         acknowledged_file,
         "actionable failures leave the incomplete-pack acknowledgement alone"
     );
+
+    // Two systems, one source: NeoGeo and NeoGeoMVS read the same NEOGEO
+    // pack, so its warning is one warning. Dismissed from one member, it
+    // must stay dismissed for the other in the next process.
+    let shared = root.join("shared-group");
+    let shared_games = shared.join("games/NEOGEO");
+    let shared_docs = shared.join("docs");
+    let shared_artwork = shared_docs.join("NEOGEO/Artwork");
+    for directory in [&shared_games, &shared_artwork] {
+        std::fs::create_dir_all(directory).unwrap();
+    }
+    std::fs::write(shared_games.join("One.neo"), b"first rom").unwrap();
+    std::fs::write(shared_games.join("Two.neo"), b"second rom").unwrap();
+    std::fs::write(
+        shared_artwork.join("manifest.tsv"),
+        "#key\tstyle\tss_system_id\nOne\tbox-2D\t142\nTwo\tbox-2D\t142\n",
+    )
+    .unwrap();
+    std::fs::write(
+        shared_artwork.join("index.tsv"),
+        "#name\tcrc\tsize\tkey\nOne\t\t\tOne\nTwo\t\t\tTwo\n",
+    )
+    .unwrap();
+    std::fs::write(
+        shared_artwork.join("gameinfo.tsv"),
+        "#key\tname\tyear\tgenre\tdeveloper\tplayers\nOne\tPack One\t1990\tAction\tStudio\t1\nTwo\tPack Two\t1991\tPuzzle\tStudio\t2\n",
+    )
+    .unwrap();
+    std::fs::write(shared_artwork.join("One.jpg"), crate::covers::JPEG_16).unwrap();
+    let shared_settings_path = shared.join("settings.toml");
+    let shared_warnings = crate::pack_health::path_beside(&shared_settings_path);
+    let mut shared_settings = Settings::default();
+    shared_settings
+        .artwork_pack_roots
+        .insert("NeoGeo".into(), shared_docs.to_string_lossy().into_owned());
+    shared_settings.save(&shared_settings_path).unwrap();
+    let start_member = |window: Rc<MinimalSoftwareWindow>, index: usize, id: &str| {
+        let mut app = unopened_fixture_app_with_systems(
+            &shared,
+            window,
+            Settings::load(&shared_settings_path).unwrap(),
+            &["NeoGeoMVS", "NeoGeo"],
+            "games/NEOGEO",
+        );
+        app.open_system_by_index(index);
+        assert!(app.source_resolution.is_none() && app.source_job.is_none());
+        assert!(app.build.is_none());
+        assert_eq!(app.open_system.as_deref(), Some(id), "{:?}", app.message);
+        assert_eq!(
+            app.artwork_provider.as_ref().unwrap().health,
+            ProviderHealth::Degraded,
+            "{:?}",
+            app.artwork_provider.as_ref().unwrap().diagnostics
+        );
+        app.leave_splash();
+        app
+    };
+    let mut app = start_member(window.clone(), 0, "NeoGeoMVS");
+    assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
+    let group_digest = app.artwork_provider.as_ref().unwrap().health_digest();
+    app.handle(Action::Accept);
+    assert!(app.message.is_none(), "{:?}", app.message);
+    let group_seen = Acknowledgements::load(&shared_warnings).unwrap();
+    assert!(
+        group_seen.acknowledged("NeoGeo", &group_digest),
+        "the acknowledgement is written under the source group, not the system"
+    );
+    assert!(!group_seen.acknowledged("NeoGeoMVS", &group_digest));
+    app.ui.hide().unwrap();
+    drop(app);
+    let app = start_member(window.clone(), 1, "NeoGeo");
+    assert_eq!(
+        app.artwork_provider.as_ref().unwrap().health_digest(),
+        group_digest,
+        "both members of the group read the same pack as the same snapshot"
+    );
+    assert!(
+        app.message.is_none(),
+        "a warning dismissed from the other member of the group must not come back: {:?}",
+        app.message
+    );
+    app.ui.hide().unwrap();
+    drop(app);
 }
 
 pub(super) fn run_ui_acceptance_flow(window: Rc<MinimalSoftwareWindow>) {

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3219,6 +3219,12 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
             .as_deref()
             .is_some_and(|message| message.contains(text))
     };
+    // The overlay is small and names no file: the cause of a file that
+    // could not be read or written stays in the log.
+    let names_the_file = |app: &App| {
+        message_contains(app, &warnings.display().to_string())
+            || message_contains(app, "not a table")
+    };
     let reopen = |app: &mut App| {
         app.handle(Action::Quit);
         assert!(
@@ -3418,6 +3424,11 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         "a file that broke between the warning and the press is said at the press: {:?}",
         app.message
     );
+    assert!(
+        !names_the_file(&app),
+        "the press says the file was replaced, not the parse error or the path: {:?}",
+        app.message
+    );
     assert_eq!(
         logged(&malformed_line),
         malformed_before + 1,
@@ -3466,7 +3477,12 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
     assert!(
         message_contains(&app, "could not be read and will be replaced"),
-        "a file set aside as malformed must be said on screen with its cause: {:?}",
+        "a file set aside as malformed must be said on screen: {:?}",
+        app.message
+    );
+    assert!(
+        !names_the_file(&app),
+        "the parse error and the path belong in the log, not on the overlay: {:?}",
         app.message
     );
     app.handle(Action::Accept);
@@ -3493,7 +3509,12 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
     assert!(
         message_contains(&app, "cannot be remembered"),
-        "an unreadable file must be said on screen with its cause: {:?}",
+        "an unreadable file must be said on screen: {:?}",
+        app.message
+    );
+    assert!(
+        !names_the_file(&app),
+        "the read error and the path belong in the log, not on the overlay: {:?}",
         app.message
     );
     app.handle(Action::Accept);

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3233,6 +3233,15 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
             .unwrap()
             .acknowledged(group, digest)
     };
+    // The log is one file for every process on the host, appended to by
+    // whatever else runs; counted lines carry this fixture's path, so only
+    // this flow adds to them. Read as bytes: a stray byte from elsewhere is
+    // no reason to fail, and a log that cannot be read at all is named.
+    let logged = |line: &str| {
+        let bytes = std::fs::read(crate::LOG_PATH)
+            .unwrap_or_else(|error| panic!("{} could not be read: {error}", crate::LOG_PATH));
+        String::from_utf8_lossy(&bytes).matches(line).count()
+    };
 
     // 6. A complete pack: no warning, and nothing written down.
     let app = start(window.clone());
@@ -3347,10 +3356,7 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         docs.display(),
         no_index_diagnostics.join("; ")
     );
-    let logged_before = std::fs::read_to_string(crate::LOG_PATH)
-        .unwrap()
-        .matches(&logged_line)
-        .count();
+    let logged_before = logged(&logged_line);
     let app = start(window.clone());
     assert!(
         app.message.is_none(),
@@ -3361,12 +3367,10 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     assert_eq!(provider.health, ProviderHealth::Degraded);
     assert_eq!(provider.diagnostics, no_index_diagnostics);
     assert_eq!(
-        std::fs::read_to_string(crate::LOG_PATH)
-            .unwrap()
-            .matches(&logged_line)
-            .count(),
+        logged(&logged_line),
         logged_before + 1,
-        "an acknowledged warning must still be written to the log in full: {logged_line:?}"
+        "an acknowledged warning must still be written to {} in full: {logged_line:?}",
+        crate::LOG_PATH
     );
     assert_eq!(std::fs::read_to_string(&warnings).unwrap(), no_index_file);
     app.ui.hide().unwrap();
@@ -3387,10 +3391,7 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         "artwork pack warnings: {} is malformed:",
         warnings.display()
     );
-    let malformed_before = std::fs::read_to_string(crate::LOG_PATH)
-        .unwrap()
-        .matches(&malformed_line)
-        .count();
+    let malformed_before = logged(&malformed_line);
     let mut app = start(window.clone());
     assert!(
         message_contains(&app, "is incomplete"),
@@ -3418,12 +3419,10 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         app.message
     );
     assert_eq!(
-        std::fs::read_to_string(crate::LOG_PATH)
-            .unwrap()
-            .matches(&malformed_line)
-            .count(),
+        logged(&malformed_line),
         malformed_before + 1,
-        "the replacement of a file that broke meanwhile must reach the log"
+        "the replacement of a file that broke meanwhile must reach {}",
+        crate::LOG_PATH
     );
     assert!(
         acknowledged("NES", &extra_digest),
@@ -3462,10 +3461,7 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     // else; that warning says the file was set aside, and why, because the
     // press that dismisses it writes over what was there.
     std::fs::write(&warnings, "degraded = \"not a table").unwrap();
-    let malformed_before = std::fs::read_to_string(crate::LOG_PATH)
-        .unwrap()
-        .matches(&malformed_line)
-        .count();
+    let malformed_before = logged(&malformed_line);
     let mut app = start(window.clone());
     assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
     assert!(
@@ -3479,12 +3475,10 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         "the broken file is replaced by a readable one"
     );
     assert_eq!(
-        std::fs::read_to_string(crate::LOG_PATH)
-            .unwrap()
-            .matches(&malformed_line)
-            .count(),
+        logged(&malformed_line),
         malformed_before + 1,
-        "one broken file is one log line, not one per read of it"
+        "one broken file is one line in {}, not one per read of it",
+        crate::LOG_PATH
     );
     let acknowledged_file = std::fs::read_to_string(&warnings).unwrap();
     app.ui.hide().unwrap();

--- a/src/ui_acceptance_tests.rs
+++ b/src/ui_acceptance_tests.rs
@@ -3372,6 +3372,68 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     app.ui.hide().unwrap();
     drop(app);
 
+    // 4. Pack content updated without a new diagnostic: a well-formed row
+    // added to gameinfo.tsv changes only the source fingerprint, and that
+    // alone brings the warning back in a new process. Meanwhile the file
+    // on the card breaks after the warning went up, so the warning could
+    // not say so: the press that writes over it says it instead, on screen
+    // and in the log.
+    std::fs::write(
+        artwork.join("gameinfo.tsv"),
+        "#key\tname\tyear\tgenre\tdeveloper\tplayers\nKnown\tPack First\t1990\tAction\tStudio\t1\nSecond\tPack Second\t1991\tPuzzle\tStudio\t2\nExtra\tPack Extra\t1992\tAction\tStudio\t1\n",
+    )
+    .unwrap();
+    let malformed_line = format!(
+        "artwork pack warnings: {} is malformed:",
+        warnings.display()
+    );
+    let malformed_before = std::fs::read_to_string(crate::LOG_PATH)
+        .unwrap()
+        .matches(&malformed_line)
+        .count();
+    let mut app = start(window.clone());
+    assert!(
+        message_contains(&app, "is incomplete"),
+        "changed content with an unchanged diagnostic is a warning not yet seen: {:?}",
+        app.message
+    );
+    assert!(
+        !message_contains(&app, "could not be read"),
+        "the file was whole when the warning went up: {:?}",
+        app.message
+    );
+    let provider = app.artwork_provider.as_ref().unwrap();
+    assert_eq!(
+        provider.diagnostics, no_index_diagnostics,
+        "the diagnostic is unchanged; only the content is"
+    );
+    let extra_digest = provider.health_digest();
+    assert_ne!(extra_digest, no_index_digest);
+    std::fs::write(&warnings, "degraded = \"not a table").unwrap();
+    app.handle(Action::Accept);
+    assert!(
+        message_contains(&app, "remembered")
+            && message_contains(&app, "could not be read and was replaced"),
+        "a file that broke between the warning and the press is said at the press: {:?}",
+        app.message
+    );
+    assert_eq!(
+        std::fs::read_to_string(crate::LOG_PATH)
+            .unwrap()
+            .matches(&malformed_line)
+            .count(),
+        malformed_before + 1,
+        "the replacement of a file that broke meanwhile must reach the log"
+    );
+    assert!(
+        acknowledged("NES", &extra_digest),
+        "the broken file is replaced by a readable one"
+    );
+    app.handle(Action::Accept);
+    assert!(app.message.is_none(), "{:?}", app.message);
+    app.ui.hide().unwrap();
+    drop(app);
+
     // 4. An updated manifest is another pack state: warned about once more.
     // Meanwhile the file on the card was replaced by hand while this
     // process runs (another group's acknowledgement, this one's gone): the
@@ -3381,7 +3443,7 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     let mut app = start(window.clone());
     assert!(message_contains(&app, "is incomplete"), "{:?}", app.message);
     let updated_digest = app.artwork_provider.as_ref().unwrap().health_digest();
-    assert_ne!(updated_digest, no_index_digest);
+    assert_ne!(updated_digest, extra_digest);
     let mut by_hand = Acknowledgements::default();
     by_hand.acknowledge("SNES", "kept");
     by_hand.save(&warnings).unwrap();
@@ -3392,7 +3454,7 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
         acknowledged("SNES", "kept"),
         "an entry written by hand while the program runs must survive the next save"
     );
-    assert!(!acknowledged("NES", &no_index_digest));
+    assert!(!acknowledged("NES", &extra_digest));
     app.ui.hide().unwrap();
     drop(app);
 
@@ -3400,10 +3462,6 @@ fn run_degraded_pack_acknowledgement_flow(root: &Path, window: Rc<MinimalSoftwar
     // else; that warning says the file was set aside, and why, because the
     // press that dismisses it writes over what was there.
     std::fs::write(&warnings, "degraded = \"not a table").unwrap();
-    let malformed_line = format!(
-        "artwork pack warnings: {} is malformed:",
-        warnings.display()
-    );
     let malformed_before = std::fs::read_to_string(crate::LOG_PATH)
         .unwrap()
         .matches(&malformed_line)


### PR DESCRIPTION
## Summary

- A `Degraded` Artwork Pack warning is shown once per pack snapshot. Dismissing it writes the snapshot identity to `artwork-pack-warnings.toml` beside `settings.toml`, keyed by source group, so the warning does not return after a game launch or a restart of Degauss.
- The snapshot identity is a digest of the selected pack root, the health state, every diagnostic and the source-content fingerprint. A change to any of these shows the warning again; a content-only change (for example a table updated without a new diagnostic) is enough.
- Systems that share an Artwork Pack source share one acknowledgement: a warning dismissed while browsing one member of the group stays dismissed for the other members.
- The acknowledgement is written by the press that dismisses the warning, not when the warning is drawn. Headless runs (`--render`, `--bench`, `--layout`, `--screen`, `--select`, `--find`) never dismiss and never write. A press that takes another message off the screen does not count as a dismissal.
- `Invalid` and `Unavailable` packs are never acknowledged: as before, they are shown once per unchanged snapshot in a running process and again at every start.
- The complete diagnostic, every part joined with `; `, is still written to `/tmp/degauss.log` on every open (previously only the first diagnostic reached the log) and still printed by `--system <id> --report`, acknowledged or not.
- The acknowledgement file is read fresh when a warning is about to be shown and again immediately before each save, never cached: a file deleted or edited by hand while Degauss runs is respected by the next save. The file is installed through the same temporary-file, flush, rename and directory-flush sequence as `settings.toml` (now one crate-private install shared by both writers), a leftover temporary file is stepped around rather than truncated, and a failed save is reported on screen with its cause.
- A malformed acknowledgement file reads as empty: the warning is shown once more, saying that the list of dismissed warnings could not be read and will be replaced, and pointing at the log, where the parse error is written once. A file that exists but cannot be read is an error: the warning says it cannot be remembered, points at the log, and nothing is written over the file. The overlay never carries the file path or the raw error.
- Pre-existing headless open defect, fixed in a separate commit because the acceptance flow reproduces it: `finish_background_work_for_headless` returned before a system open that was restarted by a cache recovery completing inside one iteration, so a headless open (`--render --system <id>`, and the flow's `start` helper) could end with the system unopened and the source-resolution message on screen. The loop now also waits for the source resolution.
- Unrelated doc comment placement, fixed in a separate commit: in `src/main.rs` the line "Beside the settings, which is beside the configuration." sat above `import_favorites`, which has its own doc comment; it describes `state_path_for` and now sits there.
- README: the Artwork Pack section describes the once-per-snapshot behaviour, the file, and how to see acknowledged warnings again (delete the file and restart). `.gitignore` lists the new file next to `settings.toml` and `state.toml`.

Fixes #50

## Compatibility

- No migration, rebuild or manual reset. Existing `settings.toml`, `state.toml` and cache files are untouched and remain readable.
- The new file is only ever written when a `Degraded` warning is dismissed. A missing, stale, malformed or unreadable file never prevents Degauss from starting; the only cost of a missing or malformed file is one more warning.
- Downgrading to an earlier release leaves an unused `artwork-pack-warnings.toml` beside the settings; earlier releases do not read it.
- `Ready` packs behave exactly as before and show no health warning. The Artwork Pack itself is never modified and `Degraded` is never treated as `Ready`.

## Tests

- `src/artwork_pack.rs`: the health digest is stable for an unchanged degraded pack, is shared by the systems of one source group, and changes with a content-only table change, with a diagnostic change and with a health change.
- `src/main.rs`: `pack_report_lines`, which `print_report` prints the Artwork Pack lines from, lists every diagnostic of an incomplete pack, in order, after the health line. The report path never reads the acknowledgement file, so the test asserts only what that path does.
- `src/pack_health.rs`: a saved acknowledgement reads back for its group only; a missing file acknowledges nothing; a malformed file acknowledges nothing and is replaced by the next save; a file that cannot be read is an error and not an empty list; a new snapshot replaces the old one and leaves other groups alone; saving leaves no temporary file; a leftover temporary file is stepped around; a save whose temporary file cannot be created, or that cannot move into place, reports its error and leaves no temporary file.
- `src/settings.rs`: a temporary file that cannot be removed after a failed write is part of the reported failure, for both writers.
- `src/ui_acceptance_tests.rs`, `run_degraded_pack_acknowledgement_flow`, exercised at App level with new processes started by rebuilding the App over the same fixture: the seven acceptance checks of the issue, including the warning shown on first open and not written until dismissed, no repeat after re-entry in the same process, no repeat in a new process, a new diagnostic and a content-only change each bringing the warning back, the acknowledgement keyed by source group across NeoGeo and NeoGeoMVS, a malformed file costing one warning that says why, an unreadable file leaving the file alone, a failed save said on screen, `Invalid` and `Unavailable` packs shown at every start, a complete pack writing nothing, and exactly one more full diagnostic line in the log after the acknowledged restart. The flow first writes one probe line through `note` and asserts it arrived, so a host where `/tmp/degauss.log` cannot be written fails on that precondition rather than on the acknowledgement logic.
- The headless open fix is asserted by the flow's `start` helper: a cache recovery completing during a headless open leaves the system opened.

## Validation

- Host gates (fmt, test, rehearse, ra, clippy for the ARM target) passed on the pushed head.
- Further review-round commits may follow on this branch.
- Device validation is pending: the acceptance checks have not yet been run on a MiSTer with a `Degraded` pack (first open warns, dismissal, game launch and return without the warning, pack update bringing it back, `Invalid` and `Unavailable` still shown), nor the compatibility checks on an existing installation, a fresh installation and a downgrade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Artwork Pack warnings can be dismissed and remain acknowledged for the relevant source and state.
  - Detailed diagnostics remain available in reports and logs after warnings are dismissed.
  - Acknowledged warnings can be reset by deleting the acknowledgement file.
  - Missing, invalid, or unavailable databases continue to be reported on each start.

- **Bug Fixes**
  - Prevented repeated warnings and stale fallback data after dismissal.
  - Improved handling and reporting of malformed, unreadable, or failed acknowledgement-file operations.
  - Ensured background processing waits for Artwork Pack source resolution before displaying results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
