### PR TITLE
Debounce very fast duplicate controller inputs before dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@ data source and rebuilding; **Appearance** contains view and image controls.
 
 A gamepad needs no extra setup and browsing and settings need no keyboard. While Degauss
 owns the screen, MiSTer sends the d-pad as arrows and the face buttons as
-Enter, Escape, Space and Tab.
+Enter, Escape, Space and Tab. One physical press counts once even when a
+controller or the input stack delivers it as two press and release pairs
+within 40 ms; held scrolling and deliberate repeated taps are not affected.
 
 ### Running MiSTer scripts
 

--- a/docs/testing/controller-double-delivery-hardware.md
+++ b/docs/testing/controller-double-delivery-hardware.md
@@ -1,0 +1,28 @@
+# Controller double delivery hardware checks
+
+Some controllers, or the input stack between them and Degauss, deliver one physical press as two very fast press and release pairs. Degauss drops the second pair of the same action when it arrives within 40 ms of the first, before the press reaches its own held-key repeater. The host tests cover the sequences themselves; the checks below need a real MiSTer, a keyboard, an ordinary controller and, for the last section, a controller known to deliver presses twice.
+
+## Ordinary keyboard and controller
+
+Use a keyboard and a controller that deliver each press once. Nothing about them may feel different.
+
+1. Tap up and down once in the Categories home screen, a system list, a folder, Favourites, search results, Actions, Menu and every Options page. Each tap moves one row.
+2. Repeat single taps of left and right with each **Left and Right Behaviour** value. Each tap changes the speed, jumps one letter, jumps one page or moves one row, once.
+3. Tap A, B, X and Y once each where they apply. Each press acts once: one folder opened, one level backed out, one Actions list, one Menu.
+4. Hold up and down through the initial delay at every **Scroll Speed**, including the fastest. The scroll starts after the same delay and runs at the same cadence as before. Hold left and right in the plain movement setting and confirm they scroll the same way.
+5. Enable **Hold X (1s) to Add/Remove Fav** and **Hold Y (1s) for Random Game**. A one-second hold fires each shortcut once; a short press still opens Actions or Menu. Releasing the button on the screen a shortcut opened does nothing there.
+6. Tap the same direction twice in quick succession, deliberately. Both taps move.
+
+## Affected controller
+
+Use a controller or input stack that delivers one press as two pairs.
+
+1. Tap up and down in the same views as above. Each tap moves exactly one row.
+2. Tap left and right with each **Left and Right Behaviour** value. Each tap acts once.
+3. Tap A, B, X and Y. Each press acts once and no screen is opened or left twice.
+4. Hold a direction. The scroll starts after the initial delay, runs at the configured speed and stops on release; nothing keeps scrolling afterwards.
+5. Reverse direction quickly, and alternate left and right quickly. Every change of direction acts immediately.
+6. Hold X and Y for one second with their shortcuts enabled. Each shortcut fires once, and releasing the button afterwards does nothing.
+7. Connect the ordinary controller alongside the affected one and repeat the taps. One press is one action whichever controller sends it.
+
+Record which controller and MiSTer input configuration was used and which checks were performed. A check not performed is not a pass.

--- a/docs/testing/controller-double-delivery-hardware.md
+++ b/docs/testing/controller-double-delivery-hardware.md
@@ -12,7 +12,7 @@ Use a keyboard and a controller that deliver each press once. Nothing about them
 4. Hold up and down through the initial delay at every **Scroll Speed**, including the fastest. The scroll starts after the same delay and runs at the same cadence as before. Hold left and right with **Left and Right Behaviour** set to Letter, to Page and to Direction, and confirm each starts after the same delay and runs at the same cadence as before.
 5. Enable **Hold X (1s) to Add/Remove Fav** and **Hold Y (1s) for Random Game**. A one-second hold fires each shortcut once; a short press still opens Actions or Menu. Releasing the button on the screen a shortcut opened does nothing there.
 6. Tap the same direction twice in quick succession, deliberately, with more than 40 ms between the taps. Both taps move.
-7. Open a large system and tap the same direction twice, deliberately, while its list is still being read; repeat while a rebuild of the library is running. Both taps move once the screen catches up: presses that queue up behind a slow frame are judged on the time each was delivered, not on the frame that dispatches them.
+7. Open a large system and tap the same direction twice, deliberately and more than 40 ms apart, while its list is still being read; repeat while a rebuild of the library is running. Both taps move once the screen catches up: presses that queue up behind a slow frame are judged on the time each was delivered, not on the frame that dispatches them.
 
 ## Affected controller
 
@@ -24,6 +24,6 @@ Use a controller or input stack that delivers one press as two pairs.
 4. Hold a direction. The scroll starts after the initial delay, runs at the configured speed and stops on release; nothing keeps scrolling afterwards.
 5. Reverse direction quickly, and alternate left and right quickly. Every change of direction acts immediately.
 6. Hold X and Y for one second with their shortcuts enabled. Each shortcut fires once, and releasing the button afterwards does nothing.
-7. Connect the ordinary controller alongside the affected one and repeat the taps. One press is one action whichever controller sends it. Repeat check 7 of the previous section with both connected: both deliberate taps move once the screen catches up.
+7. Connect the ordinary controller alongside the affected one and repeat the taps on each controller in turn. One press is one action whichever controller sends it: the affected controller's second pair, inside 40 ms, is dropped, and two deliberate taps more than 40 ms apart, on the same controller or one on each, move twice. Repeat check 7 of the previous section with both connected: both deliberate taps move once the screen catches up.
 
 Record which controller and MiSTer input configuration was used and which checks were performed. A check not performed is not a pass.

--- a/docs/testing/controller-double-delivery-hardware.md
+++ b/docs/testing/controller-double-delivery-hardware.md
@@ -11,7 +11,7 @@ Use a keyboard and a controller that deliver each press once. Nothing about them
 3. Tap A, B, X and Y once each where they apply. Each press acts once: one folder opened, one level backed out, one Actions list, one Menu.
 4. Hold up and down through the initial delay at every **Scroll Speed**, including the fastest. The scroll starts after the same delay and runs at the same cadence as before. Hold left and right with **Left and Right Behaviour** set to Letter, to Page and to Direction, and confirm each starts after the same delay and runs at the same cadence as before.
 5. Enable **Hold X (1s) to Add/Remove Fav** and **Hold Y (1s) for Random Game**. A one-second hold fires each shortcut once; a short press still opens Actions or Menu. Releasing the button on the screen a shortcut opened does nothing there.
-6. Tap the same direction twice in quick succession, deliberately. Both taps move.
+6. Tap the same direction twice in quick succession, deliberately, with more than 40 ms between the taps. Both taps move.
 7. Open a large system and tap the same direction twice, deliberately, while its list is still being read; repeat while a rebuild of the library is running. Both taps move once the screen catches up: presses that queue up behind a slow frame are judged on the time each was delivered, not on the frame that dispatches them.
 
 ## Affected controller

--- a/docs/testing/controller-double-delivery-hardware.md
+++ b/docs/testing/controller-double-delivery-hardware.md
@@ -9,9 +9,10 @@ Use a keyboard and a controller that deliver each press once. Nothing about them
 1. Tap up and down once in the Categories home screen, a system list, a folder, Favourites, search results, Actions, Menu and every Options page. Each tap moves one row.
 2. Repeat single taps of left and right with each **Left and Right Behaviour** value. Each tap changes the speed, jumps one letter, jumps one page or moves one row, once.
 3. Tap A, B, X and Y once each where they apply. Each press acts once: one folder opened, one level backed out, one Actions list, one Menu.
-4. Hold up and down through the initial delay at every **Scroll Speed**, including the fastest. The scroll starts after the same delay and runs at the same cadence as before. Hold left and right in the plain movement setting and confirm they scroll the same way.
+4. Hold up and down through the initial delay at every **Scroll Speed**, including the fastest. The scroll starts after the same delay and runs at the same cadence as before. Hold left and right with **Left and Right Behaviour** set to Letter, to Page and to Direction, and confirm each starts after the same delay and runs at the same cadence as before.
 5. Enable **Hold X (1s) to Add/Remove Fav** and **Hold Y (1s) for Random Game**. A one-second hold fires each shortcut once; a short press still opens Actions or Menu. Releasing the button on the screen a shortcut opened does nothing there.
 6. Tap the same direction twice in quick succession, deliberately. Both taps move.
+7. Open a large system and tap the same direction twice, deliberately, while its list is still being read; repeat while a rebuild of the library is running. Both taps move once the screen catches up: presses that queue up behind a slow frame are judged on the time each was delivered, not on the frame that dispatches them.
 
 ## Affected controller
 

--- a/docs/testing/controller-double-delivery-hardware.md
+++ b/docs/testing/controller-double-delivery-hardware.md
@@ -1,6 +1,6 @@
 # Controller double delivery hardware checks
 
-Some controllers, or the input stack between them and Degauss, deliver one physical press as two very fast press and release pairs. Degauss drops the second pair of the same action when its press arrives within 40 ms of the first press, measured between the two presses on the kernel's event timestamps, before the press reaches its own held-key repeater. Pairs inside that window cannot be produced by hand: the host tests feed them directly, and the checks below need a real MiSTer, a keyboard, an ordinary controller and, for the last section, a controller known to deliver presses twice.
+Some controllers, or the input stack between them and Degauss, deliver one physical press as two very fast press and release pairs. Degauss drops the second pair of the same action when its press arrives less than 40 ms after the first press, measured between the two presses on the kernel's event timestamps (a press exactly 40 ms later is a new press), before the press reaches its own held-key repeater. Pairs inside that window cannot be produced by hand: the host tests feed them directly, and the checks below need a real MiSTer, a keyboard, an ordinary controller and, for the last section, a controller known to deliver presses twice.
 
 ## Ordinary keyboard and controller
 

--- a/docs/testing/controller-double-delivery-hardware.md
+++ b/docs/testing/controller-double-delivery-hardware.md
@@ -1,6 +1,6 @@
 # Controller double delivery hardware checks
 
-Some controllers, or the input stack between them and Degauss, deliver one physical press as two very fast press and release pairs. Degauss drops the second pair of the same action when its press arrives less than 40 ms after the first press, measured between the two presses on the kernel's event timestamps (a press exactly 40 ms later is a new press), before the press reaches its own held-key repeater. Pairs inside that window cannot be produced by hand: the host tests feed them directly, and the checks below need a real MiSTer, a keyboard, an ordinary controller and, for the last section, a controller known to deliver presses twice.
+Some controllers, or the input stack between them and Degauss, deliver one physical press as two very fast press and release pairs. Degauss drops the second pair of the same action when its press arrives less than 40 ms after the first press, measured between the two presses on the kernel's event timestamps (a press exactly 40 ms later is a new press), before the press reaches its own held-key repeater. Pairs inside that window cannot be produced by hand: the host tests in `src/input.rs` feed them directly (`deliberate_taps_outside_the_window_both_count` holds the boundary, a second press 39 ms later dropped and one 40 ms later accepted), and the checks below need a real MiSTer, a keyboard, an ordinary controller and, for the last section, a controller known to deliver presses twice.
 
 ## Ordinary keyboard and controller
 

--- a/docs/testing/controller-double-delivery-hardware.md
+++ b/docs/testing/controller-double-delivery-hardware.md
@@ -24,6 +24,6 @@ Use a controller or input stack that delivers one press as two pairs.
 4. Hold a direction. The scroll starts after the initial delay, runs at the configured speed and stops on release; nothing keeps scrolling afterwards.
 5. Reverse direction quickly, and alternate left and right quickly. Every change of direction acts immediately.
 6. Hold X and Y for one second with their shortcuts enabled. Each shortcut fires once, and releasing the button afterwards does nothing.
-7. Connect the ordinary controller alongside the affected one and repeat the taps. One press is one action whichever controller sends it.
+7. Connect the ordinary controller alongside the affected one and repeat the taps. One press is one action whichever controller sends it. Repeat check 7 of the previous section with both connected: both deliberate taps move once the screen catches up.
 
 Record which controller and MiSTer input configuration was used and which checks were performed. A check not performed is not a pass.

--- a/docs/testing/controller-double-delivery-hardware.md
+++ b/docs/testing/controller-double-delivery-hardware.md
@@ -1,6 +1,6 @@
 # Controller double delivery hardware checks
 
-Some controllers, or the input stack between them and Degauss, deliver one physical press as two very fast press and release pairs. Degauss drops the second pair of the same action when it arrives within 40 ms of the first, before the press reaches its own held-key repeater. The host tests cover the sequences themselves; the checks below need a real MiSTer, a keyboard, an ordinary controller and, for the last section, a controller known to deliver presses twice.
+Some controllers, or the input stack between them and Degauss, deliver one physical press as two very fast press and release pairs. Degauss drops the second pair of the same action when its press arrives within 40 ms of the first press, measured between the two presses on the kernel's event timestamps, before the press reaches its own held-key repeater. Pairs inside that window cannot be produced by hand: the host tests feed them directly, and the checks below need a real MiSTer, a keyboard, an ordinary controller and, for the last section, a controller known to deliver presses twice.
 
 ## Ordinary keyboard and controller
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -13220,11 +13220,14 @@ impl App {
             repeater.set_horizontal_repeats(self.horizontal_scrolls());
             repeater.set_favorite_hold(self.favorite_change().is_some());
             repeater.set_random_hold(self.random_shortcut_enabled());
-            for edge in input.poll() {
+            for (edge, at) in input.poll() {
                 // Some controllers deliver one press as two very fast press
                 // and release pairs. The second pair is dropped here, before
                 // the repeater, so the held-scroll cadence is not touched.
-                let Some(edge) = duplicates.admit(edge, now) else {
+                // Judged on the kernel's stamp for each event rather than
+                // this frame's `now`: a frame stalled on a system read
+                // drains every press queued behind it in one poll.
+                let Some(edge) = duplicates.admit(edge, at) else {
                     continue;
                 };
                 let action = match edge {

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,7 +37,7 @@ use crate::covers::{BudgetedCover, CoverCache, CoverStats};
 use crate::error::{DegaussError, Result};
 use crate::font::Font;
 use crate::input::{
-    Action, InputReader, KeyEdge, RepeatConfig, Repeater, SPEED_START, SPEED_STEPS,
+    Action, DuplicateGuard, InputReader, KeyEdge, RepeatConfig, Repeater, SPEED_START, SPEED_STEPS,
 };
 use crate::list_state::ListState;
 use crate::metrics::{FrameTimer, StartupTimings};
@@ -13188,6 +13188,7 @@ impl App {
             interval: Duration::from_millis(self.speed_ms()),
             ..Default::default()
         });
+        let mut duplicates = DuplicateGuard::new();
         let mut first_frame_done = false;
         // Dropped for good if the device ever declines, so a framebuffer
         // without the ioctl costs one failed call rather than one per frame.
@@ -13220,6 +13221,12 @@ impl App {
             repeater.set_favorite_hold(self.favorite_change().is_some());
             repeater.set_random_hold(self.random_shortcut_enabled());
             for edge in input.poll() {
+                // Some controllers deliver one press as two very fast press
+                // and release pairs. The second pair is dropped here, before
+                // the repeater, so the held-scroll cadence is not touched.
+                let Some(edge) = duplicates.admit(edge, now) else {
+                    continue;
+                };
                 let action = match edge {
                     KeyEdge::Down(action) => repeater.press(action, now),
                     KeyEdge::Up(action) => repeater.release(action, now),

--- a/src/input.rs
+++ b/src/input.rs
@@ -415,6 +415,36 @@ pub fn key_edge(action: Action, value: i32) -> Option<KeyEdge> {
     }
 }
 
+/// Merge the edges one device delivered, `edges[split..]`, into those the
+/// devices before it delivered, `edges[..split]`, by stamp. Devices are
+/// drained one after another, so without this a batch carries one
+/// device's later edges before another's earlier ones, and the guard and
+/// the repeater take the edges in turn: a press placed before the release
+/// it followed reaches the repeater while that action is still held, and
+/// the press is lost. Each device's own order is kept whatever its stamps
+/// say, so a wall-clock step between a press and its release cannot swap
+/// them and leave the key held. Nothing is allocated unless both sides
+/// hold edges.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn merge_by_stamp(edges: &mut Vec<(KeyEdge, SystemTime)>, split: usize) {
+    if split == 0 || split == edges.len() {
+        return;
+    }
+    let later = edges.split_off(split);
+    let earlier = std::mem::replace(edges, Vec::with_capacity(split + later.len()));
+    let mut earlier = earlier.into_iter().peekable();
+    let mut later = later.into_iter().peekable();
+    while let (Some(&(_, before)), Some(&(_, after))) = (earlier.peek(), later.peek()) {
+        if after < before {
+            edges.extend(later.next());
+        } else {
+            edges.extend(earlier.next());
+        }
+    }
+    edges.extend(earlier);
+    edges.extend(later);
+}
+
 /// A second press of the same action closer than this to the accepted one
 /// is the same physical press arriving twice, not a deliberate second tap.
 pub const DUPLICATE_WINDOW: Duration = Duration::from_millis(40);
@@ -502,11 +532,12 @@ impl DuplicateGuard {
     /// An accepted press clears any release still owed, so a duplicate whose
     /// release never arrives cannot swallow a later genuine release.
     ///
-    /// The window reaches both ways from the accepted press. Devices are
-    /// drained one after another, so the second device's copy of a press
-    /// can carry an earlier stamp than the first's; and the stamps come
-    /// from the wall clock, which can step. A step larger than the window
-    /// lets one press through and the next accepted press re-anchors.
+    /// The window reaches both ways from the accepted press. A poll merges
+    /// what it drained by stamp, but a copy injected on one device just
+    /// after that device was read reaches the next poll behind the other
+    /// device's copy stamped later; and the stamps come from the wall
+    /// clock, which can step. A step larger than the window lets one press
+    /// through and the next accepted press re-anchors.
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub fn admit(&mut self, edge: KeyEdge, at: SystemTime) -> Option<KeyEdge> {
         match edge {
@@ -551,7 +582,7 @@ mod linux {
 
     use evdev::{Device, EventSummary};
 
-    use super::{action_for_key, key_edge, KeyEdge};
+    use super::{action_for_key, key_edge, merge_by_stamp, KeyEdge};
     use crate::error::{DegaussError, Result};
 
     /// What was opened, so Degauss can show whether it is actually
@@ -615,7 +646,7 @@ mod linux {
         }
 
         /// Drain whatever is waiting, each edge with the time the kernel
-        /// stamped on its event. Never blocks.
+        /// stamped on its event, in stamp order. Never blocks.
         pub fn poll(&mut self) -> Vec<(KeyEdge, SystemTime)> {
             let mut edges = Vec::new();
             for (_, device) in &mut self.devices {
@@ -624,6 +655,7 @@ mod linux {
                     // WouldBlock simply means nothing is waiting.
                     Err(_) => continue,
                 };
+                let drained = edges.len();
                 for event in events {
                     let at = event.timestamp();
                     if let EventSummary::Key(_, code, value) = event.destructure() {
@@ -635,6 +667,7 @@ mod linux {
                         }
                     }
                 }
+                merge_by_stamp(&mut edges, drained);
             }
             edges
         }
@@ -1478,13 +1511,31 @@ mod tests {
         }
 
         /// One loop iteration at `now` dispatching the edges one poll
-        /// drained, each stamped `at` milliseconds by the kernel.
+        /// drained from one device, each stamped `at` milliseconds by the
+        /// kernel.
         fn batch(&mut self, now: u64, edges: &[(KeyEdge, u64)]) -> Vec<Action> {
+            self.devices(now, &[edges])
+        }
+
+        /// One loop iteration at `now` dispatching the edges one poll
+        /// drained from several devices, given in the order the devices
+        /// were drained, merged as the poll merges them.
+        fn devices(&mut self, now: u64, drained: &[&[(KeyEdge, u64)]]) -> Vec<Action> {
             let now = self.t0 + ms(now);
+            let mut edges: Vec<(KeyEdge, SystemTime)> = Vec::new();
+            for device in drained {
+                let split = edges.len();
+                edges.extend(
+                    device
+                        .iter()
+                        .map(|&(edge, at)| (edge, SystemTime::UNIX_EPOCH + ms(at))),
+                );
+                merge_by_stamp(&mut edges, split);
+            }
             let mut dispatched = Vec::new();
-            for &(edge, at) in edges {
+            for (edge, at) in edges {
                 let edge = match &mut self.guard {
-                    Some(guard) => match guard.admit(edge, SystemTime::UNIX_EPOCH + ms(at)) {
+                    Some(guard) => match guard.admit(edge, at) {
                         Some(edge) => edge,
                         None => continue,
                     },
@@ -1661,10 +1712,12 @@ mod tests {
 
     #[test]
     fn a_second_device_stamped_earlier_is_still_the_same_press() {
-        // Devices are drained one after another, so the second device's
-        // copy of a press can carry an earlier stamp than the copy already
-        // accepted from the first. The window has to reach both ways or
-        // that copy would pass and move the selection again.
+        // Devices are drained one after another. A copy of a press
+        // injected on one device just after that device was read waits
+        // for the next poll, behind the other device's copy stamped a
+        // little later, so the copy already accepted can carry the later
+        // stamp. The window has to reach both ways or the earlier copy
+        // would pass and move the selection again.
         let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
         assert_eq!(
             guarded.batch(
@@ -1672,11 +1725,19 @@ mod tests {
                 &[
                     (KeyEdge::Down(Action::Down), 12),
                     (KeyEdge::Up(Action::Down), 18),
+                ]
+            ),
+            vec![Action::Down]
+        );
+        assert_eq!(
+            guarded.batch(
+                36,
+                &[
                     (KeyEdge::Down(Action::Down), 10),
                     (KeyEdge::Up(Action::Down), 16),
                 ]
             ),
-            vec![Action::Down]
+            vec![]
         );
         assert!(!guarded.repeater.anything_held());
         assert_eq!(
@@ -1700,6 +1761,75 @@ mod tests {
             ]),
             vec![Action::Down, Action::Down],
             "the press at 970 ms is inside the window of the one at 960 ms"
+        );
+    }
+
+    #[test]
+    fn a_poll_batch_is_dispatched_in_stamp_order_across_devices() {
+        // Two devices report one press; the second copy is rejected and
+        // its release is owed. A frame then stalls across the genuine
+        // release and the next deliberate tap. The poll drains the first
+        // device, which holds that release and the new press, before the
+        // second, which holds the duplicate's release. In drain order the
+        // owed release swallows the genuine one, the new press reaches the
+        // repeater while it still holds the action and dispatches nothing,
+        // and the duplicate's release then ends the hold: a deliberate tap
+        // lost. In stamp order the two releases come first and the tap
+        // acts.
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            guarded.feed(&[
+                (KeyEdge::Down(Action::Down), 0),
+                (KeyEdge::Down(Action::Down), 2),
+            ]),
+            vec![Action::Down]
+        );
+        assert_eq!(
+            guarded.devices(
+                400,
+                &[
+                    &[
+                        (KeyEdge::Up(Action::Down), 300),
+                        (KeyEdge::Down(Action::Down), 350),
+                    ],
+                    &[(KeyEdge::Up(Action::Down), 302)],
+                ]
+            ),
+            vec![Action::Down],
+            "the tap at 350 ms must act whichever device was drained first"
+        );
+        assert!(
+            guarded.repeater.anything_held(),
+            "the tap at 350 ms is still held when the frame ends"
+        );
+        assert_eq!(guarded.edge(KeyEdge::Up(Action::Down), 500), None);
+        assert!(!guarded.repeater.anything_held());
+
+        // A device's own order is kept whatever its stamps say: the wall
+        // clock stepped back between a press and its release queued in
+        // one frame. Sorted on the stamps alone, the release would come
+        // first and the press would leave the key held.
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            guarded.devices(
+                1000,
+                &[
+                    &[
+                        (KeyEdge::Down(Action::Up), 1000),
+                        (KeyEdge::Up(Action::Up), 5)
+                    ],
+                    &[
+                        (KeyEdge::Down(Action::Down), 8),
+                        (KeyEdge::Up(Action::Down), 12)
+                    ],
+                ]
+            ),
+            vec![Action::Down, Action::Up],
+            "the other device's edges are merged in by stamp"
+        );
+        assert!(
+            !guarded.repeater.anything_held(),
+            "the release still follows its press"
         );
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -22,15 +22,15 @@
 //! * Keystrokes still reach the console as well, so the terminal is put
 //!   into a quiet mode while Degauss draws and restored when it exits.
 //!
-//! * Some controllers, or the input stack between them and Degauss, deliver
-//!   one physical press as two very fast press and release pairs. The
-//!   second pair is dropped by the [`DuplicateGuard`] before anything else
-//!   sees it, so one press moves once.
-//!
 //! Key repeat is generated here rather than taken from the kernel, because
 //! the cadence of a held direction is a setting the user controls.
+//!
+//! Some controllers, or the input stack between them and Degauss, deliver
+//! one physical press as two very fast press and release pairs. The second
+//! pair is dropped by the [`DuplicateGuard`] before anything else sees it,
+//! so one press moves once.
 
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 /// What Degauss does, independent of which key or button produced it.
 ///
@@ -71,6 +71,27 @@ pub enum Action {
 }
 
 impl Action {
+    /// Every variant in declaration order. The [`DuplicateGuard`] sizes its
+    /// table from this list and indexes it by discriminant, and the check
+    /// under it refuses to compile until a new variant is appended here.
+    pub const ALL: [Action; 15] = [
+        Action::Up,
+        Action::Down,
+        Action::Slower,
+        Action::Faster,
+        Action::PageUp,
+        Action::PageDown,
+        Action::Home,
+        Action::End,
+        Action::Accept,
+        Action::Quit,
+        Action::CyclePresent,
+        Action::Menu,
+        Action::Context,
+        Action::FavoriteShortcut,
+        Action::RandomShortcut,
+    ];
+
     /// Whether holding the key always repeats. Only movement repeats:
     /// repeating "launch" would be dangerous, and repeating a speed change
     /// would run the whole ladder off one press. Left and right join in
@@ -395,16 +416,45 @@ pub fn key_edge(action: Action, value: i32) -> Option<KeyEdge> {
 /// is the same physical press arriving twice, not a deliberate second tap.
 pub const DUPLICATE_WINDOW: Duration = Duration::from_millis(40);
 
-/// One slot per [`Action`]. `RandomShortcut` is the last variant; a variant
-/// added after it must move this.
-const ACTION_SLOTS: usize = Action::RandomShortcut as usize + 1;
+/// One slot per [`Action`], indexed by discriminant.
+const ACTION_SLOTS: usize = Action::ALL.len();
+
+// `Action::ALL` must hold every variant at its own discriminant, or the
+// guard would index past its table on the first press of the missing one.
+// The match is exhaustive: a variant added to the enum does not compile
+// until it has an arm here, and the arm is only right once the variant is
+// appended to `ALL` as well.
+const _: () = {
+    let mut i = 0;
+    while i < ACTION_SLOTS {
+        let listed = match Action::ALL[i] {
+            Action::Up
+            | Action::Down
+            | Action::Slower
+            | Action::Faster
+            | Action::PageUp
+            | Action::PageDown
+            | Action::Home
+            | Action::End
+            | Action::Accept
+            | Action::Quit
+            | Action::CyclePresent
+            | Action::Menu
+            | Action::Context
+            | Action::FavoriteShortcut
+            | Action::RandomShortcut => Action::ALL[i] as usize,
+        };
+        assert!(listed == i, "Action::ALL is not in declaration order");
+        i += 1;
+    }
+};
 
 #[derive(Debug, Clone, Copy)]
 struct Slot {
-    /// When the last accepted press of this action arrived. It anchors the
-    /// window: a rejected duplicate never moves it, so a run of duplicates
-    /// cannot keep the window open.
-    accepted_at: Option<Instant>,
+    /// When the device delivered the last accepted press of this action.
+    /// It anchors the window: a rejected duplicate never moves it, so a
+    /// run of duplicates cannot keep the window open.
+    accepted_at: Option<SystemTime>,
     /// A rejected duplicate is still down as far as its device is
     /// concerned, so a release is owed for it. That release must be
     /// swallowed rather than end the genuine hold under it.
@@ -414,8 +464,14 @@ struct Slot {
 /// Drops the second delivery of one physical press before it reaches the
 /// [`Repeater`]. Only real key edges pass through here; the repeats the
 /// [`Repeater`] generates for a held key never do, which is what keeps the
-/// 7 ms scroll interval intact. One array index and two comparisons per
-/// edge, nothing allocated.
+/// 7 ms scroll interval intact.
+///
+/// The window is measured on the kernel's own timestamps, taken when each
+/// device delivered the event, not on the run loop's clock: a frame that
+/// stalls on a system read drains every press queued behind it in one
+/// poll, and two deliberate taps in that queue must still count as two.
+/// One array index, one subtraction and one comparison per edge, nothing
+/// allocated.
 #[derive(Debug)]
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub struct DuplicateGuard {
@@ -433,7 +489,8 @@ impl DuplicateGuard {
         }
     }
 
-    /// Filter one key edge read from a device. `None` means drop it.
+    /// Filter one key edge read from a device, `at` being the time the
+    /// kernel stamped on it. `None` means drop it.
     ///
     /// A press inside [`DUPLICATE_WINDOW`] of the last accepted press of the
     /// same action is a duplicate: rejected, and its eventual release is
@@ -441,19 +498,28 @@ impl DuplicateGuard {
     /// different action is never affected, an opposite direction included.
     /// An accepted press clears any release still owed, so a duplicate whose
     /// release never arrives cannot swallow a later genuine release.
+    ///
+    /// The window reaches both ways from the accepted press. Devices are
+    /// drained one after another, so the second device's copy of a press
+    /// can carry an earlier stamp than the first's; and the stamps come
+    /// from the wall clock, which can step. A step larger than the window
+    /// lets one press through and the next accepted press re-anchors.
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-    pub fn admit(&mut self, edge: KeyEdge, now: Instant) -> Option<KeyEdge> {
+    pub fn admit(&mut self, edge: KeyEdge, at: SystemTime) -> Option<KeyEdge> {
         match edge {
             KeyEdge::Down(action) => {
                 let slot = &mut self.slots[action as usize];
-                if slot
-                    .accepted_at
-                    .is_some_and(|at| now.duration_since(at) < DUPLICATE_WINDOW)
-                {
+                if slot.accepted_at.is_some_and(|accepted| {
+                    let apart = match at.duration_since(accepted) {
+                        Ok(later) => later,
+                        Err(earlier) => earlier.duration(),
+                    };
+                    apart < DUPLICATE_WINDOW
+                }) {
                     slot.duplicate_down = true;
                     return None;
                 }
-                slot.accepted_at = Some(now);
+                slot.accepted_at = Some(at);
                 slot.duplicate_down = false;
                 Some(edge)
             }
@@ -478,6 +544,7 @@ pub use linux::{
 #[cfg(target_os = "linux")]
 mod linux {
     use std::path::PathBuf;
+    use std::time::SystemTime;
 
     use evdev::{Device, EventSummary};
 
@@ -544,8 +611,9 @@ mod linux {
             self.summaries.iter().any(|d| d.is_mister_virtual)
         }
 
-        /// Drain whatever is waiting. Never blocks.
-        pub fn poll(&mut self) -> Vec<KeyEdge> {
+        /// Drain whatever is waiting, each edge with the time the kernel
+        /// stamped on its event. Never blocks.
+        pub fn poll(&mut self) -> Vec<(KeyEdge, SystemTime)> {
             let mut edges = Vec::new();
             for (_, device) in &mut self.devices {
                 let events = match device.fetch_events() {
@@ -554,12 +622,13 @@ mod linux {
                     Err(_) => continue,
                 };
                 for event in events {
+                    let at = event.timestamp();
                     if let EventSummary::Key(_, code, value) = event.destructure() {
                         let Some(action) = action_for_key(code.code()) else {
                             continue;
                         };
                         if let Some(edge) = key_edge(action, value) {
-                            edges.push(edge);
+                            edges.push((edge, at));
                         }
                     }
                 }
@@ -847,6 +916,7 @@ pub use elsewhere::{
 #[allow(dead_code)]
 mod elsewhere {
     use std::path::PathBuf;
+    use std::time::SystemTime;
 
     use super::KeyEdge;
     use crate::error::Result;
@@ -870,7 +940,7 @@ mod elsewhere {
         pub fn has_mister_virtual(&self) -> bool {
             false
         }
-        pub fn poll(&mut self) -> Vec<KeyEdge> {
+        pub fn poll(&mut self) -> Vec<(KeyEdge, SystemTime)> {
             Vec::new()
         }
     }
@@ -1378,8 +1448,9 @@ mod tests {
     /// The dispatch shape of the run loop: every key edge read from a
     /// device passes the guard before the repeater, only what the repeater
     /// returns is dispatched, and the repeater's own ticks never see the
-    /// guard. Built without the guard to show what the repeater alone does
-    /// with the same edges.
+    /// guard. The guard judges each edge on the kernel's stamp for it; the
+    /// repeater sees the loop's one instant per iteration. Built without
+    /// the guard to show what the repeater alone does with the same edges.
     struct Pipeline {
         guard: Option<DuplicateGuard>,
         repeater: Repeater,
@@ -1403,18 +1474,35 @@ mod tests {
             }
         }
 
-        fn edge(&mut self, edge: KeyEdge, at: u64) -> Option<Action> {
-            let now = self.t0 + ms(at);
-            let edge = match &mut self.guard {
-                Some(guard) => guard.admit(edge, now)?,
-                None => edge,
-            };
-            match edge {
-                KeyEdge::Down(action) => self.repeater.press(action, now),
-                KeyEdge::Up(action) => self.repeater.release(action, now),
+        /// One loop iteration at `now` dispatching the edges one poll
+        /// drained, each stamped `at` milliseconds by the kernel.
+        fn batch(&mut self, now: u64, edges: &[(KeyEdge, u64)]) -> Vec<Action> {
+            let now = self.t0 + ms(now);
+            let mut dispatched = Vec::new();
+            for &(edge, at) in edges {
+                let edge = match &mut self.guard {
+                    Some(guard) => match guard.admit(edge, SystemTime::UNIX_EPOCH + ms(at)) {
+                        Some(edge) => edge,
+                        None => continue,
+                    },
+                    None => edge,
+                };
+                let action = match edge {
+                    KeyEdge::Down(action) => self.repeater.press(action, now),
+                    KeyEdge::Up(action) => self.repeater.release(action, now),
+                };
+                dispatched.extend(action);
             }
+            dispatched
         }
 
+        /// One edge in an iteration of its own, dispatched as soon as it
+        /// was delivered.
+        fn edge(&mut self, edge: KeyEdge, at: u64) -> Option<Action> {
+            self.batch(at, &[(edge, at)]).pop()
+        }
+
+        /// Edges each dispatched as soon as delivered: the loop keeping up.
         fn feed(&mut self, edges: &[(KeyEdge, u64)]) -> Vec<Action> {
             edges
                 .iter()
@@ -1507,6 +1595,108 @@ mod tests {
                 (KeyEdge::Up(Action::Down), 50),
             ]),
             vec![Action::Down]
+        );
+    }
+
+    #[test]
+    fn taps_queued_behind_a_stalled_frame_are_judged_on_their_own_stamps() {
+        // Opening a large system parses its list inside the loop, so the
+        // next poll drains everything pressed meanwhile at once. Two taps
+        // 100 ms apart in that queue are two moves; only their kernel
+        // stamps can tell them from a double delivery, which shares the
+        // frame with them just the same.
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            guarded.batch(
+                2000,
+                &[
+                    (KeyEdge::Down(Action::Down), 0),
+                    (KeyEdge::Up(Action::Down), 10),
+                    (KeyEdge::Down(Action::Down), 100),
+                    (KeyEdge::Up(Action::Down), 110),
+                ]
+            ),
+            vec![Action::Down, Action::Down],
+            "two deliberate taps dispatched by one frame must both count"
+        );
+        assert!(!guarded.repeater.anything_held());
+
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            guarded.batch(2000, &double_delivery(Action::Down)),
+            vec![Action::Down],
+            "a double delivery dispatched by one frame is still one press"
+        );
+        assert!(!guarded.repeater.anything_held());
+
+        // The other way round: a double delivery split across two frames
+        // by a stall between them is still one press.
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            guarded.batch(
+                0,
+                &[
+                    (KeyEdge::Down(Action::Down), 0),
+                    (KeyEdge::Up(Action::Down), 5)
+                ]
+            ),
+            vec![Action::Down]
+        );
+        assert_eq!(
+            guarded.batch(
+                500,
+                &[
+                    (KeyEdge::Down(Action::Down), 10),
+                    (KeyEdge::Up(Action::Down), 15)
+                ]
+            ),
+            vec![],
+            "the frame clock must not decide what the stamps already have"
+        );
+        assert!(!guarded.repeater.anything_held());
+    }
+
+    #[test]
+    fn a_second_device_stamped_earlier_is_still_the_same_press() {
+        // Devices are drained one after another, so the second device's
+        // copy of a press can carry an earlier stamp than the copy already
+        // accepted from the first. The window has to reach both ways or
+        // that copy would pass and move the selection again.
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            guarded.batch(
+                20,
+                &[
+                    (KeyEdge::Down(Action::Down), 12),
+                    (KeyEdge::Up(Action::Down), 18),
+                    (KeyEdge::Down(Action::Down), 10),
+                    (KeyEdge::Up(Action::Down), 16),
+                ]
+            ),
+            vec![Action::Down]
+        );
+        assert!(!guarded.repeater.anything_held());
+        assert_eq!(
+            guarded.edge(KeyEdge::Down(Action::Down), 52),
+            Some(Action::Down),
+            "the window stays anchored to the accepted stamp, 12 ms"
+        );
+
+        // A stamp a whole window or more earlier is not the same press: a
+        // wall clock stepped back that far lets one press through and the
+        // next accepted press re-anchors the window.
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            guarded.feed(&[
+                (KeyEdge::Down(Action::Down), 1000),
+                (KeyEdge::Up(Action::Down), 1005),
+                (KeyEdge::Down(Action::Down), 960),
+                (KeyEdge::Up(Action::Down), 965),
+                (KeyEdge::Down(Action::Down), 970),
+                (KeyEdge::Up(Action::Down), 975),
+            ]),
+            vec![Action::Down, Action::Down],
+            "the press at 970 ms is inside the window of the one at 960 ms"
         );
     }
 
@@ -1622,50 +1812,59 @@ mod tests {
     }
 
     #[test]
-    fn generated_repeats_never_pass_through_the_guard() {
-        // The fastest scroll speed fires every 7 ms, well inside the 40 ms
-        // window. The guard only sees key edges, so a held direction must
-        // repeat exactly as it does without the guard at every speed.
+    fn a_hold_in_every_direction_at_every_speed_starts_and_ends_through_the_guard() {
+        // The repeater's cadence is its own (`a_held_key_repeats_at_the_
+        // configured_interval`) and its ticks never see the guard, so what
+        // the guard can break about a hold is its two ends: the press must
+        // be admitted or nothing scrolls, and the release must be admitted
+        // or the scroll never stops. Every direction, at every speed
+        // including the 7 ms interval, in the settings where left and
+        // right repeat.
         for (_, interval) in SPEED_STEPS {
             let config = RepeatConfig {
                 delay: ms(220),
                 interval: ms(interval),
             };
-            let mut guarded = Pipeline::guarded(Repeater::new(config));
-            let mut unguarded = Pipeline::unguarded(Repeater::new(config));
-            assert_eq!(
-                guarded.edge(KeyEdge::Down(Action::Down), 0),
-                Some(Action::Down)
-            );
-            assert_eq!(
-                unguarded.edge(KeyEdge::Down(Action::Down), 0),
-                Some(Action::Down)
-            );
-            assert!(guarded.tick(219).is_empty());
-            for k in 0..=5 {
-                let at = 220 + k * interval;
-                if k > 0 {
-                    assert!(
-                        guarded.tick(at - 1).is_empty(),
-                        "{interval} ms: nothing is due before the interval"
-                    );
-                }
+            for action in [Action::Up, Action::Down, Action::Slower, Action::Faster] {
+                let mut guarded = Pipeline::guarded(Repeater::new(config));
+                guarded.repeater.set_horizontal_repeats(true);
                 assert_eq!(
-                    guarded.tick(at),
-                    vec![Action::Down],
-                    "{interval} ms: repeat {k} must fire"
+                    guarded.edge(KeyEdge::Down(action), 0),
+                    Some(action),
+                    "{action:?} at {interval} ms: the press starts the hold"
                 );
-                assert_eq!(unguarded.tick(at), vec![Action::Down]);
+                let mut fired = 0;
+                for at in 0..=500 {
+                    fired += guarded.tick(at).len();
+                }
+                let expected = 1 + (500 - 220) / interval;
+                assert_eq!(
+                    fired, expected as usize,
+                    "{action:?} at {interval} ms: the delay and the interval are the repeater's"
+                );
+                assert_eq!(guarded.edge(KeyEdge::Up(action), 500), None);
+                assert!(
+                    !guarded.repeater.anything_held(),
+                    "{action:?} at {interval} ms: the release ends the hold"
+                );
+                assert!(guarded.tick(1000).is_empty());
+                assert_eq!(
+                    guarded.edge(KeyEdge::Down(action), 505),
+                    Some(action),
+                    "{action:?}: a press right after the release is a new press, \
+                     the window ran from the first press, not from the release"
+                );
             }
         }
     }
 
     #[test]
     fn directions_are_guarded_in_every_left_right_setting() {
-        // Left and right are retained by the repeater in the Direction
-        // setting and not in the others; up and down always are; page keys
-        // never are. The guard sits before all of that, so a double delivery
-        // is one move in every case and two taps are two.
+        // Left and right are retained by the repeater in every Left and
+        // Right Behaviour setting other than Scroll Speed Change (Letter,
+        // Page and Direction); up and down always are; page keys never are.
+        // The guard sits before all of that, so a double delivery is one
+        // move in every case and two taps are two.
         for horizontal in [true, false] {
             for action in [
                 Action::Up,
@@ -1776,22 +1975,12 @@ mod tests {
     fn ordinary_taps_and_holds_are_unchanged_without_duplicate_delivery() {
         // A keyboard or controller that delivers each press once must feel
         // exactly as before: every tap acts, and a hold repeats on the same
-        // schedule as a repeater with no guard in front of it.
-        let actions = [
-            Action::Up,
-            Action::Down,
-            Action::Slower,
-            Action::Faster,
-            Action::PageUp,
-            Action::PageDown,
-            Action::Home,
-            Action::End,
-            Action::Accept,
-            Action::Quit,
-            Action::CyclePresent,
-            Action::Menu,
-            Action::Context,
-        ];
+        // schedule as a repeater with no guard in front of it. The two
+        // shortcuts are left out: only the repeater produces them.
+        let actions: Vec<Action> = Action::ALL
+            .into_iter()
+            .filter(|action| !matches!(action, Action::FavoriteShortcut | Action::RandomShortcut))
+            .collect();
         let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
         let taps: Vec<(KeyEdge, u64)> = actions
             .iter()
@@ -1801,7 +1990,7 @@ mod tests {
                 [(KeyEdge::Down(action), at), (KeyEdge::Up(action), at + 20)]
             })
             .collect();
-        assert_eq!(guarded.feed(&taps), actions.to_vec());
+        assert_eq!(guarded.feed(&taps), actions);
         assert!(!guarded.repeater.anything_held());
 
         let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
@@ -1827,28 +2016,14 @@ mod tests {
 
     #[test]
     fn every_action_has_a_slot() {
-        // The guard indexes a fixed array by action. A variant added after
-        // `RandomShortcut` without moving `ACTION_SLOTS` would panic on the
-        // first press of the new key.
+        // The guard indexes a table sized from `Action::ALL` by discriminant.
+        // A first press and release of every listed action must pass, so a
+        // table that is too small, or a list out of declaration order that
+        // slipped past the compile-time check, shows up here rather than
+        // on the device.
         let mut guard = DuplicateGuard::new();
-        let now = Instant::now();
-        for action in [
-            Action::Up,
-            Action::Down,
-            Action::Slower,
-            Action::Faster,
-            Action::PageUp,
-            Action::PageDown,
-            Action::Home,
-            Action::End,
-            Action::Accept,
-            Action::Quit,
-            Action::CyclePresent,
-            Action::Menu,
-            Action::Context,
-            Action::FavoriteShortcut,
-            Action::RandomShortcut,
-        ] {
+        let now = SystemTime::UNIX_EPOCH + ms(1000);
+        for action in Action::ALL {
             assert_eq!(
                 guard.admit(KeyEdge::Down(action), now),
                 Some(KeyEdge::Down(action))

--- a/src/input.rs
+++ b/src/input.rs
@@ -71,12 +71,8 @@ pub enum Action {
 }
 
 impl Action {
-    /// Every variant in declaration order. The [`DuplicateGuard`] sizes its
-    /// table from this list and indexes it by discriminant. The check under
-    /// it proves the listed variants sit at their own discriminants and
-    /// refuses a variant that has no arm in its match; it cannot see a
-    /// variant that has an arm but no entry here, so append the entry with
-    /// the arm, or the first press of that variant indexes past the table.
+    /// Every variant in declaration order; sizes the [`DuplicateGuard`]
+    /// table, see the check under `ACTION_SLOTS`.
     pub const ALL: [Action; 15] = [
         Action::Up,
         Action::Down,
@@ -455,8 +451,9 @@ const ACTION_SLOTS: usize = Action::ALL.len();
 // `Action::ALL` must hold every variant at its own discriminant, or the
 // guard would index past its table on the first press of the missing one.
 // The match is exhaustive: a variant added to the enum does not compile
-// until it has an arm here, and the arm is only right once the variant is
-// appended to `ALL` as well.
+// until it has an arm here, and the assertion refuses a list out of
+// declaration order. What the check cannot see is a variant that has an
+// arm but no entry in `ALL`, so append the entry with the arm.
 const _: () = {
     let mut i = 0;
     while i < ACTION_SLOTS {
@@ -2033,9 +2030,11 @@ mod tests {
     fn face_buttons_act_once_per_physical_press_with_and_without_hold_shortcuts() {
         // The repeater does not retain Accept, Back, Menu or Context, so
         // without the guard a double delivery launches twice or backs out
-        // two levels. With a hold shortcut enabled the duplicate press must
-        // neither fire the shortcut twice nor let a release leak the short
-        // action into the screen the shortcut opened.
+        // two levels. With a hold shortcut enabled the repeater retains the
+        // button, so a second press while it is held is already ignored;
+        // what the guard adds is that the duplicate's release cannot end
+        // the hold as a short press before the shortcut fires, and no
+        // release afterwards may leak into the screen the shortcut opened.
         for action in [Action::Accept, Action::Quit, Action::Menu, Action::Context] {
             let mut unguarded = Pipeline::unguarded(Repeater::new(RepeatConfig::default()));
             assert_eq!(
@@ -2060,10 +2059,32 @@ mod tests {
                 Action::RandomShortcut,
             ),
         ] {
+            // Two devices report the press, and the duplicate's release
+            // arrives while the button is still held.
+            let mut unguarded = Pipeline::unguarded(Repeater::new(RepeatConfig::default()));
+            enable(&mut unguarded.repeater, true);
+            assert_eq!(
+                unguarded.feed(&[
+                    (KeyEdge::Down(button), 0),
+                    (KeyEdge::Down(button), 5),
+                    (KeyEdge::Up(button), 8),
+                ]),
+                vec![button],
+                "the repeater alone takes the duplicate's release as a short {button:?}"
+            );
+            assert!(
+                unguarded.tick(1000).is_empty(),
+                "and the hold it ended never fires the shortcut"
+            );
+
             let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
             enable(&mut guarded.repeater, true);
             assert_eq!(
-                guarded.feed(&[(KeyEdge::Down(button), 0), (KeyEdge::Down(button), 5)]),
+                guarded.feed(&[
+                    (KeyEdge::Down(button), 0),
+                    (KeyEdge::Down(button), 5),
+                    (KeyEdge::Up(button), 8),
+                ]),
                 vec![]
             );
             assert_eq!(
@@ -2075,9 +2096,9 @@ mod tests {
             // The shortcut opened another screen, which disables the gesture.
             enable(&mut guarded.repeater, false);
             assert_eq!(
-                guarded.feed(&[(KeyEdge::Up(button), 1010), (KeyEdge::Up(button), 1012)]),
-                vec![],
-                "neither release may act on the new screen"
+                guarded.edge(KeyEdge::Up(button), 1010),
+                None,
+                "the release may not act on the new screen"
             );
             assert!(!guarded.repeater.anything_held());
 
@@ -2107,9 +2128,10 @@ mod tests {
     #[test]
     fn ordinary_taps_and_holds_are_unchanged_without_duplicate_delivery() {
         // A keyboard or controller that delivers each press once must feel
-        // exactly as before: every tap acts, and a hold repeats on the same
-        // schedule as a repeater with no guard in front of it. The two
-        // shortcuts are left out: only the repeater produces them.
+        // exactly as before: every tap acts, and a hold starts on the
+        // press, repeats what the delay and interval give and ends on the
+        // release. The two shortcuts are left out: only the repeater
+        // produces them.
         let actions: Vec<Action> = Action::ALL
             .into_iter()
             .filter(|action| !matches!(action, Action::FavoriteShortcut | Action::RandomShortcut))
@@ -2126,24 +2148,23 @@ mod tests {
         assert_eq!(guarded.feed(&taps), actions);
         assert!(!guarded.repeater.anything_held());
 
-        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
-        let mut unguarded = Pipeline::unguarded(Repeater::new(RepeatConfig::default()));
+        let config = RepeatConfig::default();
+        let mut guarded = Pipeline::guarded(Repeater::new(config));
         assert_eq!(
             guarded.edge(KeyEdge::Down(Action::Down), 0),
-            unguarded.edge(KeyEdge::Down(Action::Down), 0)
+            Some(Action::Down)
         );
         let mut fired = 0;
-        for at in (0..=500).step_by(10) {
-            let due = guarded.tick(at);
-            assert_eq!(due, unguarded.tick(at), "tick at {at} ms");
-            fired += due.len();
+        for at in 0..=500 {
+            fired += guarded.tick(at).len();
         }
-        assert!(fired > 1, "a 500 ms hold must have repeated");
+        let expected = 1 + (500 - config.delay.as_millis()) / config.interval.as_millis();
         assert_eq!(
-            guarded.edge(KeyEdge::Up(Action::Down), 500),
-            unguarded.edge(KeyEdge::Up(Action::Down), 500)
+            fired, expected as usize,
+            "a 500 ms hold repeats what the delay and the interval give"
         );
+        assert_eq!(guarded.edge(KeyEdge::Up(Action::Down), 500), None);
         assert!(!guarded.repeater.anything_held());
-        assert!(!unguarded.repeater.anything_held());
+        assert!(guarded.tick(1000).is_empty());
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -22,6 +22,11 @@
 //! * Keystrokes still reach the console as well, so the terminal is put
 //!   into a quiet mode while Degauss draws and restored when it exits.
 //!
+//! * Some controllers, or the input stack between them and Degauss, deliver
+//!   one physical press as two very fast press and release pairs. The
+//!   second pair is dropped by the [`DuplicateGuard`] before anything else
+//!   sees it, so one press moves once.
+//!
 //! Key repeat is generated here rather than taken from the kernel, because
 //! the cadence of a held direction is a setting the user controls.
 
@@ -374,6 +379,96 @@ pub enum KeyEdge {
     Up(Action),
 }
 
+/// The edge a Linux key event value means. 1 is a press and 0 a release;
+/// 2 is the kernel's own auto-repeat, ignored because Degauss times its
+/// own repeats.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn key_edge(action: Action, value: i32) -> Option<KeyEdge> {
+    match value {
+        1 => Some(KeyEdge::Down(action)),
+        0 => Some(KeyEdge::Up(action)),
+        _ => None,
+    }
+}
+
+/// A second press of the same action closer than this to the accepted one
+/// is the same physical press arriving twice, not a deliberate second tap.
+pub const DUPLICATE_WINDOW: Duration = Duration::from_millis(40);
+
+/// One slot per [`Action`]. `RandomShortcut` is the last variant; a variant
+/// added after it must move this.
+const ACTION_SLOTS: usize = Action::RandomShortcut as usize + 1;
+
+#[derive(Debug, Clone, Copy)]
+struct Slot {
+    /// When the last accepted press of this action arrived. It anchors the
+    /// window: a rejected duplicate never moves it, so a run of duplicates
+    /// cannot keep the window open.
+    accepted_at: Option<Instant>,
+    /// A rejected duplicate is still down as far as its device is
+    /// concerned, so a release is owed for it. That release must be
+    /// swallowed rather than end the genuine hold under it.
+    duplicate_down: bool,
+}
+
+/// Drops the second delivery of one physical press before it reaches the
+/// [`Repeater`]. Only real key edges pass through here; the repeats the
+/// [`Repeater`] generates for a held key never do, which is what keeps the
+/// 7 ms scroll interval intact. One array index and two comparisons per
+/// edge, nothing allocated.
+#[derive(Debug)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub struct DuplicateGuard {
+    slots: [Slot; ACTION_SLOTS],
+}
+
+impl DuplicateGuard {
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub fn new() -> Self {
+        DuplicateGuard {
+            slots: [Slot {
+                accepted_at: None,
+                duplicate_down: false,
+            }; ACTION_SLOTS],
+        }
+    }
+
+    /// Filter one key edge read from a device. `None` means drop it.
+    ///
+    /// A press inside [`DUPLICATE_WINDOW`] of the last accepted press of the
+    /// same action is a duplicate: rejected, and its eventual release is
+    /// swallowed too. A press exactly at the window's end is accepted. A
+    /// different action is never affected, an opposite direction included.
+    /// An accepted press clears any release still owed, so a duplicate whose
+    /// release never arrives cannot swallow a later genuine release.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub fn admit(&mut self, edge: KeyEdge, now: Instant) -> Option<KeyEdge> {
+        match edge {
+            KeyEdge::Down(action) => {
+                let slot = &mut self.slots[action as usize];
+                if slot
+                    .accepted_at
+                    .is_some_and(|at| now.duration_since(at) < DUPLICATE_WINDOW)
+                {
+                    slot.duplicate_down = true;
+                    return None;
+                }
+                slot.accepted_at = Some(now);
+                slot.duplicate_down = false;
+                Some(edge)
+            }
+            KeyEdge::Up(action) => {
+                let slot = &mut self.slots[action as usize];
+                if slot.duplicate_down {
+                    slot.duplicate_down = false;
+                    return None;
+                }
+                Some(edge)
+            }
+        }
+    }
+}
+
 #[cfg(target_os = "linux")]
 pub use linux::{
     install_signal_handlers, restore_console, restore_terminal, ConsoleGuard, InputReader,
@@ -386,7 +481,7 @@ mod linux {
 
     use evdev::{Device, EventSummary};
 
-    use super::{action_for_key, KeyEdge};
+    use super::{action_for_key, key_edge, KeyEdge};
     use crate::error::{DegaussError, Result};
 
     /// What was opened, so Degauss can show whether it is actually
@@ -463,12 +558,8 @@ mod linux {
                         let Some(action) = action_for_key(code.code()) else {
                             continue;
                         };
-                        match value {
-                            // 1 = press. 2 = the kernel's own auto-repeat,
-                            // ignored: Degauss times its own repeats.
-                            1 => edges.push(KeyEdge::Down(action)),
-                            0 => edges.push(KeyEdge::Up(action)),
-                            _ => {}
+                        if let Some(edge) = key_edge(action, value) {
+                            edges.push(edge);
                         }
                     }
                 }
@@ -1278,5 +1369,494 @@ mod tests {
         let due = repeater.tick(t0 + Duration::from_millis(10));
         assert_eq!(due.len(), 2);
         assert!(due.contains(&Action::Down) && due.contains(&Action::Up));
+    }
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+
+    /// The dispatch shape of the run loop: every key edge read from a
+    /// device passes the guard before the repeater, only what the repeater
+    /// returns is dispatched, and the repeater's own ticks never see the
+    /// guard. Built without the guard to show what the repeater alone does
+    /// with the same edges.
+    struct Pipeline {
+        guard: Option<DuplicateGuard>,
+        repeater: Repeater,
+        t0: Instant,
+    }
+
+    impl Pipeline {
+        fn guarded(repeater: Repeater) -> Self {
+            Pipeline {
+                guard: Some(DuplicateGuard::new()),
+                repeater,
+                t0: Instant::now(),
+            }
+        }
+
+        fn unguarded(repeater: Repeater) -> Self {
+            Pipeline {
+                guard: None,
+                repeater,
+                t0: Instant::now(),
+            }
+        }
+
+        fn edge(&mut self, edge: KeyEdge, at: u64) -> Option<Action> {
+            let now = self.t0 + ms(at);
+            let edge = match &mut self.guard {
+                Some(guard) => guard.admit(edge, now)?,
+                None => edge,
+            };
+            match edge {
+                KeyEdge::Down(action) => self.repeater.press(action, now),
+                KeyEdge::Up(action) => self.repeater.release(action, now),
+            }
+        }
+
+        fn feed(&mut self, edges: &[(KeyEdge, u64)]) -> Vec<Action> {
+            edges
+                .iter()
+                .filter_map(|&(edge, at)| self.edge(edge, at))
+                .collect()
+        }
+
+        fn tick(&mut self, at: u64) -> Vec<Action> {
+            self.repeater.tick(self.t0 + ms(at))
+        }
+    }
+
+    /// One tap delivered twice: the sequence the affected controllers send
+    /// for a single press of `action`.
+    fn double_delivery(action: Action) -> [(KeyEdge, u64); 4] {
+        [
+            (KeyEdge::Down(action), 0),
+            (KeyEdge::Up(action), 5),
+            (KeyEdge::Down(action), 10),
+            (KeyEdge::Up(action), 15),
+        ]
+    }
+
+    #[test]
+    fn a_double_delivery_of_one_press_moves_once() {
+        // The repeater alone cannot catch this: the release in between
+        // clears its held state, so the second press fires again and one
+        // tap moves two rows.
+        let mut unguarded = Pipeline::unguarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            unguarded.feed(&double_delivery(Action::Down)),
+            vec![Action::Down, Action::Down],
+            "the repeater's own duplicate check does not cover a press, release, press"
+        );
+
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            guarded.feed(&double_delivery(Action::Down)),
+            vec![Action::Down]
+        );
+        assert!(!guarded.repeater.anything_held());
+    }
+
+    #[test]
+    fn overlapping_double_delivery_moves_once_and_leaves_nothing_held() {
+        // Both presses before either release. The second release belongs to
+        // the rejected press; if it reached the repeater it would find
+        // nothing held, and if the first one were swallowed instead the
+        // direction would stay down and scroll for ever.
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            guarded.feed(&[
+                (KeyEdge::Down(Action::Down), 0),
+                (KeyEdge::Down(Action::Down), 5),
+                (KeyEdge::Up(Action::Down), 10),
+                (KeyEdge::Up(Action::Down), 15),
+            ]),
+            vec![Action::Down]
+        );
+        assert!(!guarded.repeater.anything_held());
+        assert!(guarded.tick(1000).is_empty(), "nothing may keep scrolling");
+        assert_eq!(
+            guarded.edge(KeyEdge::Down(Action::Down), 100),
+            Some(Action::Down),
+            "the next deliberate press must work"
+        );
+    }
+
+    #[test]
+    fn deliberate_taps_outside_the_window_both_count() {
+        // Two quick taps are two moves. The window is exactly 40 ms: a
+        // press at 40 ms is a second tap, a press at 39 ms is the same tap.
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            guarded.feed(&[
+                (KeyEdge::Down(Action::Down), 0),
+                (KeyEdge::Up(Action::Down), 10),
+                (KeyEdge::Down(Action::Down), 40),
+                (KeyEdge::Up(Action::Down), 50),
+            ]),
+            vec![Action::Down, Action::Down]
+        );
+
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            guarded.feed(&[
+                (KeyEdge::Down(Action::Down), 0),
+                (KeyEdge::Up(Action::Down), 10),
+                (KeyEdge::Down(Action::Down), 39),
+                (KeyEdge::Up(Action::Down), 50),
+            ]),
+            vec![Action::Down]
+        );
+    }
+
+    #[test]
+    fn a_different_action_inside_the_window_is_immediate() {
+        // The guard is per action. A reversal of direction, a speed change
+        // either way, or launching then backing out must never wait.
+        for (first, second) in [
+            (Action::Down, Action::Up),
+            (Action::Slower, Action::Faster),
+            (Action::Accept, Action::Quit),
+        ] {
+            let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+            assert_eq!(
+                guarded.feed(&[(KeyEdge::Down(first), 0), (KeyEdge::Down(second), 2)]),
+                vec![first, second],
+                "{first:?} then {second:?} must both act, in order"
+            );
+            assert_eq!(
+                guarded.feed(&[(KeyEdge::Up(first), 4), (KeyEdge::Up(second), 6)]),
+                vec![]
+            );
+            assert!(!guarded.repeater.anything_held());
+        }
+    }
+
+    #[test]
+    fn a_rejected_duplicate_does_not_move_the_window() {
+        // The window is anchored to the accepted press. If a rejected
+        // duplicate restarted it, a controller that keeps repeating a press
+        // could hold the window open and swallow a deliberate second tap.
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            guarded.feed(&[
+                (KeyEdge::Down(Action::Down), 0),
+                (KeyEdge::Up(Action::Down), 5),
+                (KeyEdge::Down(Action::Down), 30),
+                (KeyEdge::Up(Action::Down), 32),
+            ]),
+            vec![Action::Down]
+        );
+        assert_eq!(
+            guarded.edge(KeyEdge::Down(Action::Down), 45),
+            Some(Action::Down),
+            "45 ms after the accepted press is outside the window even though \
+             a duplicate arrived at 30 ms"
+        );
+    }
+
+    #[test]
+    fn a_second_device_delivering_the_same_press_does_not_end_the_hold() {
+        // Two devices report the same physical press: one press each, a
+        // few milliseconds apart. Only one may act, and the release of the
+        // rejected one must not end the scroll the accepted one started.
+        let config = RepeatConfig {
+            delay: ms(10),
+            interval: ms(10),
+        };
+
+        // The duplicate's release comes first, while the press is held.
+        let mut unguarded = Pipeline::unguarded(Repeater::new(config));
+        assert_eq!(
+            unguarded.feed(&[
+                (KeyEdge::Down(Action::Down), 0),
+                (KeyEdge::Down(Action::Down), 2),
+                (KeyEdge::Up(Action::Down), 5),
+            ]),
+            vec![Action::Down]
+        );
+        assert!(
+            unguarded.tick(10).is_empty(),
+            "the repeater alone lets the duplicate's release end the hold"
+        );
+
+        let mut guarded = Pipeline::guarded(Repeater::new(config));
+        assert_eq!(
+            guarded.feed(&[
+                (KeyEdge::Down(Action::Down), 0),
+                (KeyEdge::Down(Action::Down), 2),
+                (KeyEdge::Up(Action::Down), 5),
+            ]),
+            vec![Action::Down]
+        );
+        assert_eq!(guarded.tick(10), vec![Action::Down], "the hold goes on");
+        assert_eq!(guarded.tick(20), vec![Action::Down]);
+        assert_eq!(guarded.edge(KeyEdge::Up(Action::Down), 500), None);
+        assert!(!guarded.repeater.anything_held());
+        assert!(guarded.tick(1000).is_empty());
+
+        // Both releases come after the repeats started. The guard cannot
+        // tell which device sent which, so the first release is taken as
+        // the duplicate's and the hold ends on the second; nothing may stay
+        // held after both.
+        let mut guarded = Pipeline::guarded(Repeater::new(config));
+        assert_eq!(
+            guarded.feed(&[
+                (KeyEdge::Down(Action::Down), 0),
+                (KeyEdge::Down(Action::Down), 2),
+            ]),
+            vec![Action::Down]
+        );
+        assert_eq!(guarded.tick(10), vec![Action::Down]);
+        assert_eq!(guarded.tick(20), vec![Action::Down]);
+        assert_eq!(guarded.edge(KeyEdge::Up(Action::Down), 30), None);
+        assert_eq!(
+            guarded.tick(30),
+            vec![Action::Down],
+            "one release of two does not end the hold"
+        );
+        assert_eq!(guarded.edge(KeyEdge::Up(Action::Down), 32), None);
+        assert!(!guarded.repeater.anything_held());
+        assert!(guarded.tick(1000).is_empty(), "nothing may stay held");
+    }
+
+    #[test]
+    fn generated_repeats_never_pass_through_the_guard() {
+        // The fastest scroll speed fires every 7 ms, well inside the 40 ms
+        // window. The guard only sees key edges, so a held direction must
+        // repeat exactly as it does without the guard at every speed.
+        for (_, interval) in SPEED_STEPS {
+            let config = RepeatConfig {
+                delay: ms(220),
+                interval: ms(interval),
+            };
+            let mut guarded = Pipeline::guarded(Repeater::new(config));
+            let mut unguarded = Pipeline::unguarded(Repeater::new(config));
+            assert_eq!(
+                guarded.edge(KeyEdge::Down(Action::Down), 0),
+                Some(Action::Down)
+            );
+            assert_eq!(
+                unguarded.edge(KeyEdge::Down(Action::Down), 0),
+                Some(Action::Down)
+            );
+            assert!(guarded.tick(219).is_empty());
+            for k in 0..=5 {
+                let at = 220 + k * interval;
+                if k > 0 {
+                    assert!(
+                        guarded.tick(at - 1).is_empty(),
+                        "{interval} ms: nothing is due before the interval"
+                    );
+                }
+                assert_eq!(
+                    guarded.tick(at),
+                    vec![Action::Down],
+                    "{interval} ms: repeat {k} must fire"
+                );
+                assert_eq!(unguarded.tick(at), vec![Action::Down]);
+            }
+        }
+    }
+
+    #[test]
+    fn directions_are_guarded_in_every_left_right_setting() {
+        // Left and right are retained by the repeater in the Direction
+        // setting and not in the others; up and down always are; page keys
+        // never are. The guard sits before all of that, so a double delivery
+        // is one move in every case and two taps are two.
+        for horizontal in [true, false] {
+            for action in [
+                Action::Up,
+                Action::Down,
+                Action::Slower,
+                Action::Faster,
+                Action::PageUp,
+                Action::PageDown,
+            ] {
+                let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+                guarded.repeater.set_horizontal_repeats(horizontal);
+                assert_eq!(
+                    guarded.feed(&double_delivery(action)),
+                    vec![action],
+                    "{action:?} with horizontal repeats {horizontal}"
+                );
+                assert_eq!(
+                    guarded.feed(&[
+                        (KeyEdge::Down(action), 100),
+                        (KeyEdge::Up(action), 105),
+                        (KeyEdge::Down(action), 200),
+                        (KeyEdge::Up(action), 205),
+                    ]),
+                    vec![action, action],
+                    "{action:?} with horizontal repeats {horizontal}: two taps"
+                );
+                assert!(!guarded.repeater.anything_held());
+            }
+        }
+    }
+
+    #[test]
+    fn face_buttons_act_once_per_physical_press_with_and_without_hold_shortcuts() {
+        // The repeater does not retain Accept, Back, Menu or Context, so
+        // without the guard a double delivery launches twice or backs out
+        // two levels. With a hold shortcut enabled the duplicate press must
+        // neither fire the shortcut twice nor let a release leak the short
+        // action into the screen the shortcut opened.
+        for action in [Action::Accept, Action::Quit, Action::Menu, Action::Context] {
+            let mut unguarded = Pipeline::unguarded(Repeater::new(RepeatConfig::default()));
+            assert_eq!(
+                unguarded.feed(&double_delivery(action)),
+                vec![action, action],
+                "{action:?} is not retained, so the repeater alone acts twice"
+            );
+            let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+            assert_eq!(guarded.feed(&double_delivery(action)), vec![action]);
+            assert!(!guarded.repeater.anything_held());
+        }
+
+        for (button, enable, shortcut) in [
+            (
+                Action::Context,
+                Repeater::set_favorite_hold as fn(&mut Repeater, bool),
+                Action::FavoriteShortcut,
+            ),
+            (
+                Action::Menu,
+                Repeater::set_random_hold,
+                Action::RandomShortcut,
+            ),
+        ] {
+            let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+            enable(&mut guarded.repeater, true);
+            assert_eq!(
+                guarded.feed(&[(KeyEdge::Down(button), 0), (KeyEdge::Down(button), 5)]),
+                vec![]
+            );
+            assert_eq!(
+                guarded.tick(1000),
+                vec![shortcut],
+                "{button:?} held for one second fires its shortcut once"
+            );
+            assert!(guarded.tick(1005).is_empty());
+            // The shortcut opened another screen, which disables the gesture.
+            enable(&mut guarded.repeater, false);
+            assert_eq!(
+                guarded.feed(&[(KeyEdge::Up(button), 1010), (KeyEdge::Up(button), 1012)]),
+                vec![],
+                "neither release may act on the new screen"
+            );
+            assert!(!guarded.repeater.anything_held());
+
+            let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+            enable(&mut guarded.repeater, true);
+            assert_eq!(
+                guarded.feed(&double_delivery(button)),
+                vec![button],
+                "a short {button:?} delivered twice is one short press"
+            );
+            assert!(!guarded.repeater.anything_held());
+        }
+    }
+
+    #[test]
+    fn the_kernel_auto_repeat_value_stays_ignored() {
+        // The kernel repeats a held key on its own schedule. Degauss times
+        // its own repeats, so taking those events as presses would double
+        // every scroll.
+        assert_eq!(key_edge(Action::Down, 1), Some(KeyEdge::Down(Action::Down)));
+        assert_eq!(key_edge(Action::Down, 0), Some(KeyEdge::Up(Action::Down)));
+        assert_eq!(key_edge(Action::Down, 2), None, "value 2 is auto-repeat");
+        assert_eq!(key_edge(Action::Accept, 3), None);
+        assert_eq!(key_edge(Action::Accept, -1), None);
+    }
+
+    #[test]
+    fn ordinary_taps_and_holds_are_unchanged_without_duplicate_delivery() {
+        // A keyboard or controller that delivers each press once must feel
+        // exactly as before: every tap acts, and a hold repeats on the same
+        // schedule as a repeater with no guard in front of it.
+        let actions = [
+            Action::Up,
+            Action::Down,
+            Action::Slower,
+            Action::Faster,
+            Action::PageUp,
+            Action::PageDown,
+            Action::Home,
+            Action::End,
+            Action::Accept,
+            Action::Quit,
+            Action::CyclePresent,
+            Action::Menu,
+            Action::Context,
+        ];
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        let taps: Vec<(KeyEdge, u64)> = actions
+            .iter()
+            .enumerate()
+            .flat_map(|(i, &action)| {
+                let at = i as u64 * 150;
+                [(KeyEdge::Down(action), at), (KeyEdge::Up(action), at + 20)]
+            })
+            .collect();
+        assert_eq!(guarded.feed(&taps), actions.to_vec());
+        assert!(!guarded.repeater.anything_held());
+
+        let mut guarded = Pipeline::guarded(Repeater::new(RepeatConfig::default()));
+        let mut unguarded = Pipeline::unguarded(Repeater::new(RepeatConfig::default()));
+        assert_eq!(
+            guarded.edge(KeyEdge::Down(Action::Down), 0),
+            unguarded.edge(KeyEdge::Down(Action::Down), 0)
+        );
+        let mut fired = 0;
+        for at in (0..=500).step_by(10) {
+            let due = guarded.tick(at);
+            assert_eq!(due, unguarded.tick(at), "tick at {at} ms");
+            fired += due.len();
+        }
+        assert!(fired > 1, "a 500 ms hold must have repeated");
+        assert_eq!(
+            guarded.edge(KeyEdge::Up(Action::Down), 500),
+            unguarded.edge(KeyEdge::Up(Action::Down), 500)
+        );
+        assert!(!guarded.repeater.anything_held());
+        assert!(!unguarded.repeater.anything_held());
+    }
+
+    #[test]
+    fn every_action_has_a_slot() {
+        // The guard indexes a fixed array by action. A variant added after
+        // `RandomShortcut` without moving `ACTION_SLOTS` would panic on the
+        // first press of the new key.
+        let mut guard = DuplicateGuard::new();
+        let now = Instant::now();
+        for action in [
+            Action::Up,
+            Action::Down,
+            Action::Slower,
+            Action::Faster,
+            Action::PageUp,
+            Action::PageDown,
+            Action::Home,
+            Action::End,
+            Action::Accept,
+            Action::Quit,
+            Action::CyclePresent,
+            Action::Menu,
+            Action::Context,
+            Action::FavoriteShortcut,
+            Action::RandomShortcut,
+        ] {
+            assert_eq!(
+                guard.admit(KeyEdge::Down(action), now),
+                Some(KeyEdge::Down(action))
+            );
+            assert_eq!(
+                guard.admit(KeyEdge::Up(action), now),
+                Some(KeyEdge::Up(action))
+            );
+        }
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -486,9 +486,9 @@ struct Slot {
     /// run of duplicates cannot keep the window open.
     accepted_at: Option<SystemTime>,
     /// A rejected duplicate is still down as far as its device is
-    /// concerned, so a release is owed for it. That release must be
-    /// swallowed rather than end the genuine hold under it.
-    duplicate_down: bool,
+    /// concerned, so a release is owed for each one. Those releases must
+    /// be swallowed rather than end the genuine hold under them.
+    duplicates_down: u8,
 }
 
 /// Drops the second delivery of one physical press before it reaches the
@@ -514,7 +514,7 @@ impl DuplicateGuard {
         DuplicateGuard {
             slots: [Slot {
                 accepted_at: None,
-                duplicate_down: false,
+                duplicates_down: 0,
             }; ACTION_SLOTS],
         }
     }
@@ -524,10 +524,12 @@ impl DuplicateGuard {
     ///
     /// A press inside [`DUPLICATE_WINDOW`] of the last accepted press of the
     /// same action is a duplicate: rejected, and its eventual release is
-    /// swallowed too. A press exactly at the window's end is accepted. A
-    /// different action is never affected, an opposite direction included.
-    /// An accepted press clears any release still owed, so a duplicate whose
-    /// release never arrives cannot swallow a later genuine release.
+    /// swallowed too, one release per rejected press, so a press delivered
+    /// three times still ends its hold on the last release. A press exactly
+    /// at the window's end is accepted. A different action is never
+    /// affected, an opposite direction included. An accepted press clears
+    /// any releases still owed, so a duplicate whose release never arrives
+    /// cannot swallow a later genuine release.
     ///
     /// The window reaches both ways from the accepted press. A poll merges
     /// what it drained by stamp, but a copy injected on one device just
@@ -547,17 +549,17 @@ impl DuplicateGuard {
                     };
                     apart < DUPLICATE_WINDOW
                 }) {
-                    slot.duplicate_down = true;
+                    slot.duplicates_down = slot.duplicates_down.saturating_add(1);
                     return None;
                 }
                 slot.accepted_at = Some(at);
-                slot.duplicate_down = false;
+                slot.duplicates_down = 0;
                 Some(edge)
             }
             KeyEdge::Up(action) => {
                 let slot = &mut self.slots[action as usize];
-                if slot.duplicate_down {
-                    slot.duplicate_down = false;
+                if slot.duplicates_down > 0 {
+                    slot.duplicates_down -= 1;
                     return None;
                 }
                 Some(edge)
@@ -1939,6 +1941,64 @@ mod tests {
         assert_eq!(guarded.edge(KeyEdge::Up(Action::Down), 32), None);
         assert!(!guarded.repeater.anything_held());
         assert!(guarded.tick(1000).is_empty(), "nothing may stay held");
+    }
+
+    #[test]
+    fn a_press_delivered_three_times_ends_its_hold_on_the_last_release() {
+        // Three copies of one press owe three releases. The guard counts
+        // the rejected copies, so only their releases are swallowed and the
+        // hold ends on the genuine one; a single flag would let the second
+        // release through and stop the scroll while the key is still down.
+        let config = RepeatConfig {
+            delay: ms(10),
+            interval: ms(10),
+        };
+        let mut guarded = Pipeline::guarded(Repeater::new(config));
+        assert_eq!(
+            guarded.feed(&[
+                (KeyEdge::Down(Action::Down), 0),
+                (KeyEdge::Down(Action::Down), 2),
+                (KeyEdge::Down(Action::Down), 4),
+                (KeyEdge::Up(Action::Down), 5),
+                (KeyEdge::Up(Action::Down), 6),
+            ]),
+            vec![Action::Down]
+        );
+        assert_eq!(
+            guarded.tick(10),
+            vec![Action::Down],
+            "two releases of three do not end the hold"
+        );
+        assert_eq!(guarded.tick(20), vec![Action::Down]);
+        assert_eq!(guarded.edge(KeyEdge::Up(Action::Down), 500), None);
+        assert!(!guarded.repeater.anything_held());
+        assert!(guarded.tick(1000).is_empty(), "nothing may stay held");
+
+        // Copies whose releases never come leave releases owed while the
+        // key stays down. The next accepted press clears them, so that
+        // press's own release still ends the hold instead of being
+        // swallowed as the old debt.
+        assert_eq!(
+            guarded.feed(&[
+                (KeyEdge::Down(Action::Down), 1000),
+                (KeyEdge::Down(Action::Down), 1002),
+                (KeyEdge::Down(Action::Down), 1004),
+                (KeyEdge::Up(Action::Down), 1005),
+            ]),
+            vec![Action::Down]
+        );
+        assert!(guarded.repeater.anything_held(), "one release of three");
+        assert_eq!(
+            guarded.feed(&[
+                (KeyEdge::Down(Action::Down), 1100),
+                (KeyEdge::Up(Action::Down), 1105),
+            ]),
+            vec![]
+        );
+        assert!(
+            !guarded.repeater.anything_held(),
+            "the owed releases were cleared"
+        );
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -72,8 +72,11 @@ pub enum Action {
 
 impl Action {
     /// Every variant in declaration order. The [`DuplicateGuard`] sizes its
-    /// table from this list and indexes it by discriminant, and the check
-    /// under it refuses to compile until a new variant is appended here.
+    /// table from this list and indexes it by discriminant. The check under
+    /// it proves the listed variants sit at their own discriminants and
+    /// refuses a variant that has no arm in its match; it cannot see a
+    /// variant that has an arm but no entry here, so append the entry with
+    /// the arm, or the first press of that variant indexes past the table.
     pub const ALL: [Action; 15] = [
         Action::Up,
         Action::Down,
@@ -2012,26 +2015,5 @@ mod tests {
         );
         assert!(!guarded.repeater.anything_held());
         assert!(!unguarded.repeater.anything_held());
-    }
-
-    #[test]
-    fn every_action_has_a_slot() {
-        // The guard indexes a table sized from `Action::ALL` by discriminant.
-        // A first press and release of every listed action must pass, so a
-        // table that is too small, or a list out of declaration order that
-        // slipped past the compile-time check, shows up here rather than
-        // on the device.
-        let mut guard = DuplicateGuard::new();
-        let now = SystemTime::UNIX_EPOCH + ms(1000);
-        for action in Action::ALL {
-            assert_eq!(
-                guard.admit(KeyEdge::Down(action), now),
-                Some(KeyEdge::Down(action))
-            );
-            assert_eq!(
-                guard.admit(KeyEdge::Up(action), now),
-                Some(KeyEdge::Up(action))
-            );
-        }
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -32,6 +32,27 @@
 
 use std::time::{Duration, Instant, SystemTime};
 
+/// Declares [`Action`] and [`Action::ALL`] from one list of variants, so
+/// the list that sizes the [`DuplicateGuard`] table cannot miss a variant
+/// or hold one out of declaration order: the guard indexes that table by
+/// discriminant, and a variant absent from the list would send its first
+/// press past the end.
+macro_rules! actions {
+    ($(#[$outer:meta])* pub enum Action { $($(#[$inner:meta])* $variant:ident,)* }) => {
+        $(#[$outer])*
+        pub enum Action {
+            $($(#[$inner])* $variant,)*
+        }
+
+        impl Action {
+            /// Every variant in declaration order, generated from the enum's
+            /// own variant list.
+            pub const ALL: [Action; [$(Action::$variant),*].len()] = [$(Action::$variant),*];
+        }
+    };
+}
+
+actions! {
 /// What Degauss does, independent of which key or button produced it.
 ///
 /// Only the device build turns real key codes into these; a development
@@ -69,28 +90,9 @@ pub enum Action {
     FavoriteShortcut,
     RandomShortcut,
 }
+}
 
 impl Action {
-    /// Every variant in declaration order; sizes the [`DuplicateGuard`]
-    /// table, see the check under `ACTION_SLOTS`.
-    pub const ALL: [Action; 15] = [
-        Action::Up,
-        Action::Down,
-        Action::Slower,
-        Action::Faster,
-        Action::PageUp,
-        Action::PageDown,
-        Action::Home,
-        Action::End,
-        Action::Accept,
-        Action::Quit,
-        Action::CyclePresent,
-        Action::Menu,
-        Action::Context,
-        Action::FavoriteShortcut,
-        Action::RandomShortcut,
-    ];
-
     /// Whether holding the key always repeats. Only movement repeats:
     /// repeating "launch" would be dangerous, and repeating a speed change
     /// would run the whole ladder off one press. Left and right join in
@@ -445,39 +447,10 @@ pub fn merge_by_stamp(edges: &mut Vec<(KeyEdge, SystemTime)>, split: usize) {
 /// is the same physical press arriving twice, not a deliberate second tap.
 pub const DUPLICATE_WINDOW: Duration = Duration::from_millis(40);
 
-/// One slot per [`Action`], indexed by discriminant.
+/// One slot per [`Action`], indexed by discriminant. `Action::ALL` is
+/// generated from the enum's own variant list, so the table always has a
+/// slot for every variant at its discriminant.
 const ACTION_SLOTS: usize = Action::ALL.len();
-
-// `Action::ALL` must hold every variant at its own discriminant, or the
-// guard would index past its table on the first press of the missing one.
-// The match is exhaustive: a variant added to the enum does not compile
-// until it has an arm here, and the assertion refuses a list out of
-// declaration order. What the check cannot see is a variant that has an
-// arm but no entry in `ALL`, so append the entry with the arm.
-const _: () = {
-    let mut i = 0;
-    while i < ACTION_SLOTS {
-        let listed = match Action::ALL[i] {
-            Action::Up
-            | Action::Down
-            | Action::Slower
-            | Action::Faster
-            | Action::PageUp
-            | Action::PageDown
-            | Action::Home
-            | Action::End
-            | Action::Accept
-            | Action::Quit
-            | Action::CyclePresent
-            | Action::Menu
-            | Action::Context
-            | Action::FavoriteShortcut
-            | Action::RandomShortcut => Action::ALL[i] as usize,
-        };
-        assert!(listed == i, "Action::ALL is not in declaration order");
-        i += 1;
-    }
-};
 
 #[derive(Debug, Clone, Copy)]
 struct Slot {


### PR DESCRIPTION
## Summary

- Some controllers, or the input stack between them and Degauss, deliver one physical press as two very fast press and release pairs. The release in between cleared the repeater's held state, so the second press moved the selection again.
- A `DuplicateGuard` in `src/input.rs` now sits in front of the repeater in the run loop (`src/app.rs`). A press of the same mapped action arriving less than 40 ms after the last accepted press of that action is rejected; a press at exactly 40 ms is accepted.
- The window is measured on the kernel's timestamp of each event (`InputReader::poll` now returns each edge with it), not on the run loop's frame clock. A frame that stalls on a system read drains every press queued behind it in one poll; two deliberate taps in that queue still count as two, and a double delivery split across such a frame still counts as one. `poll` merges what each device delivered into one batch by stamp, keeping each device's own order, because devices are drained one after another and a batch would otherwise carry one device's later edges before another's earlier ones. The window reaches both ways from the accepted press because a copy injected on one device just after that device was read reaches the next poll behind the other device's copy stamped later.
- The window is anchored to the accepted press. A rejected duplicate never restarts or extends it.
- The rule is per action: a different action, an opposite direction included, passes immediately.
- Each rejected press owes one release, and exactly that many releases are swallowed, so a press delivered two or three times cannot end the genuine hold under it early or leave an action stuck. An accepted press clears any releases still owed.
- Only key edges read from a device pass the guard. The repeater's own generated ticks never do, so every scroll speed, including the 7 ms interval, keeps its cadence.
- The rule applies uniformly to Up, Down, Left, Right, page and speed navigation and the face-button actions (Accept, Back, Menu, Context), with and without the hold shortcuts.
- The Linux key value match moved from `poll` into `key_edge(action, value)` so the auto-repeat rule (value `2` ignored) is host-testable. Behaviour unchanged.
- No user setting was added. Hot path: one array index, one subtraction and one comparison per edge, nothing allocated. `Action::ALL` sizes the guard's table and is generated from the enum's own variant list by a small declarative macro, so a variant cannot exist without a slot at its discriminant.
- README gamepad paragraph updated; `docs/testing/controller-double-delivery-hardware.md` lists the checks that need hardware.

Fixes #60

## Compatibility

- Every scroll-speed setting and its initial repeat delay are preserved; the repeater is untouched.
- Rapid held scrolling, including the 7 ms interval, is preserved because generated repeats bypass the guard.
- Deliberate consecutive taps outside the 40 ms window both count.
- Simultaneous or rapidly alternating different directions are unaffected.
- Short and long X/Y gestures, including the optional favourite and random shortcuts, are unaffected.
- Keyboard, MiSTer virtual input and multiple input devices continue to work; two devices reporting the same press produce one action.
- Kernel value `2` auto-repeat events remain ignored.
- No configuration or state migration.

## Tests

New tests in `src/input.rs` drive the run loop's dispatch shape (guard, then repeater; ticks bypass the guard) and prove:

- `Down, Up, Down, Up` of one action inside 40 ms dispatches once; the same edges through the repeater alone dispatch twice, which shows the repeater cannot catch this on its own.
- `Down, Down, Up, Up` inside 40 ms dispatches once and leaves nothing held.
- Two taps 40 ms apart both dispatch; 39 ms apart dispatch once.
- A different action inside the window is immediate, an opposite direction included.
- A rejected duplicate does not move the window.
- A second device delivering the same press does not end the hold started by the first, whether the duplicate's release arrives during the hold or after the repeats started.
- A press delivered three times ends its hold on the last release, not the second, and copies whose releases never come do not swallow the release of the next accepted press.
- Two taps 100 ms apart dispatched by one frame both count; a double delivery dispatched by one frame, or split across two, is one press.
- A second device's copy of a press stamped earlier than the accepted one is still the same press; the window stays anchored to the accepted stamp.
- A poll batch is dispatched in stamp order across devices: after two devices report one press, a frame that stalls across the genuine release and the next deliberate tap still dispatches that tap, and a device's own order is kept when the wall clock steps back between a press and its release.
- A hold in every direction at every configured speed, including 7 ms, starts on the admitted press, repeats what the delay and interval give, and ends on the admitted release.
- Up, Down, Left and Right are guarded in every Left and Right Behaviour setting.
- Accept, Back, Menu and Context act once per physical press, with and without the hold shortcuts; the release of a duplicate press cannot end a hold as a short press before the shortcut fires (the repeater alone does that), and no release leaks into the screen a shortcut opened.
- Kernel value `2` events are ignored.
- Ordinary taps and holds without duplicate delivery are unchanged: every action taps once, and a hold starts on the press, repeats what the delay and interval give and ends on the release.

## Validation

- Host gates (fmt, test, rehearse, ra, clippy) passed on the pushed head.
- Host render comparison: frames from the branch binary and a baseline built the same way are identical for the details, list, tiled, Options and Actions views; the change draws nothing.
- Headless device check on a MiSTer: the branch binary passes the install check, renders a frame identical to the baseline and shows no bench regression. Nothing on those paths touches the guard.
- Further review-round commits may follow on this branch.
- Pending: acceptance check 11 (interactive keyboard and an ordinary controller on the screen) and acceptance check 12 (reproduce and verify on a real MiSTer with an affected controller or input stack). Both need the screen and, for check 12, an affected physical controller. The procedures are listed in `docs/testing/controller-double-delivery-hardware.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved duplicate input handling to prevent unintended repeated actions when duplicate press/release events arrive rapidly.
  - Correctly handles queued input after delayed frames, while preserving held scrolling and deliberate repeated taps.

- **Documentation**
  - Clarified the 40 ms duplicate-detection boundary and added guidance for testing ordinary and mixed-controller input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->